### PR TITLE
Update Persistence Docs

### DIFF
--- a/src/data/persistence/coverage.json
+++ b/src/data/persistence/coverage.json
@@ -27,6 +27,13 @@
     "test_suite": true,
     "limitations": ""
   },
+  "aiops": {
+    "service": "aiops",
+    "full_name": "aiops",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
   "amp": {
     "service": "amp",
     "full_name": "amp",
@@ -1014,6 +1021,13 @@
     "test_suite": false,
     "limitations": ""
   },
+  "evs": {
+    "service": "evs",
+    "full_name": "evs",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
   "finspace": {
     "service": "finspace",
     "full_name": "finspace",
@@ -1427,6 +1441,13 @@
     "test_suite": false,
     "limitations": ""
   },
+  "keyspacesstreams": {
+    "service": "keyspacesstreams",
+    "full_name": "keyspacesstreams",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
   "kinesis": {
     "service": "kinesis",
     "full_name": "Kinesis",
@@ -1812,6 +1833,13 @@
     "test_suite": false,
     "limitations": ""
   },
+  "mpa": {
+    "service": "mpa",
+    "full_name": "mpa",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
   "mq": {
     "service": "mq",
     "full_name": "Amazon MQ",
@@ -1906,6 +1934,13 @@
   "observabilityadmin": {
     "service": "observabilityadmin",
     "full_name": "observabilityadmin",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
+  "odb": {
+    "service": "odb",
+    "full_name": "odb",
     "support": "unknown",
     "test_suite": false,
     "limitations": ""
@@ -2575,6 +2610,13 @@
     "test_suite": false,
     "limitations": ""
   },
+  "ssm-guiconnect": {
+    "service": "ssm-guiconnect",
+    "full_name": "ssm-guiconnect",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
   "ssm-incidents": {
     "service": "ssm-incidents",
     "full_name": "ssm-incidents",
@@ -2694,6 +2736,20 @@
     "test_suite": true,
     "limitations": ""
   },
+  "timestream-query": {
+    "service": "timestream-query",
+    "full_name": "Timestream Query",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
+  "timestream-write": {
+    "service": "timestream-write",
+    "full_name": "Timestream Write",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
   "tnb": {
     "service": "tnb",
     "full_name": "tnb",
@@ -2802,6 +2858,13 @@
   "workspaces": {
     "service": "workspaces",
     "full_name": "workspaces",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
+  "workspaces-instances": {
+    "service": "workspaces-instances",
+    "full_name": "workspaces-instances",
     "support": "unknown",
     "test_suite": false,
     "limitations": ""


### PR DESCRIPTION
Updating Persistence Coverage Documentation based on the [Persistence Catalog](https://www.notion.so/localstack/Persistence-Catalog-a9e0e5cb89df4784adb4a1ed377b3c23) on Notion.