### PR TITLE
Automate feature coverage for Snowflake REST APIs docs.

### DIFF
--- a/.github/workflows/update-snowflake-feature-coverage.yml
+++ b/.github/workflows/update-snowflake-feature-coverage.yml
@@ -39,7 +39,8 @@ jobs:
           cd localstack-docs
           mv coverage-features.md src/content/docs/snowflake/features/index.md
           mv coverage-functions.md src/content/docs/snowflake/sql-functions.md
-      
+          mv coverage-restapi.md src/content/docs/snowflake/rest-api-endpoints.md
+
       - name: Check for changes
         id: check-for-changes
         working-directory: localstack-docs


### PR DESCRIPTION
This PR makes the necessary changes that'll help us add feature-coverage support to the LocalStack for Snowflake REST APIs. Essentially, this means that for any new REST API endpoints that we implement, the docs will be updated automatically when the workflow runs.

Specifically, the PR modifies `.github/workflows/update-snowflake-feature-coverage.yml` by adding the step of replacing the REST APIs markdown file with a newly generated one.