### PR TITLE
Update Persistence Docs

### DIFF
--- a/src/content/docs/aws/services/acm-pca.mdx
+++ b/src/content/docs/aws/services/acm-pca.mdx
@@ -2,6 +2,7 @@
 title: Private Certificate Authority (ACM PCA)
 description: Get started with Private Certificate Authority (ACM PCA) on LocalStack
 tags: ["Ultimate"]
+persistence: supported
 ---
 
 import FeatureCoverage from "../../../../components/feature-coverage/FeatureCoverage";

--- a/src/data/persistence/coverage.json
+++ b/src/data/persistence/coverage.json
@@ -293,6 +293,20 @@
     "test_suite": false,
     "limitations": ""
   },
+  "bedrock-agentcore": {
+    "service": "bedrock-agentcore",
+    "full_name": "bedrock-agentcore",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
+  "bedrock-agentcore-control": {
+    "service": "bedrock-agentcore-control",
+    "full_name": "bedrock-agentcore-control",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
   "bedrock-data-automation": {
     "service": "bedrock-data-automation",
     "full_name": "bedrock-data-automation",
@@ -2368,6 +2382,13 @@
   "s3tables": {
     "service": "s3tables",
     "full_name": "s3tables",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
+  "s3vectors": {
+    "service": "s3vectors",
+    "full_name": "s3vectors",
     "support": "unknown",
     "test_suite": false,
     "limitations": ""


### PR DESCRIPTION
Updating Persistence Coverage Documentation based on the [Persistence Catalog](https://www.notion.so/localstack/Persistence-Catalog-a9e0e5cb89df4784adb4a1ed377b3c23) on Notion.