### PR TITLE
update changelog with v4.8.0

### DIFF
--- a/src/content/docs/aws/changelog.md
+++ b/src/content/docs/aws/changelog.md
@@ -31,6 +31,7 @@ which can be released as patch version because we are committed to make LocalSta
 
 | Version  | Release Date       | Release Notes                                                                                      |
 |----------|--------------------|----------------------------------------------------------------------------------------------------|
+| `v4.8.0` | September 11, 2025 | [v4.8.0](https://blog.localstack.cloud/localstack-for-aws-release-v-4-8-0/)                        |
 | `v4.7.0` | July 31, 2025      | [v4.7.0](https://blog.localstack.cloud/localstack-for-aws-release-v-4-7-0/)                        |
 | `v4.6.0` | July 3, 2025       | [v4.6.0](https://blog.localstack.cloud/localstack-for-aws-release-v-4-6-0/)                        |
 | `v4.5.0` | June 5, 2025       | [v4.5.0](https://blog.localstack.cloud/localstack-release-v-4-5-0/)                                |


### PR DESCRIPTION
## Motivation
LocalStack for AWS 4.8.0 was released yesterday, this PR adds the new release to the changelog on the new docs! 🥳 
Similar to https://github.com/localstack/localstack-docs/pull/147.

## Changes
- Add the changelog entry for v4.8.0