### PR TITLE
Make extensions available in free plan (take 2)

### DIFF
--- a/src/content/docs/aws/licensing.md
+++ b/src/content/docs/aws/licensing.md
@@ -179,6 +179,7 @@ To learn more about how a service behaves in LocalStack, refer to that individua
 | [](https://docs.localstack.cloud/user-guide/aws/backup/)[AWS Backup](https://docs.localstack.cloud/user-guide/aws/backup/) | ❌ | ❌ | ✅ | ✅ |
 | [](https://docs.localstack.cloud/references/coverage/coverage_efs/)[Amazon EFS](https://docs.localstack.cloud/references/coverage/coverage_efs/) | ❌ | ❌ | ✅ | ✅ |
 | Emulator Enhancements |  |  |  |  |
+| [Extensions](/aws/tooling/extensions/) | ✅ | ✅ | ✅ | ✅ |
 | CI Credits | ❌ | ✅ 300 credits monthly per workspace | ✅ 1000 credits monthly per workspace | ✅ 1,000 CI/CD credits / month |
 | Stack Insights | ❌ | ✅ For all supported services | ✅ For all supported services | ✅ For all supported services |
 | Local state persistence | ❌ | ✅ | ✅ | ✅ |

--- a/src/content/docs/aws/tooling/extensions/developing-extensions.mdx
+++ b/src/content/docs/aws/tooling/extensions/developing-extensions.mdx
@@ -4,7 +4,7 @@ description: How to develop your own extensions.
 template: doc
 sidebar:
     order: 4
-tags: ["Base"]
+tags: ["Free"]
 ---
 
 import { FileTree } from '@astrojs/starlight/components';

--- a/src/content/docs/aws/tooling/extensions/extensions-library.md
+++ b/src/content/docs/aws/tooling/extensions/extensions-library.md
@@ -4,7 +4,7 @@ description: Extend LocalStack by adding new services and features as extensions
 template: doc
 sidebar:
     order: 5
-tags: ["Base"]
+tags: ["Free"]
 ---
 
 ## Introduction
@@ -12,7 +12,7 @@ tags: ["Base"]
 LocalStack extensions allows you to extend and customize LocalStack.
 A LocalStack extension is a Python application that runs together with LocalStack within the LocalStack container.
 
-LocalStack extensions are available to licensed users, and the list of available extensions can be found in the [Extensions Library](https://app.localstack.cloud/extensions/library).
+LocalStack extensions are available across all plans, including Free, and the list of available extensions can be found in the [Extensions Library](https://app.localstack.cloud/extensions/library).
 
 ![LocalStack Extensions Library](/images/aws/extensions-library-ui.png)
 

--- a/src/content/docs/aws/tooling/extensions/index.md
+++ b/src/content/docs/aws/tooling/extensions/index.md
@@ -4,10 +4,10 @@ description: Use LocalStack Extensions to customize and extend your local develo
 template: doc
 sidebar:
     order: 1
-tags: ["Base"]
+tags: ["Free"]
 ---
 
-LocalStack Extensions let you customize and extend LocalStack’s core functionality by running additional logic and services inside the same container. This feature is available in our paid offering, and is ideal for teams that want deeper control over how LocalStack behaves during development or testing.
+LocalStack Extensions let you customize and extend LocalStack's core functionality by running additional logic and services inside the same container. This feature is available across all LocalStack plans, including Free, and is ideal for teams that want deeper control over how LocalStack behaves during development or testing.
 
 You can use LocalStack Extensions to:
 
@@ -19,7 +19,7 @@ You can use LocalStack Extensions to:
 
 The Extensions API makes it easy to integrate your own logic or extend existing services, all within LocalStack’s runtime.
 
-Officially supported extensions are available in our [Official Extensions Library](https://app.localstack.cloud/extensions/library). To install and use extensions, you'll need an active LocalStack license.
+Officially supported extensions are available in our [Official Extensions Library](https://app.localstack.cloud/extensions/library).
 
 :::tip
 Want to try out a common LocalStack extension?

--- a/src/content/docs/aws/tooling/extensions/mailhog.md
+++ b/src/content/docs/aws/tooling/extensions/mailhog.md
@@ -4,7 +4,7 @@ description: Learn how to install and use the official MailHog extension.
 template: doc
 sidebar:
   order: 2
-tags: ['Base']
+tags: ['Free']
 ---
 
 ## Introduction

--- a/src/content/docs/aws/tooling/extensions/managing-extensions.mdx
+++ b/src/content/docs/aws/tooling/extensions/managing-extensions.mdx
@@ -4,7 +4,7 @@ description: How to manage LocalStack extensions in your LocalStack environment.
 template: doc
 sidebar:
     order: 3
-tags: ["Base"]
+tags: ["Free"]
 ---
 
 import { FileTree } from '@astrojs/starlight/components';


### PR DESCRIPTION
Re-opening https://github.com/localstack/localstack-docs/pull/391.

Included lincensing table update which was missed in the first attempt.

See DOC-32.