### PR TITLE
docs: fix missing tutorial link

### DIFF
--- a/src/content/docs/aws/services/s3.mdx
+++ b/src/content/docs/aws/services/s3.mdx
@@ -335,7 +335,7 @@ The following code snippets and sample applications provide practical examples o
 - [Serverless Transcription application using Transcribe, S3, Lambda, SQS, and SES](https://github.com/localstack/sample-transcribe-app)
 - [Query data in S3 Bucket with Amazon Athena, Glue Catalog & CloudFormation](https://github.com/localstack/query-data-s3-athena-glue-sample)
 - [Serverless Image Resizer with Lambda, S3, SNS, and SES](https://github.com/localstack/serverless-image-resizer)
-- [Host a static website locally using Simple Storage Service (S3) and Terraform with LocalStack]()
+- [Host a static website locally using Simple Storage Service (S3) and Terraform with LocalStack](https://docs.localstack.cloud/aws/tutorials/s3-static-website-terraform/)
 
 ## API Coverage
 


### PR DESCRIPTION
The link to static hosted website is pointing back to the s3 docs page instead of the s3 tutorial. 