### PR TITLE
docs: update redirect for python-sdk path

### DIFF
--- a/scripts/redirects/_redirects
+++ b/scripts/redirects/_redirects
@@ -397,7 +397,7 @@
 /user-guide/web-application/workspace/ /aws/capabilities/web-app/workspace 301
 /references/coverage/coverage_cloudcontrol/ /aws/services/cloudcontrol 301
 /tutorials/replicate-aws-resources-localstack-extension/ /aws/tutorials/replicate-aws-resources-localstack-extension 301
-/user-guide/tools/localstack-sdk/python/ /aws/tooling/localstack-sdks/python 301
+/user-guide/tools/localstack-sdk/python/ /aws/tooling/localstack-sdks/python-sdk 301
 /user-guide/lambda-tools/hot-reloading/ /aws/tooling/lambda-tools/hot-reloading 301
 /getting-started/quickstart/ /aws/getting-started/quickstart 301
 /overview/ /aws 301


### PR DESCRIPTION
Broken link when searching for localstack python sdk