### PR TITLE
Enable an Algolia facet for AWS vs Snowflake

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -200,6 +200,9 @@ export default defineConfig({
           appId: 'XBW1JU7CW5',
           apiKey: '6b0341e2f50196d328d088dbb5cd6166',
           indexName: 'localstack',
+          searchParameters: {
+            facets: ['lvl0'],
+          },
         }),
       ],
       sidebar: [


### PR DESCRIPTION
This enables the facet that I created in the index to display in the output. This allows the results to be separated by AWS and Snowflake as shown in the screenshot below.

<img width="580" height="613" alt="Screenshot 2025-07-30 at 10 38 01 AM" src="https://github.com/user-attachments/assets/872baf1e-f5d7-4d01-a47f-a14a3c9160b2" />
