### PR TITLE
MWAA: Deprecate Airflow v2.4.3, v2.5.1 and v2.6.3

### DIFF
--- a/src/content/docs/aws/services/mwaa.mdx
+++ b/src/content/docs/aws/services/mwaa.mdx
@@ -76,7 +76,9 @@ LocalStack supports the following versions of Apache Airflow:
 - `2.10.1`
 - `2.10.3` (default)
 
+:::note
 Deprecated versions will be removed in line with [AWS's end of support dates](https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-versions.html#airflow-versions-official).
+:::
 
 ## Airflow configuration options
 

--- a/src/content/docs/aws/services/mwaa.mdx
+++ b/src/content/docs/aws/services/mwaa.mdx
@@ -67,14 +67,16 @@ LocalStack also prints this information in the logs:
 
 LocalStack supports the following versions of Apache Airflow:
 
-- `2.4.3`
-- `2.5.1`
-- `2.6.3`
+- `2.4.3` (deprecated)
+- `2.5.1` (deprecated)
+- `2.6.3` (deprecated)
 - `2.7.2`
 - `2.8.1`
 - `2.9.2`
 - `2.10.1`
 - `2.10.3` (default)
+
+Deprecated versions will be removed in line with [AWS's end of support dates](https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-versions.html#airflow-versions-official).
 
 ## Airflow configuration options
 


### PR DESCRIPTION
[Jump to preview](https://mwaa-deprecations.localstack-docs.pages.dev/aws/services/mwaa/#airflow-versions)