### PR TITLE
Restore sidebar right padding

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -298,7 +298,3 @@ h2#starlight__on-this-page::before {
 .sidebar-pane {
     scrollbar-gutter: stable;
 }
-
-.sidebar-pane .sidebar-content {
-    padding-right: 0;
-}


### PR DESCRIPTION
Restore sidebar right padding that was removed in https://github.com/localstack/localstack-docs/pull/88. Cc @cloutierMat @remotesynth 

| BEFORE | AFTER |
|--------|--------|
| <img width="367" height="513" alt="Frame 48097198" src="https://github.com/user-attachments/assets/91617523-09f6-4307-bf30-887647b75243" /> | <img width="367" height="513" alt="Frame 48097197" src="https://github.com/user-attachments/assets/dc9b2888-59ca-4465-b82b-8369cd67ae0a" /> | 