### PR TITLE
Azure: Use stop-interception with dash

### DIFF
--- a/src/content/docs/azure/getting-started/quickstart.md
+++ b/src/content/docs/azure/getting-started/quickstart.md
@@ -82,7 +82,7 @@ $ az group delete --name myResourceGroup --yes
 When you're done using the Azure Emulator, you can run the following command:
 
 ```
-$ azlocal stop_interception
+$ azlocal stop-interception
 ```
 
 All invocations of the `az` CLI tool will now talk to the real Azure Cloud again.


### PR DESCRIPTION
Follow-up from https://github.com/localstack/localstack-docs/pull/545 - the `stop-interception` needs a dash, instead of an underscore.

FYI @paolosalvatori 