### PR TITLE
add note on SSL_NO_VERIFY in HTTPS/TLS support page

### DIFF
--- a/src/content/docs/aws/capabilities/networking/https-tls-support.mdx
+++ b/src/content/docs/aws/capabilities/networking/https-tls-support.mdx
@@ -15,6 +15,8 @@ https://s3.us-east-1.localhost.localstack.cloud:4566
 ```
 These certificates enable proper hostname validation for supported AWS regions when using HTTPS with SDKs, the AWS CLI, browsers, and other tools.
 
+If LocalStack runs behind a corporate proxy that interferes with fetching the public certificate, you can set [`SSL_NO_VERIFY=1`](/aws/capabilities/config/configuration#miscellaneous) to disable TLS verification when downloading the certificate from `localhost.localstack.cloud`.
+
 ### Supported Regions
 
 Due to certificate authority and infrastructure limitations, TLS certificates are currently only issued for a subset of AWS regions. If you attempt to use an unsupported region, you may encounter TLS errors such as:


### PR DESCRIPTION
Fixes [DOC-205](https://linear.app/localstack/issue/DOC-205/doc-ssl-print-error-if-there-is-one-when-fetching-certificate)