### PR TITLE
docs: fix sign up URL for SNOW emulator

### DIFF
--- a/src/components/LanguageSelectWithGetStarted.astro
+++ b/src/components/LanguageSelectWithGetStarted.astro
@@ -8,7 +8,7 @@ const isSnowflakePage = route.id.startsWith('snowflake');
 let getStartedUrl = 'https://app.localstack.cloud/sign-up';
 
 if (isSnowflakePage) {
-  getStartedUrl += 'p?emulator=snowflake';
+  getStartedUrl += '?emulator=snowflake';
 }
 ---
 


### PR DESCRIPTION
Fix broken sign up URL for the Snowflake emulator.

<img width="473" height="111" alt="Screenshot 2025-09-16 at 12 47 27" src="https://github.com/user-attachments/assets/f44734c3-b09c-4465-88b1-9f2310db5ebf" />

Steps to reproduce issue:
1. Go to any Snowflake docs pages, https://docs.localstack.cloud/snowflake/
2. Click Get started for free on the top right, added in https://github.com/localstack/localstack-docs/pull/172.