### PR TITLE
DOC: remove mention of `events` legacy implementation

### DIFF
--- a/src/content/docs/aws/capabilities/config/configuration.md
+++ b/src/content/docs/aws/capabilities/config/configuration.md
@@ -222,11 +222,6 @@ Also see [OpenSearch configuration variables](#opensearch) which are used to man
 | - | - | - |
 | `IGNORE_ES_DOWNLOAD_ERRORS` | `0`\|`1` | Whether to ignore errors (e.g., network/SSL) when downloading ElasticSearch plugins |
 
-### EventBridge
-
-| Variable | Example Values | Description |
-| - | - | - |
-| `PROVIDER_OVERRIDE_EVENTS` | `legacy`\|`v2` (default) | The [new EventBridge provider](https://discuss.localstack.cloud/t/introducing-eventbridge-v2-in-localstack/946) is active by default since LocalStack 4.0. |
 
 ### Glue
 
@@ -483,6 +478,7 @@ These configurations have already been removed and **won't have any effect** on 
 | `EVENT_RULE_ENGINE` | 4.1.0 | `python` (default) \| `java` (deprecated) | Engine for [event pattern matching](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) used in EventBridge, EventBridge Pipes, and Lambda Event Source Mapping. Our [new](https://github.com/localstack/localstack/pull/11960) `python` implementation introduced with [4.0.3](https://github.com/localstack/localstack/releases/tag/v4.0.3) makes the `java` engine (previously in preview) using AWS [event-ruler](https://github.com/aws/event-ruler) obsolete. |
 | `LAMBDA_EVENT_SOURCE_MAPPING` | 4.0.0 | `v2` (default since [3.8.0](https://blog.localstack.cloud/localstack-release-v-3-8-0/#new-default-lambda-event-source-mapping-implementation)) \| `v1` | Feature flag to switch Lambda Event Source Mapping (ESM) implementations. |
 | `PROVIDER_OVERRIDE_STEPFUNCTIONS` | 4.0.0 | `v2` (default) \| `legacy` | The new LocalStack-native StepFunctions provider (v2) is active by default since LocalStack 3.0. |
+| `PROVIDER_OVERRIDE_EVENTS` | 2026.4.0 | `v2` (default) \| `legacy` | The new EventBridge provider is active by default since LocalStack 4.0. |
 | `STEPFUNCTIONS_LAMBDA_ENDPOINT` | 4.0.0 | `default` | This is only supported for the `legacy` provider. URL to use as the Lambda service endpoint in Step Functions. By default this is the LocalStack Lambda endpoint. Use default to select the original AWS Lambda endpoint. |
 | `LOCAL_PORT_STEPFUNCTIONS` | 4.0.0 | `8083` (default) | This is only supported for the legacy provider. It defines the local port to which Step Functions traffic is redirected. By default, LocalStack routes Step Functions traffic to its internal runtime. Use this variable only if you need to redirect traffic to a different local Step Functions runtime. |
 | `S3_DIR` | 4.0.0 | `/path/to/root` | This was only supported for the `legacy_v2` provider. Configure a global parent directory that contains all buckets as sub-directories (`S3_DIR=/path/to/root`) or an individual directory that will get mounted as special bucket names (`S3_DIR=/path/to/root/bucket1:bucket1`). Only available for LocalStack for AWS.

--- a/src/content/docs/aws/services/events.mdx
+++ b/src/content/docs/aws/services/events.mdx
@@ -18,10 +18,6 @@ LocalStack allows you to use the EventBridge APIs in your local environment to c
 The supported APIs are available on our [API Coverage section](#api-coverage), which provides information on the extent of EventBridge's integration with LocalStack.
 For information on EventBridge Pipes, please refer to the [EventBridge Pipes](/aws/services/pipes/) documentation.
 
-:::note
-The native EventBridge provider, introduced in [LocalStack 3.5.0](https://discuss.localstack.cloud/t/localstack-release-v3-5-0/947), is now the default in 4.0. The legacy provider can still be enabled using the `PROVIDER_OVERRIDE_EVENTS=v1` configuration, but it is deprecated and will be removed in the next major release. We strongly recommend migrating to the new provider.
-:::
-
 ## Getting Started
 
 This guide is designed for users new to EventBridge and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.


### PR DESCRIPTION
Completes DOC-216

Related to https://github.com/localstack/localstack-pro/pull/6838

The EventBridge (`events`) legacy implementation has been deprecated since LocalStack v4.0.0. We're removing this implementation with LocalStack v2026.04.0 (it has been removed in `latest` this week already), so this can be merged as soon as you want. 

This PR moves the flag in the legacy configuration, and remove the notes in the EventBridge page. 

Preview of the Legacy config: https://3169b45a.localstack-docs.pages.dev/aws/capabilities/config/configuration/#legacy

Preview of the EventBridge page: https://3169b45a.localstack-docs.pages.dev/aws/services/events/