### PR TITLE
docs: WebSocket subscriptions for AppSync

### DIFF
--- a/src/content/docs/aws/services/appsync.mdx
+++ b/src/content/docs/aws/services/appsync.mdx
@@ -247,7 +247,7 @@ The Resource Browser allows you to perform the following actions:
 
 ## WebSocket Subscriptions
 
-LocalStack supports real-time GraphQL subscriptions over WebSocket for AWS AppSync APIs. Clients can subscribe to mutation-triggered events and receive updates in real time via the AppSync WebSocket endpoint. LocalStack supports the GraphQL `@aws_subscribe` directive, core subscription message flow, and API Key-based authentication.
+LocalStack supports real-time GraphQL subscriptions over WebSocket for AWS AppSync APIs. Clients can subscribe to mutation-triggered events and receive updates in real time via the AppSync WebSocket endpoint. LocalStack supports the GraphQL `@aws_subscribe` directive, and core subscription message flow.
 
 Use this feature to power live updates in apps such as chat, dashboards, or collaborative editors. There's no need to poll for changes.
 
@@ -390,7 +390,6 @@ LocalStack supports the following WebSocket message types:
 | ----------------- | ----------------------------------------------- |
 | `connection_init` | Client initiates connection                     |
 | `connection_ack`  | Server acknowledges the connection              |
-| `ka`              | Keep-alive (heartbeat) message                  |
 | `start`           | Starts a subscription                           |
 | `start_ack`       | Acknowledges a successful subscription          |
 | `data`            | Sends a message when a matching mutation occurs |

--- a/src/content/docs/aws/services/appsync.mdx
+++ b/src/content/docs/aws/services/appsync.mdx
@@ -245,6 +245,160 @@ The Resource Browser allows you to perform the following actions:
   Click on **Create Function** to create a function, by providing a name for the function, data source name, and Function Version, Request Mapping Template, Response Mapping Template, among other parameters, before clicking **Submit**.
 
 
+## WebSocket Subscriptions
+
+LocalStack supports real-time GraphQL subscriptions over WebSocket for AWS AppSync APIs. Clients can subscribe to mutation-triggered events and receive updates in real time via the AppSync WebSocket endpoint. LocalStack supports the GraphQL `@aws_subscribe` directive, core subscription message flow, and API Key-based authentication.
+
+Use this feature to power live updates in apps such as chat, dashboards, or collaborative editors. There's no need to poll for changes.
+
+### Getting Started
+
+Set up a GraphQL subscription in your schema, connect to the WebSocket endpoint, and receive live updates triggered by a mutation.
+
+#### 1. Extend Your GraphQL Schema
+
+First, ensure your schema includes a `subscription` type. Use the `@aws_subscribe` directive to link each subscription to a corresponding mutation.
+
+```graphql
+type Message {
+  id: ID!
+  content: String!
+}
+
+type Mutation {
+  postMessage(id: ID!, content: String!): Message!
+}
+
+type Subscription {
+  onMessagePosted: Message
+    @aws_subscribe(mutations: ["postMessage"])
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+```
+
+#### 2. Connect to the WebSocket Endpoint
+
+LocalStack exposes a WebSocket endpoint for each GraphQL API:
+
+```json
+"REALTIME": "ws://localhost:4510/graphql/<api-id>"
+```
+
+Use a WebSocket client like `wscat` to connect:
+
+```bash
+npm install -g wscat
+
+export API_ID=<your-api-id>
+export API_KEY=<your-api-key>
+export HEADER="{\"host\":\"localhost:4566\",\"x-api-key\":\"$API_KEY\"}"
+export HEADER_ENCODED=$(echo -n $HEADER | base64 | tr '+/' '-_' | tr -d '=')
+
+wscat \
+  -s "header-$HEADER_ENCODED" \
+  -s "graphql-ws" \
+  -c "ws://localhost:4510/graphql/$API_ID"
+```
+
+#### 3. Initialize the WebSocket Connection
+
+After connecting, send a `connection_init` message:
+
+```json
+{ "type": "connection_init" }
+```
+
+You should receive a `connection_ack` in response.
+
+#### 4. Start a Subscription
+
+Use a `start` message to register your subscription:
+
+```json
+{
+  "id": "1",
+  "type": "start",
+  "payload": {
+    "data": "{\"query\":\"subscription { onMessagePosted { id content } }\"}"
+  }
+}
+```
+
+#### 5. Trigger the Subscription
+
+Now, trigger the matching mutation:
+
+```bash
+awslocal appsync graphql \
+  --api-id $API_ID \
+  --query 'mutation { postMessage(id: "1", content: "Hello world!") { id content } }'
+```
+
+You should see a live message from the WebSocket server like:
+
+```json title="Output"
+{
+  "type": "data",
+  "id": "1",
+  "payload": {
+    "data": {
+      "onMessagePosted": {
+        "id": "1",
+        "content": "Hello world!"
+      }
+    }
+  }
+}
+```
+
+#### 6. Stop the Subscription
+
+To unregister, send a `stop` message:
+
+```json
+{ "type": "stop", "id": "1" }
+```
+
+You'll receive a `complete` message when successful.
+
+
+### Configuring WebSocket endpoints
+
+The WebSocket endpoint for GraphQL subscriptions is provided in the `uris` section of the `create-graphql-api` response.
+
+Example:
+
+```json
+"uris": {
+  "GRAPHQL": "http://localhost:4566/graphql/<api-id>",
+  "REALTIME": "ws://localhost:4510/graphql/<api-id>"
+}
+```
+
+To connect, encode your headers (such as `x-api-key` and `host`) as a base64 JSON string and provide it using the `Sec-WebSocket-Protocol` header prefixed with `header-`. Use `graphql-ws` as the subprotocol.
+
+Only `API_KEY` authentication is currently supported for WebSocket connections in LocalStack. Other methods like Cognito, IAM, and Lambda are not yet implemented.
+
+LocalStack supports the following WebSocket message types:
+
+| Type              | Description                                     |
+| ----------------- | ----------------------------------------------- |
+| `connection_init` | Client initiates connection                     |
+| `connection_ack`  | Server acknowledges the connection              |
+| `ka`              | Keep-alive (heartbeat) message                  |
+| `start`           | Starts a subscription                           |
+| `start_ack`       | Acknowledges a successful subscription          |
+| `data`            | Sends a message when a matching mutation occurs |
+| `stop`            | Client unsubscribes from a subscription         |
+| `complete`        | Server confirms unsubscription                  |
+
+
+
 ## Events API
 
 Enable sending real-time event data to subscribed clients.

--- a/src/content/docs/aws/services/appsync.mdx
+++ b/src/content/docs/aws/services/appsync.mdx
@@ -334,10 +334,10 @@ Use a `start` message to register your subscription:
 Now, trigger the matching mutation:
 
 ```bash
-awslocal appsync graphql \
-  --api-id $API_ID \
-  --query 'mutation { postMessage(id: "1", content: "Hello world!") { id content } }'
-```
+curl -X POST http://${API_ID}.appsync-api.localhost.localstack.cloud:4566/graphql \
+  -H "content-type: application/json" \
+  -H "x-api-key: ${API_KEY}" \
+  -d '{"query": "mutation { postMessage(id: \"1\", content: \"Hello world!\") { id content } }" }'
 
 You should see a live message from the WebSocket server like:
 

--- a/src/content/docs/aws/services/appsync.mdx
+++ b/src/content/docs/aws/services/appsync.mdx
@@ -252,14 +252,10 @@ Use a WebSocket client like `wscat` to connect:
 npm install -g wscat
 
 export API_ID=<your-api-id>
-export API_KEY=<your-api-key>
-export HEADER="{\"host\":\"localhost:4566\",\"x-api-key\":\"$API_KEY\"}"
-export HEADER_ENCODED=$(echo -n $HEADER | base64 | tr '+/' '-_' | tr -d '=')
 
 wscat \
   -s "graphql-ws" \
   -c "ws://localhost:4510/graphql/$API_ID"
-```
 
 ### 3. Initialize the WebSocket Connection
 

--- a/src/content/docs/aws/services/appsync.mdx
+++ b/src/content/docs/aws/services/appsync.mdx
@@ -300,7 +300,6 @@ export HEADER="{\"host\":\"localhost:4566\",\"x-api-key\":\"$API_KEY\"}"
 export HEADER_ENCODED=$(echo -n $HEADER | base64 | tr '+/' '-_' | tr -d '=')
 
 wscat \
-  -s "header-$HEADER_ENCODED" \
   -s "graphql-ws" \
   -c "ws://localhost:4510/graphql/$API_ID"
 ```
@@ -380,9 +379,6 @@ Example:
 }
 ```
 
-To connect, encode your headers (such as `x-api-key` and `host`) as a base64 JSON string and provide it using the `Sec-WebSocket-Protocol` header prefixed with `header-`. Use `graphql-ws` as the subprotocol.
-
-Only `API_KEY` authentication is currently supported for WebSocket connections in LocalStack. Other methods like Cognito, IAM, and Lambda are not yet implemented.
 
 LocalStack supports the following WebSocket message types:
 

--- a/src/content/docs/aws/services/appsync.mdx
+++ b/src/content/docs/aws/services/appsync.mdx
@@ -204,7 +204,7 @@ Pipeline resolvers, on the other hand, invoke AppSync functions that wraps the A
 Unit resolvers are written in the Velocity templating language (VTL), while pipeline resolvers can be written in either VTL or JavaScript.
 
 
-## WebSocket Subscriptions
+### WebSocket Subscriptions
 
 LocalStack supports real-time GraphQL subscriptions over WebSocket for AWS AppSync APIs.
 
@@ -212,7 +212,7 @@ Clients can subscribe to mutation-triggered events and receive updates in real t
 
 You can set up a GraphQL subscription in your schema, connect to the WebSocket endpoint, and receive live updates triggered by a mutation.
 
-### 1. Extend Your GraphQL Schema
+#### 1. Extend Your GraphQL Schema
 
 First, ensure your schema includes a `subscription` type. Use the `@aws_subscribe` directive to link each subscription to a corresponding mutation.
 
@@ -238,7 +238,7 @@ schema {
 }
 ```
 
-### 2. Connect to the WebSocket Endpoint
+#### 2. Connect to the WebSocket Endpoint
 
 LocalStack exposes a WebSocket endpoint for each GraphQL API:
 
@@ -256,8 +256,9 @@ export API_ID=<your-api-id>
 wscat \
   -s "graphql-ws" \
   -c "ws://localhost:4510/graphql/$API_ID"
+```
 
-### 3. Initialize the WebSocket Connection
+#### 3. Initialize the WebSocket Connection
 
 After connecting, send a `connection_init` message:
 
@@ -267,7 +268,7 @@ After connecting, send a `connection_init` message:
 
 You should receive a `connection_ack` in response.
 
-### 4. Start a Subscription
+#### 4. Start a Subscription
 
 Use a `start` message to register your subscription:
 
@@ -281,7 +282,7 @@ Use a `start` message to register your subscription:
 }
 ```
 
-### 5. Trigger the Subscription
+#### 5. Trigger the Subscription
 
 Now, trigger the matching mutation:
 
@@ -290,6 +291,7 @@ curl -X POST http://${API_ID}.appsync-api.localhost.localstack.cloud:4566/graphq
   -H "content-type: application/json" \
   -H "x-api-key: ${API_KEY}" \
   -d '{"query": "mutation { postMessage(id: \"1\", content: \"Hello world!\") { id content } }" }'
+```
 
 You should see a live message from the WebSocket server like:
 
@@ -308,7 +310,7 @@ You should see a live message from the WebSocket server like:
 }
 ```
 
-### 6. Stop the Subscription
+#### 6. Stop the Subscription
 
 To unregister, send a `stop` message:
 
@@ -318,19 +320,7 @@ To unregister, send a `stop` message:
 
 You'll receive a `complete` message when successful.
 
-
-### Configuring WebSocket Subscription endpoints
-
-The WebSocket endpoint for GraphQL subscriptions is provided in the `uris` section of the `create-graphql-api` response.
-
-Example:
-
-```json
-"uris": {
-  "GRAPHQL": "http://localhost:4566/graphql/<api-id>",
-  "REALTIME": "ws://localhost:4510/graphql/<api-id>"
-}
-```
+### Supported WebSocket Message Types
 
 LocalStack supports the following WebSocket message types:
 
@@ -356,6 +346,20 @@ The strategy can be configured via the `GRAPHQL_ENDPOINT_STRATEGY` environment v
 | `domain` | `<api-id>.appsync-api.localhost.localstack.cloud:4566` | This strategy, slated to be the future default, uses the `localhost.localstack.cloud` domain to route to your localhost. |
 | `path`   | `localhost:4566/appsync-api/<api-id>/graphql`         | An alternative strategy that can be beneficial if you're unable to resolve LocalStack's `localhost` domain. |
 | `legacy` | `localhost:4566/graphql/<api-id>`                    | This strategy represents the old endpoint format, which is currently the default but will eventually be phased out. |
+
+
+In addition to the GraphQL HTTP endpoint, each AppSync API also provides a WebSocket endpoint for GraphQL subscriptions. 
+
+The WebSocket server runs on a separate port that may change between deployments. To ensure correct connectivity, always use the `REALTIME` URL returned in the `uris` field of the `create-graphql-api` or `get-graphql-api` responses.
+
+Example:
+
+```json
+"uris": {
+  "GRAPHQL": "http://localhost:4566/graphql/<api-id>",
+  "REALTIME": "ws://localhost:4510/graphql/<api-id>"
+}
+```
 
 :::note
 The `REALTIME` endpoint will ignore the `GRAPHQL_ENDPOINT_STRATEGY` and always use the `legacy` strategy.

--- a/src/content/docs/aws/services/appsync.mdx
+++ b/src/content/docs/aws/services/appsync.mdx
@@ -204,9 +204,155 @@ Pipeline resolvers, on the other hand, invoke AppSync functions that wraps the A
 Unit resolvers are written in the Velocity templating language (VTL), while pipeline resolvers can be written in either VTL or JavaScript.
 
 
+## WebSocket Subscriptions
+
+LocalStack supports real-time GraphQL subscriptions over WebSocket for AWS AppSync APIs.
+
+Clients can subscribe to mutation-triggered events and receive updates in real time via the AppSync WebSocket endpoint. LocalStack supports the GraphQL `@aws_subscribe` directive, and core subscription message flow. Use this feature to power live updates in apps such as chat, dashboards, or collaborative editors. There's no need to poll for changes.
+
+You can set up a GraphQL subscription in your schema, connect to the WebSocket endpoint, and receive live updates triggered by a mutation.
+
+### 1. Extend Your GraphQL Schema
+
+First, ensure your schema includes a `subscription` type. Use the `@aws_subscribe` directive to link each subscription to a corresponding mutation.
+
+```graphql
+type Message {
+  id: ID!
+  content: String!
+}
+
+type Mutation {
+  postMessage(id: ID!, content: String!): Message!
+}
+
+type Subscription {
+  onMessagePosted: Message
+    @aws_subscribe(mutations: ["postMessage"])
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+```
+
+### 2. Connect to the WebSocket Endpoint
+
+LocalStack exposes a WebSocket endpoint for each GraphQL API:
+
+```json
+"REALTIME": "ws://localhost:4510/graphql/<api-id>"
+```
+
+Use a WebSocket client like `wscat` to connect:
+
+```bash
+npm install -g wscat
+
+export API_ID=<your-api-id>
+export API_KEY=<your-api-key>
+export HEADER="{\"host\":\"localhost:4566\",\"x-api-key\":\"$API_KEY\"}"
+export HEADER_ENCODED=$(echo -n $HEADER | base64 | tr '+/' '-_' | tr -d '=')
+
+wscat \
+  -s "graphql-ws" \
+  -c "ws://localhost:4510/graphql/$API_ID"
+```
+
+### 3. Initialize the WebSocket Connection
+
+After connecting, send a `connection_init` message:
+
+```json
+{ "type": "connection_init" }
+```
+
+You should receive a `connection_ack` in response.
+
+### 4. Start a Subscription
+
+Use a `start` message to register your subscription:
+
+```json
+{
+  "id": "1",
+  "type": "start",
+  "payload": {
+    "data": "{\"query\":\"subscription { onMessagePosted { id content } }\"}"
+  }
+}
+```
+
+### 5. Trigger the Subscription
+
+Now, trigger the matching mutation:
+
+```bash
+curl -X POST http://${API_ID}.appsync-api.localhost.localstack.cloud:4566/graphql \
+  -H "content-type: application/json" \
+  -H "x-api-key: ${API_KEY}" \
+  -d '{"query": "mutation { postMessage(id: \"1\", content: \"Hello world!\") { id content } }" }'
+
+You should see a live message from the WebSocket server like:
+
+```json title="Output"
+{
+  "type": "data",
+  "id": "1",
+  "payload": {
+    "data": {
+      "onMessagePosted": {
+        "id": "1",
+        "content": "Hello world!"
+      }
+    }
+  }
+}
+```
+
+### 6. Stop the Subscription
+
+To unregister, send a `stop` message:
+
+```json
+{ "type": "stop", "id": "1" }
+```
+
+You'll receive a `complete` message when successful.
+
+
+### Configuring WebSocket Subscription endpoints
+
+The WebSocket endpoint for GraphQL subscriptions is provided in the `uris` section of the `create-graphql-api` response.
+
+Example:
+
+```json
+"uris": {
+  "GRAPHQL": "http://localhost:4566/graphql/<api-id>",
+  "REALTIME": "ws://localhost:4510/graphql/<api-id>"
+}
+```
+
+LocalStack supports the following WebSocket message types:
+
+| Type              | Description                                     |
+| ----------------- | ----------------------------------------------- |
+| `connection_init` | Client initiates connection                     |
+| `connection_ack`  | Server acknowledges the connection              |
+| `start`           | Starts a subscription                           |
+| `start_ack`       | Acknowledges a successful subscription          |
+| `data`            | Sends a message when a matching mutation occurs |
+| `stop`            | Client unsubscribes from a subscription         |
+| `complete`        | Server confirms unsubscription                  |
+
+
 ### Configuring GraphQL endpoints
 
 There are three configurable strategies that govern how GraphQL API endpoints are created.
+
 The strategy can be configured via the `GRAPHQL_ENDPOINT_STRATEGY` environment variable.
 
 | Value    | Format                                                 | Description                                                                                         |
@@ -214,6 +360,10 @@ The strategy can be configured via the `GRAPHQL_ENDPOINT_STRATEGY` environment v
 | `domain` | `<api-id>.appsync-api.localhost.localstack.cloud:4566` | This strategy, slated to be the future default, uses the `localhost.localstack.cloud` domain to route to your localhost. |
 | `path`   | `localhost:4566/appsync-api/<api-id>/graphql`         | An alternative strategy that can be beneficial if you're unable to resolve LocalStack's `localhost` domain. |
 | `legacy` | `localhost:4566/graphql/<api-id>`                    | This strategy represents the old endpoint format, which is currently the default but will eventually be phased out. |
+
+:::note
+The `REALTIME` endpoint will ignore the `GRAPHQL_ENDPOINT_STRATEGY` and always use the `legacy` strategy.
+:::
 
 
 ### GraphQL Resource Browser
@@ -243,155 +393,6 @@ The Resource Browser allows you to perform the following actions:
   Click on **Attach Resolver** to attach a resolver to a field, by providing the field name, data source name, Request Mapping Template, Response Mapping Template, among other parameters, before clicking **Submit**.
 - **Create Function**: Click on the GraphQL API name and click **Functions**.
   Click on **Create Function** to create a function, by providing a name for the function, data source name, and Function Version, Request Mapping Template, Response Mapping Template, among other parameters, before clicking **Submit**.
-
-
-## WebSocket Subscriptions
-
-LocalStack supports real-time GraphQL subscriptions over WebSocket for AWS AppSync APIs. Clients can subscribe to mutation-triggered events and receive updates in real time via the AppSync WebSocket endpoint. LocalStack supports the GraphQL `@aws_subscribe` directive, and core subscription message flow.
-
-Use this feature to power live updates in apps such as chat, dashboards, or collaborative editors. There's no need to poll for changes.
-
-### Getting Started
-
-Set up a GraphQL subscription in your schema, connect to the WebSocket endpoint, and receive live updates triggered by a mutation.
-
-#### 1. Extend Your GraphQL Schema
-
-First, ensure your schema includes a `subscription` type. Use the `@aws_subscribe` directive to link each subscription to a corresponding mutation.
-
-```graphql
-type Message {
-  id: ID!
-  content: String!
-}
-
-type Mutation {
-  postMessage(id: ID!, content: String!): Message!
-}
-
-type Subscription {
-  onMessagePosted: Message
-    @aws_subscribe(mutations: ["postMessage"])
-}
-
-schema {
-  query: Query
-  mutation: Mutation
-  subscription: Subscription
-}
-```
-
-#### 2. Connect to the WebSocket Endpoint
-
-LocalStack exposes a WebSocket endpoint for each GraphQL API:
-
-```json
-"REALTIME": "ws://localhost:4510/graphql/<api-id>"
-```
-
-Use a WebSocket client like `wscat` to connect:
-
-```bash
-npm install -g wscat
-
-export API_ID=<your-api-id>
-export API_KEY=<your-api-key>
-export HEADER="{\"host\":\"localhost:4566\",\"x-api-key\":\"$API_KEY\"}"
-export HEADER_ENCODED=$(echo -n $HEADER | base64 | tr '+/' '-_' | tr -d '=')
-
-wscat \
-  -s "graphql-ws" \
-  -c "ws://localhost:4510/graphql/$API_ID"
-```
-
-#### 3. Initialize the WebSocket Connection
-
-After connecting, send a `connection_init` message:
-
-```json
-{ "type": "connection_init" }
-```
-
-You should receive a `connection_ack` in response.
-
-#### 4. Start a Subscription
-
-Use a `start` message to register your subscription:
-
-```json
-{
-  "id": "1",
-  "type": "start",
-  "payload": {
-    "data": "{\"query\":\"subscription { onMessagePosted { id content } }\"}"
-  }
-}
-```
-
-#### 5. Trigger the Subscription
-
-Now, trigger the matching mutation:
-
-```bash
-curl -X POST http://${API_ID}.appsync-api.localhost.localstack.cloud:4566/graphql \
-  -H "content-type: application/json" \
-  -H "x-api-key: ${API_KEY}" \
-  -d '{"query": "mutation { postMessage(id: \"1\", content: \"Hello world!\") { id content } }" }'
-
-You should see a live message from the WebSocket server like:
-
-```json title="Output"
-{
-  "type": "data",
-  "id": "1",
-  "payload": {
-    "data": {
-      "onMessagePosted": {
-        "id": "1",
-        "content": "Hello world!"
-      }
-    }
-  }
-}
-```
-
-#### 6. Stop the Subscription
-
-To unregister, send a `stop` message:
-
-```json
-{ "type": "stop", "id": "1" }
-```
-
-You'll receive a `complete` message when successful.
-
-
-### Configuring WebSocket endpoints
-
-The WebSocket endpoint for GraphQL subscriptions is provided in the `uris` section of the `create-graphql-api` response.
-
-Example:
-
-```json
-"uris": {
-  "GRAPHQL": "http://localhost:4566/graphql/<api-id>",
-  "REALTIME": "ws://localhost:4510/graphql/<api-id>"
-}
-```
-
-
-LocalStack supports the following WebSocket message types:
-
-| Type              | Description                                     |
-| ----------------- | ----------------------------------------------- |
-| `connection_init` | Client initiates connection                     |
-| `connection_ack`  | Server acknowledges the connection              |
-| `start`           | Starts a subscription                           |
-| `start_ack`       | Acknowledges a successful subscription          |
-| `data`            | Sends a message when a matching mutation occurs |
-| `stop`            | Client unsubscribes from a subscription         |
-| `complete`        | Server confirms unsubscription                  |
-
 
 
 ## Events API


### PR DESCRIPTION
Added documentation for WebSocket subscriptions in AWS AppSync using LocalStack, including setup instructions and message types.

**Preview URL:** 
https://9150cac2.localstack-docs.pages.dev/aws/services/appsync/#websocket-subscriptions 