### PR TITLE
fix sidebar pane width changing

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -281,3 +281,11 @@ h2#starlight__on-this-page::before {
 .right-sidebar-panel:where(.astro-pb3aqygn) :where(a) {
     font-size: 14px;
 }
+
+.sidebar-pane {
+    scrollbar-gutter: stable;
+}
+
+.sidebar-pane .sidebar-content {
+    padding-right: 0;
+}


### PR DESCRIPTION
Expanding a few menus in the sidebar pane would affect it's width.

This pr will keep the width stable and remove the 1 rem right padding of the sidebar-content.