### PR TITLE
fix: update to create pull request vs automatic commit to main

### DIFF
--- a/.github/workflows/update-snowflake-feature-coverage.yml
+++ b/.github/workflows/update-snowflake-feature-coverage.yml
@@ -39,12 +39,17 @@ jobs:
           cd localstack-docs
           mv coverage-features.md src/content/docs/snowflake/features/index.md
           mv coverage-functions.md src/content/docs/snowflake/sql-functions.md
-
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v9
+      
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v7
+        if: ${{ success() && steps.check-for-changes.outputs.diff-count != '0' && steps.check-for-changes.outputs.diff-count != '' }}
         with:
-          author_name: 'LocalStack Bot'
-          author_email: localstack-bot@users.noreply.github.com
-          message: 'Updated function coverage docs'
-          cwd: localstack-docs
-          add: 'src/content/'
+          path: docs
+          title: "Update function coverage documentation"
+          body: "Automated update of snowflake feature coverage docs"
+          branch: "snowflake-feature-coverage-updates"
+          author: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
+          committer: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
+          commit-message: "automated update of snowflake feature coverage docs"
+          token: ${{ secrets.PRO_ACCESS_TOKEN }}
+          reviewers: hovaesco, harshcasper


### PR DESCRIPTION
Snowflake Update function coverage docs workflow is currently broken:
https://github.com/localstack/localstack-docs/actions/runs/16699319055/job/47267864136

This workflow needs to be updated to create a pull request rather than making a direct commit to `main`.
