### PR TITLE
Fix 3rd level sidebar not highlighting

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -192,6 +192,12 @@ select.astro-oojz3yon {
     color: var(--sl-color-accent) !important;
 }
 
+/* Additional rule to ensure span inside active page link is styled */
+.sidebar-content .top-level li details ul li details ul li a[aria-current="page"] span {
+    background-color: transparent;
+    color: var(--sl-color-accent) !important;
+  }
+
 /* Style the parent li element when it contains an active page link */
 li:has([aria-current="page"]) > details > summary > div > span {
     color: var(--sl-color-accent) !important;


### PR DESCRIPTION
[BUG] AWS docs left nav: Active nav item not highlighted