### PR TITLE
docs: Fix broken Markdown format in Cloud Control API documentation

### DIFF
--- a/src/content/docs/aws/services/cloudcontrol.mdx
+++ b/src/content/docs/aws/services/cloudcontrol.mdx
@@ -90,7 +90,7 @@ The following resources are supported by Cloud Control:
 15. [`AWS::SecretsManager::Secret`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secret.html)
 16. [`AWS::StepFunctions::StateMachine`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html)
 17. [`AWS::CloudFront::Distribution`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-distribution.html)
-18. [`AWS::Pipes::Pipe`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-pipes-pi
+18. [`AWS::Pipes::Pipe`](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-pipes-pipe.html)
 
 ## API Coverage
 


### PR DESCRIPTION
Hi😀

I found that the Markdown format was broken in the Cloud Control API documentation.
https://docs.localstack.cloud/aws/services/cloudcontrol/

<img width="1107" height="1214" alt="image" src="https://github.com/user-attachments/assets/2576c323-2921-4f93-9423-9524eb64ec48" />

Thank you.