### PR TITLE
Document FIFO queue creation

### DIFF
--- a/src/content/docs/aws/services/sqs.mdx
+++ b/src/content/docs/aws/services/sqs.mdx
@@ -58,7 +58,7 @@ awslocal sqs get-queue-attributes \
     --attribute-names All
 ```
 
-To create a FIFO queue with suffix `.fifo`, as used by [AWS FIFO queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-fifo-queue-message-identifiers.html), the queue needs to have the attributes `FifoQueue=true` set:
+To create a [FIFO queue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-fifo-queue-message-identifiers.html), the queue name must end with the `.fifo` suffix in addition to the `FifoQueue=true` attribute set:
 
 ```bash
 awslocal sqs create-queue --queue-name localstack-queue.fifo --attributes "FifoQueue=true"


### PR DESCRIPTION
Creating a FIFO queue with suffix `.fifo` is prohibited, because `CreateQueue` won't accept the queue name:

`An error occurred (InvalidParameterValue) when calling the CreateQueue operation: Can only include alphanumeric characters, hyphens, or underscores. 1 to 80 in length`

It seems to be missing in the documentation that `--attributes "FifoQueue=true"` must be set and raised issues like https://github.com/localstack/localstack/issues/1063