### PR TITLE
Fix the build issues

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,16 +15,84 @@ import react from '@astrojs/react';
 
 import tailwindcss from '@tailwindcss/vite';
 
-// Fetch the latest release version from GitHub
-const response = await fetch(
-  'https://api.github.com/repos/localstack/localstack/releases/latest',
-  {
-    headers: { Accept: 'application/vnd.github+json' },
-  },
-);
-const data = await response.json();
-const latestVersion = data.tag_name.replace('v', '');
+// Used on the AWS and Snowflake installation guides: CLI download URLs and some bash examples.
+// Source of truth: public https://github.com/localstack/localstack-cli/releases/latest
+const LOCALSTACK_CLI_RELEASE_API =
+  'https://api.github.com/repos/localstack/localstack-cli/releases/latest';
 
+/** When the API fails or rate-limits, builds still succeed; bump when CLI ships a new line. */
+const LOCALSTACK_CLI_VERSION_FALLBACK = '2026.4.0';
+
+/** @param {unknown} tagName */
+function normalizeCliReleaseTag(tagName) {
+  if (typeof tagName !== 'string' || !tagName.trim()) return null;
+  return tagName.replace(/^v/i, '').trim();
+}
+
+/**
+ * One request per build when LOCALSTACK_AWS_VERSION is unset. Use that env in CI to skip the
+ * network entirely, or set GITHUB_TOKEN for 5k req/hr instead of unauthenticated 60/hr per IP.
+ */
+async function fetchLatestLocalstackCliVersionFromGitHub() {
+  /** @type {Record<string, string>} */
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'localstack-docs-build (https://docs.localstack.cloud)',
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const maxAttempts = 3;
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      if (attempt > 1) {
+        await new Promise((r) => setTimeout(r, 400 * attempt));
+      }
+      const response = await fetch(LOCALSTACK_CLI_RELEASE_API, { headers });
+      const data = await response.json();
+
+      if (response.ok) {
+        const version = normalizeCliReleaseTag(data?.tag_name);
+        if (version) return version;
+        lastError = new Error('GitHub release response missing tag_name');
+      } else {
+        const msg =
+          typeof data?.message === 'string' ? data.message : `HTTP ${response.status}`;
+        lastError = new Error(msg);
+      }
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  throw lastError ?? new Error('Failed to fetch localstack-cli release from GitHub');
+}
+
+const cliVersionFromEnv = normalizeCliReleaseTag(process.env.LOCALSTACK_AWS_VERSION ?? '');
+
+/** @type {string} */
+let latestAWSVersion;
+
+if (cliVersionFromEnv) {
+  latestAWSVersion = cliVersionFromEnv;
+} else {
+  try {
+    latestAWSVersion = await fetchLatestLocalstackCliVersionFromGitHub();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[astro.config] Could not read localstack-cli version from GitHub (${reason}). ` +
+        `Using pinned fallback ${LOCALSTACK_CLI_VERSION_FALLBACK}. ` +
+        'Set LOCALSTACK_AWS_VERSION in the build, add GITHUB_TOKEN for higher API limits, or bump LOCALSTACK_CLI_VERSION_FALLBACK.',
+    );
+    latestAWSVersion = LOCALSTACK_CLI_VERSION_FALLBACK;
+  }
+}
+
+/** @type {import('./types/astro-local-fonts').AstroLocalFontVariants} */
 const aeonikProVariants = [
   {
     src: [
@@ -118,10 +186,10 @@ export default defineConfig({
   ],
   env: {
     schema: {
-      LOCALSTACK_VERSION: envField.string({
+      LOCALSTACK_AWS_VERSION: envField.string({
         context: 'server',
         access: 'public',
-        default: latestVersion,
+        default: latestAWSVersion,
         optional: true,
       }),
     },

--- a/src/content/docs/aws/getting-started/installation.mdx
+++ b/src/content/docs/aws/getting-started/installation.mdx
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 import { Code, LinkButton, Tabs, TabItem } from '@astrojs/starlight/components';
-import { LOCALSTACK_VERSION } from "astro:env/server";
+import { LOCALSTACK_AWS_VERSION } from 'astro:env/server';
 
 ## LocalStack CLI
 
@@ -26,22 +26,43 @@ For alternative methods of managing the LocalStack container, see our [alternati
 
 You can download the pre-built binary for your architecture using the link below:
 
-<LinkButton href={`https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_VERSION}/localstack-cli-${LOCALSTACK_VERSION}-linux-amd64-onefile.tar.gz`} icon="download" variant="minimal">x86-64</LinkButton>
-<LinkButton href={`https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_VERSION}/localstack-cli-${LOCALSTACK_VERSION}-linux-arm64-onefile.tar.gz`} icon="download" variant="minimal">ARM64</LinkButton>
+<LinkButton
+  href={`https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_AWS_VERSION}/localstack-cli-${LOCALSTACK_AWS_VERSION}-linux-amd64-onefile.tar.gz`}
+  icon="download"
+  variant="minimal"
+>
+  x86-64
+</LinkButton>
+<LinkButton
+  href={`https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_AWS_VERSION}/localstack-cli-${LOCALSTACK_AWS_VERSION}-linux-arm64-onefile.tar.gz`}
+  icon="download"
+  variant="minimal"
+>
+  ARM64
+</LinkButton>
 
 or use the curl commands below:
 
 For x86-64:
 
-<Code code={`curl --output localstack-cli-${LOCALSTACK_VERSION}-linux-amd64-onefile.tar.gz \\\n    --location https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_VERSION}/localstack-cli-${LOCALSTACK_VERSION}-linux-amd64-onefile.tar.gz`} lang="bash" />
+<Code
+  code={`curl --output localstack-cli-${LOCALSTACK_AWS_VERSION}-linux-amd64-onefile.tar.gz \\\n    --location https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_AWS_VERSION}/localstack-cli-${LOCALSTACK_AWS_VERSION}-linux-amd64-onefile.tar.gz`}
+  lang="bash"
+/>
 
 For ARM64:
 
-<Code code={`curl --output localstack-cli-${LOCALSTACK_VERSION}-linux-arm64-onefile.tar.gz \\\n    --location https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_VERSION}/localstack-cli-${LOCALSTACK_VERSION}-linux-arm64-onefile.tar.gz`} lang="bash" />
+<Code
+  code={`curl --output localstack-cli-${LOCALSTACK_AWS_VERSION}-linux-arm64-onefile.tar.gz \\\n    --location https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_AWS_VERSION}/localstack-cli-${LOCALSTACK_AWS_VERSION}-linux-arm64-onefile.tar.gz`}
+  lang="bash"
+/>
 
 Then extract the LocalStack CLI from the terminal:
 
-<Code code={`sudo tar xvzf localstack-cli-${LOCALSTACK_VERSION}-linux-*-onefile.tar.gz -C /usr/local/bin`} lang="bash" />
+<Code
+  code={`sudo tar xvzf localstack-cli-${LOCALSTACK_AWS_VERSION}-linux-*-onefile.tar.gz -C /usr/local/bin`}
+  lang="bash"
+/>
 
 <details>
 <summary>Alternative: Homebrew on Linux</summary>
@@ -51,6 +72,7 @@ If you are using [Homebrew for Linux](https://docs.brew.sh/Homebrew-on-Linux), y
 ```bash
 brew install localstack/tap/localstack-cli
 ```
+
 </details>
 
 </TabItem>
@@ -68,16 +90,28 @@ brew install localstack/tap/localstack-cli
 
 You may download the binary for your architecture using the link below:
 
-<LinkButton href={`https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_VERSION}/localstack-cli-${LOCALSTACK_VERSION}-darwin-amd64-onefile.tar.gz`} icon="download" variant="minimal">Intel (AMD64)</LinkButton>
+<LinkButton
+  href={`https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_AWS_VERSION}/localstack-cli-${LOCALSTACK_AWS_VERSION}-darwin-amd64-onefile.tar.gz`}
+  icon="download"
+  variant="minimal"
+>
+  Intel (AMD64)
+</LinkButton>
 
 or use the following curl command:
 
-<Code code={`curl --output ${LOCALSTACK_VERSION}-darwin-amd64-onefile.tar.gz \
-    --location https://github.com/localstack/localstack-cli/releases/download/${LOCALSTACK_VERSION}/localstack-cli-${LOCALSTACK_VERSION}-darwin-amd64-onefile.tar.gz`} lang="bash" />
+<Code
+  code={`curl --output ${LOCALSTACK_AWS_VERSION}-darwin-amd64-onefile.tar.gz \
+    --location https://github.com/localstack/localstack-cli/releases/download/${LOCALSTACK_AWS_VERSION}/localstack-cli-${LOCALSTACK_AWS_VERSION}-darwin-amd64-onefile.tar.gz`}
+  lang="bash"
+/>
 
 Then extract the LocalStack CLI from the terminal:
 
-<Code code={`sudo tar xvzf localstack-cli-${LOCALSTACK_VERSION}-darwin-*-onefile.tar.gz -C /usr/local/bin`} lang="bash" />
+<Code
+  code={`sudo tar xvzf localstack-cli-${LOCALSTACK_AWS_VERSION}-darwin-*-onefile.tar.gz -C /usr/local/bin`}
+  lang="bash"
+/>
 
 </details>
 </TabItem>
@@ -86,9 +120,16 @@ Then extract the LocalStack CLI from the terminal:
 
 You can download the pre-built binary for your architecture using the link below:
 
-<LinkButton href={`https://github.com/localstack/localstack-cli/releases/download/v2026.3.0/localstack-cli-2026.3.0-windows-amd64-onefile.zip`} icon="download" variant="minimal">Intel (AMD64)</LinkButton>
+<LinkButton
+  href={`https://github.com/localstack/localstack-cli/releases/download/v2026.3.0/localstack-cli-2026.3.0-windows-amd64-onefile.zip`}
+  icon="download"
+  variant="minimal"
+>
+  Intel (AMD64)
+</LinkButton>
 
 Then extract the archive and execute the binary in Powershell.
+
 </TabItem>
 
 <TabItem label="Other/Python" >
@@ -112,8 +153,8 @@ To download a specific version of LocalStack, replace `<version>` with the requi
 ```bash
 python3 -m pip install localstack==<version>
 ```
-:::
 
+:::
 
 :::tip[MacOS Sierra?]
 If you have problems with permissions in MacOS X Sierra, install with:
@@ -121,6 +162,7 @@ If you have problems with permissions in MacOS X Sierra, install with:
 ```bash
 python3 -m pip install --user localstack
 ```
+
 :::
 
 :::danger
@@ -135,10 +177,9 @@ It should be installed and started entirely under a local non-root user.
 
 To verify that the LocalStack CLI was installed correctly, you can check the version in your terminal:
 
-<Code code={`localstack --version\n${LOCALSTACK_VERSION}`} lang="bash" />
+<Code code={`localstack --version\n${LOCALSTACK_AWS_VERSION}`} lang="bash" />
 
 You are all set!
-
 
 :::note
 To start LocalStack, you must first [set up your auth token](/aws/getting-started/auth-token).
@@ -150,23 +191,27 @@ Once you've set up your auth token, you can start LocalStack with the following 
 localstack start # start localstack in background with -d flag
 ```
 
-```bash
-     __                     _______ __             __
+{/* prettier-ignore */}
+<Code
+  code={`   __                     _______ __             __
     / /   ____  _________ _/ / ___// /_____ ______/ /__
-   / /   / __ \/ ___/ __ `/ /\__ \/ __/ __ `/ ___/ //_/
+   / /   / __ \\/ ___/ __ \`/ /\\__ \\/ __/ __ \`/ ___/ //_/
   / /___/ /_/ / /__/ /_/ / /___/ / /_/ /_/ / /__/ ,<
- /_____/\____/\___/\__,_/_//____/\__/\__,_/\___/_/|_|
- 
- 💻 LocalStack CLI ${LOCALSTACK_VERSION}
- 👤 Profile: default
+ /_____/\\____/\\___/\\__,_/_//____/\\__/\\__,_/\\___/_/|_|
+
+ - LocalStack CLI ` +
+    LOCALSTACK_AWS_VERSION +
+    `
+ - Profile: default
+ - App: https://app.localstack.cloud
 
 [12:47:13] starting LocalStack in Docker mode 🐳                       localstack.py:494
            preparing environment                                       bootstrap.py:1240
            configuring container                                       bootstrap.py:1248
            starting container                                          bootstrap.py:1258
-[12:47:15] detaching                                                   bootstrap.py:1262
-```
-
+[12:47:15] detaching                                                   bootstrap.py:1262`}
+  lang="bash"
+/>
 
 ### Updating LocalStack CLI
 
@@ -248,23 +293,22 @@ Docker Compose v1.9.0 and above is supported.
 ```yaml showshowLineNumbers
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
-    image: localstack/localstack-pro  # required for Pro
+    container_name: '${LOCALSTACK_DOCKER_NAME:-localstack-main}'
+    image: localstack/localstack-pro # required for Pro
     ports:
-      - "127.0.0.1:4566:4566"            # LocalStack Gateway
-      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
-      - "127.0.0.1:443:443"              # LocalStack HTTPS Gateway (Pro)
+      - '127.0.0.1:4566:4566' # LocalStack Gateway
+      - '127.0.0.1:4510-4559:4510-4559' # external services port range
+      - '127.0.0.1:443:443' # LocalStack HTTPS Gateway (Pro)
     environment:
       # Activate LocalStack for AWS: https://docs.localstack.cloud/getting-started/auth-token/
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?}  # required for Pro
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?} # required for Pro
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - PERSISTENCE=${PERSISTENCE:-0}
     volumes:
-      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - '${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack'
+      - '/var/run/docker.sock:/var/run/docker.sock'
 ```
-
 
 Start the container by running the following command:
 
@@ -273,6 +317,7 @@ docker compose up
 ```
 
 :::note
+
 - This command pulls the current nightly build from the `main` branch (if you don't have the image locally) and **not** the latest supported version.
   If you want to use a specific version, set the appropriate LocalStack image tag at `services.localstack.image` in the `docker-compose.yml` file (for example `localstack/localstack:<version>`).
 
@@ -291,7 +336,7 @@ docker compose up
   Please consider removing it, if this functionality is needed.
 
 - To configure an Auth Token, refer to the [Auth Token](/aws/getting-started/auth-token) documentation.
-:::
+  :::
 
 Please note that there are a few pitfalls when configuring your stack manually via docker-compose (e.g., required container name, Docker network, volume mounts, and environment variables).
 We recommend using the LocalStack CLI to validate your configuration, which will print warning messages in case it detects any potential misconfigurations:
@@ -327,6 +372,7 @@ docker run \
 ```
 
 :::note
+
 - This command pulls the current nightly build from the `main` branch (if you don't have the image locally) and **not** the latest supported version.
   If you want to use a specific version of LocalStack, use the appropriate tag: `docker run --rm -it -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack:<tag>`.
   Check-out the [LocalStack releases](https://github.com/localstack/localstack/releases) to know more about specific LocalStack versions.
@@ -347,7 +393,7 @@ docker run \
   For instance, setting `LOCALSTACK_PERSISTENCE=1` is equivalent to `PERSISTENCE=1`.
 
 - To configure an Auth Token, refer to the [Auth Token](/aws/getting-started/auth-token) documentation.
-:::
+  :::
 
 ### Helm
 
@@ -361,6 +407,7 @@ If you want to deploy LocalStack in your [Kubernetes](https://kubernetes.io) clu
 #### Deploy LocalStack using Helm
 
 You can deploy LocalStack in a Kubernetes cluster by running these commands:
+
 ```bash
 helm repo add localstack-repo https://helm.localstack.cloud
 helm upgrade --install localstack localstack-repo/localstack
@@ -371,6 +418,7 @@ The Helm charts are not maintained in the main repository, but in a [separate on
 ## What's next?
 
 Now that you have LocalStack up and running, the following resources might be useful for your next steps:
+
 - Check out our [Quickstart guide](/aws/getting-started/quickstart) if you are a new user to get started with LocalStack quickly.
 - [Use the LocalStack integrations](/aws/integrations) to interact with LocalStack and other integrated tools, for example:
   - Use `awslocal` to use the AWS CLI against your local cloud!
@@ -386,10 +434,12 @@ Now that you have LocalStack up and running, the following resources might be us
 #### The LocalStack CLI installation is successful, but I cannot execute `localstack`
 
 If you can successfully install LocalStack using `pip` but you cannot use it in your terminal, you most likely haven't set up your operating system's / terminal's `PATH` variable (in order to tell them where to find programs installed via `pip`).
+
 - If you are using Windows, you can enable the `PATH` configuration when installing Python, [as described in the official docs of Python](https://docs.python.org/3/using/windows.html#finding-the-python-executable).
 - If you are using a MacOS or Linux operating system, please make sure that the `PATH` is correctly set up - either system wide, or in your terminal.
 
 As a workaround you can call the LocalStack CLI python module directly:
+
 ```bash
 python3 -m localstack.cli.main
 ```
@@ -397,12 +447,15 @@ python3 -m localstack.cli.main
 #### The `localstack` CLI does not start the LocalStack container
 
 If you are using the `localstack` CLI to start LocalStack, but the container is not starting, please check the following:
+
 - Uncheck the **Use kernel networking for UDP** option in Docker Desktop (**Settings** → **Resources** → **Network**) or follow the steps in our [documentation](/aws/tooling/dns-server#system-dns-configuration) to disable it.
 - Start LocalStack with a specific DNS address:
+
 ```bash
 DNS_ADDRESS=0 localstack start
 ```
-- Remove port 53 as indicated in our [standard `docker-compose.yml`  file](https://github.com/localstack/localstack/blob/main/docker-compose-pro.yml).
+
+- Remove port 53 as indicated in our [standard `docker-compose.yml` file](https://github.com/localstack/localstack/blob/main/docker-compose-pro.yml).
 
 #### How should I access the LocalStack logs on my local machine?
 

--- a/src/content/docs/snowflake/getting-started/index.mdx
+++ b/src/content/docs/snowflake/getting-started/index.mdx
@@ -3,11 +3,11 @@ title: Installation
 description: Installation guide to get started with LocalStack for Snowflake.
 template: doc
 sidebar:
-    order: 0
+  order: 0
 ---
 
 import { Code, LinkButton, Tabs, TabItem } from '@astrojs/starlight/components';
-import { LOCALSTACK_VERSION } from "astro:env/server";
+import { LOCALSTACK_AWS_VERSION } from 'astro:env/server';
 
 ## LocalStack CLI for Snowflake
 
@@ -16,7 +16,6 @@ The easiest way to get started with LocalStack for Snowflake is by using the Loc
 ## Installing the LocalStack CLI
 
 The LocalStack CLI can be installed using Python, Brew (macOS), or Windows executables.
-
 
 <Tabs>
 
@@ -33,7 +32,7 @@ Then install the LocalStack CLI:
 
 ```bash
 python3 -m pip install --upgrade localstack
-````
+```
 
 :::note
 To download a specific version of LocalStack, replace `<version>` with the required version from [release page](https://github.com/localstack/localstack/releases).
@@ -41,8 +40,8 @@ To download a specific version of LocalStack, replace `<version>` with the requi
 ```bash
 python3 -m pip install localstack==<version>
 ```
-:::
 
+:::
 
 :::tip[MacOS Sierra?]
 If you have problems with permissions in MacOS X Sierra, install with:
@@ -50,6 +49,7 @@ If you have problems with permissions in MacOS X Sierra, install with:
 ```bash
 python3 -m pip install --user localstack
 ```
+
 :::
 
 :::danger
@@ -72,11 +72,20 @@ brew install localstack/tap/localstack-cli
 
 Download the binary for your architecture:
 
-<LinkButton href={`https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_VERSION}/localstack-cli-${LOCALSTACK_VERSION}-darwin-amd64-onefile.tar.gz`} icon="download" variant="minimal">Intel (AMD64)</LinkButton>
+<LinkButton
+  href={`https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_AWS_VERSION}/localstack-cli-${LOCALSTACK_AWS_VERSION}-darwin-amd64-onefile.tar.gz`}
+  icon="download"
+  variant="minimal"
+>
+  Intel (AMD64)
+</LinkButton>
 
 Then extract it:
 
-<Code code={`sudo tar xvzf localstack-cli-${LOCALSTACK_VERSION}-darwin-*-onefile.tar.gz -C /usr/local/bin`} lang="bash" />
+<Code
+  code={`sudo tar xvzf localstack-cli-${LOCALSTACK_AWS_VERSION}-darwin-*-onefile.tar.gz -C /usr/local/bin`}
+  lang="bash"
+/>
 
 </details>
 
@@ -86,7 +95,13 @@ Then extract it:
 
 You can download the pre-built binary below:
 
-<LinkButton href={`https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_VERSION}/localstack-cli-${LOCALSTACK_VERSION}-windows-amd64-onefile.zip`} icon="download" variant="minimal">Intel (AMD64)</LinkButton>
+<LinkButton
+  href={`https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_AWS_VERSION}/localstack-cli-${LOCALSTACK_AWS_VERSION}-windows-amd64-onefile.zip`}
+  icon="download"
+  variant="minimal"
+>
+  Intel (AMD64)
+</LinkButton>
 
 Then extract the archive and run the binary in PowerShell.
 
@@ -97,7 +112,6 @@ You can download and install the Windows executable from our [GitHub Releases](h
 </TabItem>
 
 </Tabs>
-
 
 Need more options? See our [alternative installation instructions](https://docs.localstack.cloud/snowflake/getting-started/#alternatives).
 
@@ -126,9 +140,8 @@ curl -d '{}' snowflake.localhost.localstack.cloud:4566/session
 Expected response:
 
 ```json
-{"success": true}
+{ "success": true }
 ```
-
 
 ## Updating LocalStack
 
@@ -153,20 +166,20 @@ Refer to the available [tags on Docker Hub](https://hub.docker.com/r/localstack/
 If you prefer Docker Compose, you can start the emulator using the configuration below:
 
 ```yaml showLineNumbers
-version: "3.8"
+version: '3.8'
 
 services:
   localstack:
-    container_name: "localstack-snowflake"
+    container_name: 'localstack-snowflake'
     image: localstack/snowflake
     ports:
-      - "127.0.0.1:4566:4566"
-      - "127.0.0.1:4510-4559:4510-4559"
-      - "127.0.0.1:443:443"
+      - '127.0.0.1:4566:4566'
+      - '127.0.0.1:4510-4559:4510-4559'
+      - '127.0.0.1:443:443'
     environment:
       - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?}
     volumes:
-      - "./volume:/var/lib/localstack"
+      - './volume:/var/lib/localstack'
 ```
 
 Start the container with:

--- a/types/astro-local-fonts.d.ts
+++ b/types/astro-local-fonts.d.ts
@@ -1,0 +1,4 @@
+import type { LocalFamilyOptions } from '../node_modules/astro/dist/assets/fonts/providers/local';
+
+/** Non-empty variant list for `fontProviders.local()` (see Astro `LocalFamilyOptions`). */
+export type AstroLocalFontVariants = LocalFamilyOptions['variants'];


### PR DESCRIPTION
These appear to have been related to API rate limits when getting the latest version release on GitHub. However, it was also getting them from the wrong place as the OSS library no longer had the latest version. Swapped to getting it from the CLI version since they match and this is primarily used to get the links for binary downloads.