### PR TITLE
Add AWS Lake Formation availability in service coverage for the Student plan

### DIFF
--- a/src/content/docs/aws/licensing.md
+++ b/src/content/docs/aws/licensing.md
@@ -247,7 +247,7 @@ For any subscription or access-related questions, please reach out to Support.
 | [](https://docs.localstack.cloud/references/coverage/coverage_emr-serverless/)[Amazon EMR Serverless](https://docs.localstack.cloud/references/coverage/coverage_emr-serverless/) | ✅ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/references/coverage/coverage_glue/)[AWS Glue](https://docs.localstack.cloud/references/coverage/coverage_glue/) | ✅ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/references/coverage/coverage_redshift-data/)[Amazon Redshift Data API](https://docs.localstack.cloud/references/coverage/coverage_redshift-data/) | ✅ | ✅ | ✅ |
-| [](https://docs.localstack.cloud/references/coverage/coverage_lakeformation/)[AWS Lake Formation](https://docs.localstack.cloud/references/coverage/coverage_lakeformation/) | ✅ | ✅ | ✅ |
+| [](https://docs.localstack.cloud/references/coverage/coverage_lakeformation/)[AWS Lake Formation](https://docs.localstack.cloud/references/coverage/coverage_lakeformation/) | ✅ | ✅ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/user-guide/aws/msk/)[Amazon Managed Streaming for Apache Kafka](https://docs.localstack.cloud/user-guide/aws/msk/) | ✅ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/user-guide/aws/kinesisanalytics/)[Amazon Kinesis Data Analytics](https://docs.localstack.cloud/user-guide/aws/kinesisanalytics/) | ✅ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/user-guide/aws/kinesisanalyticsv2/)[Amazon Managed Service for Apache Flink](https://docs.localstack.cloud/user-guide/aws/kinesisanalyticsv2/) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
This will add missing availability in service coverage for AWS Lake Formation for the Student plan.

Cc @remotesynth @quetzalliwrites because https://github.com/localstack/localstack-docs/pull/200

| BEFORE | AFTER |
|--------|--------|
| <img width="736" height="355" alt="Frame 48097289" src="https://github.com/user-attachments/assets/d7c1e29c-513e-4cee-a0ff-9cc1e628d65e" /> | <img width="736" height="355" alt="Frame 48097290" src="https://github.com/user-attachments/assets/30996a20-7523-46c3-8605-5717c203f3d1" /> | 