### PR TITLE
CI: Fix incorrect artifact prefix for pro pipeline metrics

### DIFF
--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
           REPOSITORY_NAME: localstack-pro
-          ARTIFACT_ID: parity-metric-ext-raw-*
+          ARTIFACT_ID: parity-metric-pro-raw-amd*
           WORKFLOW: "AWS / Build, Test, Push" 
           PREFIX_ARTIFACT: pro-integration-test
       


### PR DESCRIPTION
**Motivation**

The name of the metrics artifact was changed in the `localstack-pro` repository after the repository was renamed from `-ext` to `-pro`, but we forgot to reflect this change in this pipeline. This PR fixes that. 

Also, we generate metrics for both ARM and AMD runners, but since AMD metrics are enough for parity reports, I’ve updated the prefix to fetch only the metrics from AMD runners.