### PR TITLE
Update service coverage table

### DIFF
--- a/src/content/docs/aws/licensing.md
+++ b/src/content/docs/aws/licensing.md
@@ -170,9 +170,9 @@ To learn more about how a service behaves in LocalStack, refer to that individua
 | [](https://docs.localstack.cloud/references/coverage/coverage_acm/)[AWS Certificate Manager](https://docs.localstack.cloud/references/coverage/coverage_acm/) | ✅ | ✅ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/references/coverage/coverage_cognito-identity/)[Amazon Cognito Identity Pools](https://docs.localstack.cloud/references/coverage/coverage_cognito-identity/) | ❌ | ✅ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/references/coverage/coverage_cognito-idp/)[Amazon Cognito User Pools](https://docs.localstack.cloud/references/coverage/coverage_cognito-idp/) | ❌ | ✅ | ✅ | ✅ |
-| [](https://docs.localstack.cloud/references/coverage/coverage_acm-pca/)[AWS Private Certificate Authority](https://docs.localstack.cloud/references/coverage/coverage_acm-pca/) | ❌ |  | ✅ | ✅ |
+| [](https://docs.localstack.cloud/references/coverage/coverage_acm-pca/)[AWS Private Certificate Authority](https://docs.localstack.cloud/references/coverage/coverage_acm-pca/) | ❌ | ❌ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/references/coverage/coverage_wafv2/)[AWS Web Application Firewall (WAF)](https://docs.localstack.cloud/references/coverage/coverage_wafv2/) | ❌ | ❌ | ✅ | ✅ |
-| [](https://docs.localstack.cloud/references/coverage/coverage_iam/)[AWS Identity and Access Management (IAM)](https://docs.localstack.cloud/references/coverage/coverage_iam/) | ✅ | ✅ | ✅ |
+| [](https://docs.localstack.cloud/references/coverage/coverage_iam/)[AWS Identity and Access Management (IAM)](https://docs.localstack.cloud/references/coverage/coverage_iam/) | ✅ | ✅ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/references/coverage/coverage_identitystore/)[AWS IAM Identity Store API](https://docs.localstack.cloud/references/coverage/coverage_identitystore/) | ❌ | ❌ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/references/coverage/coverage_sso-admin/)[AWS IAM Identity Center](https://docs.localstack.cloud/references/coverage/coverage_sso-admin/) | ❌ | ❌ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/references/coverage/coverage_ram/)[AWS Resource Access Manager (RAM)](https://docs.localstack.cloud/references/coverage/coverage_ram/) | ❌ | ❌ | ✅ | ✅ |


### PR DESCRIPTION
This will add 2 missing states in service coverage:
1. Private Certificate Authority in _Base_
2. Identity and Access Management in _Ultimate_

| BEFORE | AFTER |
|--------|--------|
| <img width="709" height="405" alt="Frame 48097282" src="https://github.com/user-attachments/assets/ade8d974-304c-48f9-92ac-4dad40d6d493" /> | <img width="709" height="405" alt="Frame 48097283" src="https://github.com/user-attachments/assets/807cf9c9-cd16-4dfd-8b61-4f539c680805" /> | 