### PR TITLE
Fix filetree styles

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -209,6 +209,13 @@ li:has([aria-current="page"]) > a > span::before {
     padding: 24px;
 }
 
+/* this fixes the file tree styling */
+.sl-markdown-content li.directory details {
+    border-radius: 0px;
+    border: none;
+    padding: 0 0 0 1.5em;
+}
+
 .tab {
     font-size: 16px;
 }


### PR DESCRIPTION
The details styles were causing a weird border radius on the filetree which I removed without overwriting the other details style.