### PR TITLE
docs bug: fix 404 url bug in PersistenceCoverage.tsx

### DIFF
--- a/src/components/persistence-coverage/PersistenceCoverage.tsx
+++ b/src/components/persistence-coverage/PersistenceCoverage.tsx
@@ -29,7 +29,7 @@ const columns: ColumnDef<any>[] = [
     accessorKey: 'full_name',
     header: () => 'Service',
     cell: ({ row }) => (
-      <a href={`/aws/${row.original.service}`}>{row.original.full_name}</a>
+      <a href={`/aws/services/${row.original.service}`}>{row.original.full_name}</a>
     ),
     enableColumnFilter: true,
     filterFn: (row, columnId, filterValue) => {


### PR DESCRIPTION
There is a bug in the persistence coverage component:

https://github.com/localstack/localstack-docs/blob/master/src/components/persistence-coverage/PersistenceCoverage.tsx

ALL of the services links are 404ing because the links are incorrect, they are missing the `/services/` directory in the url.

Should be:  `/aws/services/amplify`

**NOT**: `/aws/amplify`

<img width="1345" alt="Screenshot 2025-06-25 at 8 28 09 PM" src="https://github.com/user-attachments/assets/8976709c-54af-4bd2-b1dc-e26d78c8c00c" />
<img width="1115" alt="Screenshot 2025-06-25 at 8 28 19 PM" src="https://github.com/user-attachments/assets/f1403d9e-c384-4e5f-a3bc-7526dcec5ebf" />
<img width="1129" alt="Screenshot 2025-06-25 at 8 28 27 PM" src="https://github.com/user-attachments/assets/6451ed39-c8af-4a5d-9d15-ab2e7e5ebd05" />




