### PR TITLE
DOCS: fix missing auth token mention in aws ci integrations

### DIFF
--- a/src/content/docs/aws/integrations/continuous-integration/index.md
+++ b/src/content/docs/aws/integrations/continuous-integration/index.md
@@ -41,8 +41,9 @@ We exclusively support the [`localstack/localstack` image in Docker Hub](https:/
 **Auth Token Requirement**: Using LocalStack in a CI environment requires a valid Auth Token. Ensure your environment variables are configured to include your token to avoid authentication failures during image pull or container initialization.
 :::
 
- can be used in your CI environment by adding an [Auth Token](https://docs.localstack.cloud/aws/getting-started/auth-token/).
-The LocalStack Docker image is available on [Docker Hub](https://hub.docker.com/r/localstack/localstack/tags), and comprehensive documentation is available on our .
+LocalStack Docker images can be used in your CI environment by adding an [Auth Token](https://docs.localstack.cloud/aws/getting-started/auth-token/).
+
+The LocalStack Docker image is available on [Docker Hub](https://hub.docker.com/r/localstack/localstack/tags), and here is our [Docker images documentation](https://docs.localstack.cloud/references/docker-images/).
 
 
 ## CI integrations

--- a/src/content/docs/aws/integrations/continuous-integration/index.md
+++ b/src/content/docs/aws/integrations/continuous-integration/index.md
@@ -41,7 +41,7 @@ We exclusively support the [`localstack/localstack` image in Docker Hub](https:/
 **Auth Token Requirement**: Using LocalStack in a CI environment requires a valid Auth Token. Ensure your environment variables are configured to include your token to avoid authentication failures during image pull or container initialization.
 :::
 
- can be used in your CI environment by adding a .
+ can be used in your CI environment by adding an [Auth Token](https://docs.localstack.cloud/aws/getting-started/auth-token/).
 The LocalStack Docker image is available on [Docker Hub](https://hub.docker.com/r/localstack/localstack/tags), and comprehensive documentation is available on our .
 
 


### PR DESCRIPTION
fixes [DOC-219](https://linear.app/localstack/issue/DOC-219/docs-bug-report-missing-text-in-ci-documentation)