### PR TITLE
DOC: Add App Inspector to Licensing & Tiers `current-plans.json`

### DIFF
--- a/src/data/licensing/current-plans.json
+++ b/src/data/licensing/current-plans.json
@@ -672,7 +672,7 @@
     "Base": "1,000 maximum operations stored, error analysis, request & response payload",
     "Ultimate": "1,000 maximum operations stored, error analysis, request & response payload",
     "Enterprise": "1,000 maximum operations stored, error analysis, request & response payload",
-    "Student": "1,000 maximum operations stored, error analysis, request & response payload",
+    "Student": "1,000 maximum operations stored, error analysis, request & response payload"
      }
     },
     {

--- a/src/data/licensing/current-plans.json
+++ b/src/data/licensing/current-plans.json
@@ -672,7 +672,7 @@
     "Base": "1,000 maximum operations stored, error analysis, request & response payload",
     "Ultimate": "1,000 maximum operations stored, error analysis, request & response payload",
     "Enterprise": "1,000 maximum operations stored, error analysis, request & response payload",
-    "Student": true
+    "Student": "1,000 maximum operations stored, error analysis, request & response payload"
      }
     },
     {

--- a/src/data/licensing/current-plans.json
+++ b/src/data/licensing/current-plans.json
@@ -665,6 +665,16 @@
         "Student": true
       }
     },
+  {
+   "name": "App Inspector",
+   "plans": {
+    "Hobby": "10 maximum operations stored",
+    "Base": "1,000 maximum operations stored, error analysis, request & response payload",
+    "Ultimate": "1,000 maximum operations stored, error analysis, request & response payload",
+    "Enterprise": "1,000 maximum operations stored, error analysis, request & response payload",
+    "Student": true
+     }
+    },
     {
       "name": "Preview: Debug and Inspect through Event Studio",
       "docsUrl": "/aws/tooling/event-studio/",

--- a/src/data/licensing/current-plans.json
+++ b/src/data/licensing/current-plans.json
@@ -672,7 +672,7 @@
     "Base": "1,000 maximum operations stored, error analysis, request & response payload",
     "Ultimate": "1,000 maximum operations stored, error analysis, request & response payload",
     "Enterprise": "1,000 maximum operations stored, error analysis, request & response payload",
-    "Student": "1,000 maximum operations stored, error analysis, request & response payload"
+    "Student": "1,000 maximum operations stored, error analysis, request & response payload",
      }
     },
     {


### PR DESCRIPTION
Let's consistently store all **Licensing & Tiers** table plans in same spot.

