### PR TITLE
Add MERGE_STRATEGY environment variable

### DIFF
--- a/src/content/docs/aws/capabilities/config/configuration.md
+++ b/src/content/docs/aws/capabilities/config/configuration.md
@@ -414,7 +414,7 @@ To learn more about these configuration options, see [Cloud Pods](/aws/capabilit
 | `POD_LOAD_CLI_TIMEOUT` | 60 (default) | Timeout in seconds to wait before returning from load operations on the Cloud Pods CLI |
 | `POD_ENCRYPTION` | `0` (default) \| `1` | Whether to encrypt the Cloud Pods artifacts at rest. |
 | `ENABLE_POD_RESOURCES=1` | `0` (default) \| `1`  | Whether to save a detailed Stack Overview including available resources for the Cloud Pod |
-| `MERGE_STRATEGY` | `account-region-merge` (default) \| `service-merge` \| `overwrite`  | The merge strategy to apply when loading a Cloud Pod into LocalStack (see [state merging](aws/capabilities/state-management/cloud-pods/#state-merging)) |
+| `MERGE_STRATEGY` | `account-region-merge` (default) \| `service-merge` \| `overwrite`  | The merge strategy to apply when loading a Cloud Pod into LocalStack (see [state merging](/aws/capabilities/state-management/cloud-pods/#state-merging)) |
 
 ## Extensions
 

--- a/src/content/docs/aws/capabilities/config/configuration.md
+++ b/src/content/docs/aws/capabilities/config/configuration.md
@@ -414,6 +414,7 @@ To learn more about these configuration options, see [Cloud Pods](/aws/capabilit
 | `POD_LOAD_CLI_TIMEOUT` | 60 (default) | Timeout in seconds to wait before returning from load operations on the Cloud Pods CLI |
 | `POD_ENCRYPTION` | `0` (default) \| `1` | Whether to encrypt the Cloud Pods artifacts at rest. |
 | `ENABLE_POD_RESOURCES=1` | `0` (default) \| `1`  | Whether to save a detailed Stack Overview including available resources for the Cloud Pod |
+| `MERGE_STRATEGY` | `account-region-merge` (default) \| `service-merge` \| `overwrite`  | The merge strategy to apply when loading a Cloud Pod into LocalStack (see [state merging](aws/capabilities/state-management/cloud-pods/#state-merging)) |
 
 ## Extensions
 

--- a/src/content/docs/aws/capabilities/state-management/cloud-pods.mdx
+++ b/src/content/docs/aws/capabilities/state-management/cloud-pods.mdx
@@ -589,9 +589,12 @@ The available strategies are:
 - `service-merge`: This strategy merges services at the account-region level, provided there's no overlap in resources.
   It prioritizes the loaded resources when merging.
 
+The LocalStack's default merge strategy can be changed via the `MERGE_STRATEGY` [configuration variable](/aws/capabilities/config/configuration/).
+
 ### LocalStack CLI
 
-To activate merge strategies, set `--strategy <strategy>` when loading a Cloud Pod using the LocalStack CLI.
+Every `pod load` operation uses the merge strategy set in `MERGE_STRATEGY` (`account-region-merge` by default).
+When loading a Cloud Pod via the LocalStack CLI, one can set the `--strategy <strategy>` option to override the strategy in the configuration variable.
 For instance, to load a Cloud Pod named `test-pod-s3-sqs` with the `service-merge` strategy, run the following command:
 
 ```bash

--- a/src/content/docs/aws/capabilities/state-management/cloud-pods.mdx
+++ b/src/content/docs/aws/capabilities/state-management/cloud-pods.mdx
@@ -594,7 +594,7 @@ The LocalStack's default merge strategy can be changed via the `MERGE_STRATEGY` 
 ### LocalStack CLI
 
 Every `pod load` operation uses the merge strategy set in `MERGE_STRATEGY` (`account-region-merge` by default).
-When loading a Cloud Pod via the LocalStack CLI, one can set the `--strategy <strategy>` option to override the strategy in the configuration variable.
+When loading a Cloud Pod via the LocalStack CLI, set the `--strategy <strategy>` option to override the strategy in the configuration variable.
 For instance, to load a Cloud Pod named `test-pod-s3-sqs` with the `service-merge` strategy, run the following command:
 
 ```bash


### PR DESCRIPTION
Introducing a new MERGE_STRATEGIES  environmental variable that users can use to specify a merge strategy when loading a cloud pod into LocalStack. If a strategy is provided via the CLI (or with a raw HTTP endpoint call) it takes the precedence over this environment variable. This variable also applies to the auto-load pod.