### PR TITLE
add docs on lambda no_proxy env var

### DIFF
--- a/src/content/docs/aws/enterprise/kubernetes/faq.md
+++ b/src/content/docs/aws/enterprise/kubernetes/faq.md
@@ -237,6 +237,10 @@ If you are using `HTTP_PROXY` or `HTTPS_PROXY` environment variables to configur
 
 In the example above, add `NO_PROXY=192.168.0.1` to your pod environment variables.
 
+For Lambda child pods, LocalStack automatically extends the Lambda execution environment's `no_proxy` value with the configured `LOCALSTACK_HOST` host, such as `localhost.localstack.cloud`.
+This ensures Lambda runtime traffic to LocalStack bypasses corporate proxies.
+If your cluster uses an admission controller or webhook to inject proxy variables into pods, ensure that it does not overwrite this value, or configure it to include the LocalStack host in `no_proxy`/`NO_PROXY`.
+
 ### Docker runtime errors
 
 ```text

--- a/src/content/docs/aws/services/lambda.mdx
+++ b/src/content/docs/aws/services/lambda.mdx
@@ -537,6 +537,17 @@ Some noteworthy configurations include:
 The full list of configurations is defined in the Golang function
 [InitLsOpts](https://github.com/localstack/lambda-runtime-init/blob/localstack/cmd/localstack/main.go#L43).
 
+### Proxy configuration
+
+Lambda execution environments communicate back to the LocalStack container for runtime APIs, credentials, logs, and calls to emulated AWS services.
+If your host, Docker daemon, or Kubernetes cluster injects `http_proxy` or `https_proxy` into Lambda containers, that internal traffic must bypass the proxy.
+
+LocalStack automatically adds the configured `LOCALSTACK_HOST` host, and the runtime `LOCALSTACK_HOSTNAME` when present, to the Lambda execution environment's `no_proxy` variable.
+If your function already defines `no_proxy`, LocalStack preserves the existing entries and prepends the LocalStack hosts.
+
+In Kubernetes deployments, make sure admission controllers or proxy-injection policies do not overwrite the `no_proxy` value after LocalStack creates Lambda pods.
+If your cluster-level policy manages `no_proxy`, include the LocalStack host used by your deployment, for example `localhost.localstack.cloud` or the host configured through `LOCALSTACK_HOST`.
+
 ## Special Tools
 
 LocalStack provides various tools to help you develop, debug, and test your AWS Lambda functions more efficiently.


### PR DESCRIPTION
Fixes [DOC-168](https://linear.app/localstack/issue/DOC-168/doc-lambda-always-add-no-proxy-envar)