### PR TITLE
DOC: update ec2 docker operations to include `CreateFleet` and `DeleteFleets`

### DIFF
--- a/src/content/docs/aws/services/ec2.mdx
+++ b/src/content/docs/aws/services/ec2.mdx
@@ -448,6 +448,8 @@ Any operation not listed below will use the mock VM manager.
 | `StopInstances`       | Pauses the Docker containers that back instances |
 | `StartInstances`      | Resumes the Docker containers that back instances |
 | `TerminateInstances`  | Stops the Docker containers that back instances |
+| `CreateFleet`         | Spawns Docker containers or Kubernetes pods to fulfill fleet capacity requests. Supports On-Demand, Spot, and mixed fleets. |
+| `DeleteFleets`        | Stops and removes the underlying containers or pods when `TerminateInstances` is set to `true`. | 
 
 ## Libvirt VM Manager
 


### PR DESCRIPTION
Resolves: [DOC 116](https://linear.app/localstack/issue/DOC-116/ec2-fleet-emulation-support)