### PR TITLE
Add more padding to the content pane

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -62,6 +62,11 @@ h3 {
   font-weight: 600;
 }
 
+.main-pane {
+  padding-left: 7rem;
+  padding-right: 7rem;
+}
+
 /* Product Cards Styles */
 .product-card {
   color: #ffffff !important;


### PR DESCRIPTION
Currently, the content is a bit snug with the sidebar, causing it to be a bit more difficult to read. The lines on the sidebar visually connect with the lines in the content.

After quickly checking the Figma designs, I've noticed that they also include a bit more padding than we currently have.


This PR makes the content padding more aligned with the designs and increases it. 