### PR TITLE
docs: add new redirects for CI and web app resource browser

### DIFF
--- a/scripts/redirects/_redirects
+++ b/scripts/redirects/_redirects
@@ -51,6 +51,7 @@
 /user-guide/aws/memorydb/ /aws/services/memorydb 301
 /user-guide/integrations/devcontainers/ /aws/integrations/containers/devcontainers 301
 /references/coverage/coverage_secretsmanager/ /aws/services/secretsmanager 301
+/user-guide/ci /aws/integrations/continuous-integration/ 301
 /user-guide/ci/travis-ci/ /aws/integrations/continuous-integration/travis-ci 301
 /applications/serverless-microservices-with-amazon-api-gateway-dynamodb-sqs-and-lambda/ https://github.com/localstack-samples/sample-microservices-apigateway-lambda-dynamodb-sqs 301
 /user-guide/lambda-tools/ /aws/tooling/lambda-tools 301
@@ -351,6 +352,7 @@
 /references/coverage/coverage_config/ /aws/services/config 301
 /references/coverage/coverage_account/ /aws/services/account 301
 /user-guide/web-application/stack-overview/ /aws/capabilities/web-app/stack-overview 301
+/user-guide/web-application/stack-overview/resources /aws/capabilities/web-app/resource-browser/ 301
 /academy/localstack-deployment/cloud-pods/ https://www.youtube.com/watch?list=PLTew28KOwGxPdtdW00WNXZLZnstvRQyTF&v=ZJP2xfvwR_g&feature=youtu.be 301
 /user-guide/aws/appconfig/ /aws/services/appconfig 301
 /user-guide/aws/cognito/ /aws/services/cognito 301


### PR DESCRIPTION
George flagged that the onboarding emails have some links that need the redirects updated:

- https://docs.localstack.cloud/user-guide/ci
- https://docs.localstack.cloud/user-guide/web-application/stack-overview/resources 

_> note: I **think**_ the `resources` link was the original spot where we had the resource browser documentation.