### PR TITLE
docs: update LocalStack Replicator document to add support for batch replication

### DIFF
--- a/src/content/docs/aws/tooling/aws-replicator.mdx
+++ b/src/content/docs/aws/tooling/aws-replicator.mdx
@@ -112,7 +112,7 @@ localstack replicator start \
   --resource-identifier /dev/
 ```
 
-The `--resource-identifier` in this case must be a path prefix (not a wildcard or glob). All parameters under that prefix will be discovered and replicated. This replication runs in parallel with a fixed concurrency limit (10 resources at a time).
+The `--resource-identifier` in this case must be a path prefix (not a wildcard or glob). All parameters under that prefix will be discovered and replicated.
 
 If `--replication-type` is not specified, the default is `SINGLE_RESOURCE`.
 


### PR DESCRIPTION
The LocalStack Replicator will now be able to create batch replications, using `--replication-type BATCH`. 