### PR TITLE
Update Persistence Docs

### DIFF
--- a/src/data/persistence/coverage.json
+++ b/src/data/persistence/coverage.json
@@ -125,13 +125,6 @@
     "test_suite": false,
     "limitations": ""
   },
-  "cloudcontrol": {
-    "service": "cloudcontrol",
-    "full_name": "cloudcontrol",
-    "support": "unknown",
-    "test_suite": false,
-    "limitations": ""
-  },
   "cloudformation": {
     "service": "cloudformation",
     "full_name": "CloudFormation",
@@ -716,6 +709,13 @@
   "shield": {
     "service": "shield",
     "full_name": "shield",
+    "support": "unknown",
+    "test_suite": false,
+    "limitations": ""
+  },
+  "sikmon": {
+    "service": "sikmon",
+    "full_name": "sikmon",
     "support": "unknown",
     "test_suite": false,
     "limitations": ""


### PR DESCRIPTION
Updating Persistence Coverage Documentation based on the [Persistence Catalog](https://www.notion.so/localstack/Persistence-Catalog-a9e0e5cb89df4784adb4a1ed377b3c23) on Notion.