### PR TITLE
docs: updating docker tags and defining them

### DIFF
--- a/src/content/docs/aws/capabilities/config/docker-images.md
+++ b/src/content/docs/aws/capabilities/config/docker-images.md
@@ -29,12 +29,20 @@ While configuring to run LocalStack with Docker or Docker Compose, run the `loca
 
 ## Image tags
 
-Starting with the end-of-March 2026 release, LocalStack version tags follow
-[calendar versioning](https://calver.org/) in the `YYYY.MM.patch` format (for example, `2026.03.0`).
+Starting with the end-of-March 2026 release, LocalStack version tags follow [calendar versioning](https://calver.org/) in the `YYYY.MM.patch` format (for example, `2026.03.0`). Releases up to and including `v4.14.0` use [semantic versioning](https://semver.org).
 
-Releases up to and including `v4.14.0` use [semantic versioning](https://semver.org).
-To ensure that we move quickly and steadily, we run nightly builds, where all our updates are available on the `latest` tag of LocalStack's Docker image.
-We intend to announce more significant features and enhancements during major & minor releases.
-We occasionally create patch releases for minor bug fixes and enhancements, to ensure that we can deliver changes quickly while not breaking your existing workflows (in case you prefer not to use `latest`).
+The following tags are available for the LocalStack Docker image:
 
-Visit the [LocalStack for AWS tag](https://hub.docker.com/r/localstack/localstack-pro/tags?page=1&ordering=last_updated) in Docker Hub pages.
+| Tag | Updated when | Recommended for |
+|---|---|---|
+| `latest` / `stable` | Tagged releases only (e.g. `2026.05.0`) | Most users — stable, release-quality builds |
+| `dev` | Every merged commit on `main` | Users who need the latest unreleased changes |
+| `nightly` | Scheduled nightly builds | CI pipelines that need a fresh build on a regular cadence |
+| `YYYY.MM` (e.g. `2026.05`) | Each patch release within that month | Users who want bugfixes but want to avoid feature changes |
+| `YYYY.MM.patch` (e.g. `2026.05.0`) | Never (pinned) | Fully reproducible environments where no changes are acceptable |
+
+:::note
+As of May 2026, `latest` was changed to mirror `stable` and is only updated on official tagged releases. If you previously relied on `latest` for the most recent unreleased changes, switch to the `dev` tag.
+:::
+
+Visit the [LocalStack for AWS tag](https://hub.docker.com/r/localstack/localstack-pro/tags?page=1&ordering=last_updated) page on Docker Hub.

--- a/src/content/docs/aws/getting-started/faq.mdx
+++ b/src/content/docs/aws/getting-started/faq.mdx
@@ -60,6 +60,10 @@ Across our docs, we use `localhost.localstack.cloud:4566` instead of `localhost:
 
 ### How should I use the latest LocalStack Docker images?
 
+:::note
+As of May 2026, the `latest` tag mirrors `stable` and is only updated on official releases. If you need the most recent unreleased changes, pull `localstack/localstack:dev` instead.
+:::
+
 To use the latest LocalStack Docker images, you either run `docker pull localstack/localstack:latest` or use the `docker-compose pull` if the image is set to `localstack/localstack:latest`.
 You can also specify a particular digest to make sure you are using the correct image, like this: `localstack/localstack:latest@sha256:f803cc657843c6c7acf2631d15600783c3593e496fba418415afc87680d9d5bc`.
 
@@ -68,27 +72,16 @@ The diagnose endpoint is only available if you run LocalStack with `DEBUG=1`.
 
 ### What do the tags of the LocalStack Docker images mean?
 
-We do push a set of different image tags for the LocalStack Docker images.
-When using LocalStack, you can decide which tag you want to use.
-These tags have different semantics and will be updated on different occasions:
+We publish a set of image tags with different semantics, updated on different occasions:
 
-- `latest` (default)
-  - This is our default tag.
-    It refers to the latest commit which has been fully tested using our extensive integration test suite.
-  - This also entails changes that are part of major releases, which means that this tag can contain breaking changes.
-  - This tag should be used if you want to stay up-to-date with the latest changes.
-- `stable`
-  - This tag refers to the latest tagged release.
-    It will be updated with every release of LocalStack.
-  - This also entails major releases, which means that this tag can contain breaking changes.
-  - This tag should be used if you want to stay up-to-date with releases, but don't necessarily need the latest and greatest changes right away.
-- `<YYYY.MM>` (e.g., `2026.03`)
-  - These tags can be used to refer to the latest release of a month. It will be updated with every patch release within this month.
-  - This tag can be used if you want to avoid any bigger changes, like new features, but still want to update to the latest bugfix release.
-- `<YYYY.MM.patch>` (e.g., `2026.03.0`)
-  - These tags can be used if you want to use a very specific release.
-    It will not be updated.
-  - This tag can be used if you really want to avoid any changes to the image (not even minimal bug fixes).
+- **`latest`**: Updated only on official tagged releases (e.g. `2026.05.0`). Equivalent to `stable`. Recommended for most users who want a stable, release-quality image. As of May 2026, this tag no longer tracks untagged commits on `main`, use `dev` for that behavior.
+- **`stable`**: Same as `latest`. Updated with every official release.
+- **`dev`**: Contains all merged, untagged commits from the `main` branch. Use this if you want the latest unreleased changes.
+- **`nightly`**: Pushed from scheduled nightly builds. Useful for CI pipelines that benefit from a fresh build on a predictable cadence.
+- **`YYYY.MM`** (e.g. `2026.05`): Updated with each patch release within that month. Use this to avoid feature changes while still receiving bugfixes.
+- **`YYYY.MM.patch`** (e.g. `2026.05.0`): Pinned to an exact release and never updated. Use this for fully reproducible environments where even minor bugfix changes are undesirable.
+
+Starting with the end-of-March 2026 release, LocalStack follows [calendar versioning](https://calver.org/) for official releases. For releases up to and including `v4.14.0`, tags follow Semantic Versioning.
 
 Starting with the end-of-March 2026 release, LocalStack follows [calendar versioning](https://calver.org/) for official releases.
 

--- a/src/content/docs/aws/getting-started/faq.mdx
+++ b/src/content/docs/aws/getting-started/faq.mdx
@@ -74,11 +74,11 @@ The diagnose endpoint is only available if you run LocalStack with `DEBUG=1`.
 
 We publish a set of image tags with different semantics, updated on different occasions:
 
-- **`latest`**: Updated only on official tagged releases (e.g. `2026.05.0`). Equivalent to `stable`. Recommended for most users who want a stable, release-quality image. As of May 2026, this tag no longer tracks untagged commits on `main`, use `dev` for that behavior.
+- **`latest`**: Updated only on official tagged releases  (e.g. `2026.05.0`, `2026.05.1`). Equivalent to `stable`. Recommended for most users who want a stable, release-quality image. As of May 2026, this tag no longer tracks untagged commits on `main`, use `dev` for that behavior.
 - **`stable`**: Same as `latest`. Updated with every official release.
 - **`dev`**: Contains all merged, untagged commits from the `main` branch. Use this if you want the latest unreleased changes.
 - **`nightly`**: Pushed from scheduled nightly builds. Useful for CI pipelines that benefit from a fresh build on a predictable cadence.
-- **`YYYY.MM`** (e.g. `2026.05`): Updated with each patch release within that month. Use this to avoid feature changes while still receiving bugfixes.
+- **`YYYY.MM`** (e.g. `2026.05`): Updated with each patch release within that month. Use this to get the latest security fixes and dependency updates.
 - **`YYYY.MM.patch`** (e.g. `2026.05.0`): Pinned to an exact release and never updated. Use this for fully reproducible environments where even minor bugfix changes are undesirable.
 
 Starting with the end-of-March 2026 release, LocalStack follows [calendar versioning](https://calver.org/) for official releases. For releases up to and including `v4.14.0`, tags follow Semantic Versioning.

--- a/src/content/docs/azure/getting-started/index.mdx
+++ b/src/content/docs/azure/getting-started/index.mdx
@@ -77,7 +77,15 @@ $ docker-compose up
 ### Updating
 
 To update the Azure Docker container, pull the latest image and restart the container.
-The `latest` tag is the nightly build of the Azure Docker image.
+
+The following tags are available for the LocalStack for Azure Docker image:
+
+| Tag | Updated when | Recommended for |
+|---|---|---|
+| `latest` / `stable` | Tagged releases only (e.g. `2026.05.0`) | Most users — stable, release-quality builds |
+| `dev` | Every merged commit on `main` | Users who need the latest unreleased changes |
+| `nightly` | Scheduled nightly builds | CI pipelines that need a fresh build on a regular cadence |
+| `YYYY.MM.patch` (e.g. `2026.05.0`) | Never (pinned) | Fully reproducible environments where no changes are acceptable |
 
 Starting with the end-of-March 2026 release, versioned Azure image tags follow
 [calendar versioning](https://calver.org/) in the `YYYY.MM.patch` format (for example, `2026.03.0`).

--- a/src/content/docs/azure/getting-started/index.mdx
+++ b/src/content/docs/azure/getting-started/index.mdx
@@ -82,10 +82,9 @@ The following tags are available for the LocalStack for Azure Docker image:
 
 | Tag | Updated when | Recommended for |
 |---|---|---|
-| `latest` / `stable` | Tagged releases only (e.g. `2026.05.0`) | Most users — stable, release-quality builds |
+| `latest` | Tagged releases only (e.g. `2026.05.0`) | Most users, stable, release-quality builds |
 | `dev` | Every merged commit on `main` | Users who need the latest unreleased changes |
 | `nightly` | Scheduled nightly builds | CI pipelines that need a fresh build on a regular cadence |
-| `YYYY.MM.patch` (e.g. `2026.05.0`) | Never (pinned) | Fully reproducible environments where no changes are acceptable |
 
 Starting with the end-of-March 2026 release, versioned Azure image tags follow
 [calendar versioning](https://calver.org/) in the `YYYY.MM.patch` format (for example, `2026.03.0`).

--- a/src/content/docs/snowflake/getting-started/index.mdx
+++ b/src/content/docs/snowflake/getting-started/index.mdx
@@ -158,7 +158,6 @@ If you want to pull a specific image tag manually, the following tags are availa
 |---|---|---|
 | `latest` / `stable` | Tagged releases only (e.g. `2026.05.0`) | Most users — stable, release-quality builds |
 | `dev` | Every merged commit on `main` | Users who need the latest unreleased changes |
-| `nightly` | Scheduled nightly builds | CI pipelines that need a fresh build on a regular cadence |
 | `YYYY.MM.patch` (e.g. `2026.05.0`) | Never (pinned) | Fully reproducible environments where no changes are acceptable |
 
 Starting with the end-of-March 2026 release, versioned Snowflake image tags follow [calendar versioning](https://calver.org/) in the `YYYY.MM.patch` format (for example, `2026.03.0`).

--- a/src/content/docs/snowflake/getting-started/index.mdx
+++ b/src/content/docs/snowflake/getting-started/index.mdx
@@ -143,23 +143,27 @@ Expected response:
 { "success": true }
 ```
 
+
 ## Updating LocalStack
 
 To keep both the CLI and emulator images up to date, run:
 
-```bash
+```shell
 localstack update all
 ```
 
-If you only want to update the Snowflake image manually (e.g. to pick up a recent fix), you can run:
+If you want to pull a specific image tag manually, the following tags are available for the LocalStack for Snowflake Docker image:
 
-```bash
-docker pull localstack/snowflake:latest
-```
+| Tag | Updated when | Recommended for |
+|---|---|---|
+| `latest` / `stable` | Tagged releases only (e.g. `2026.05.0`) | Most users — stable, release-quality builds |
+| `dev` | Every merged commit on `main` | Users who need the latest unreleased changes |
+| `nightly` | Scheduled nightly builds | CI pipelines that need a fresh build on a regular cadence |
+| `YYYY.MM.patch` (e.g. `2026.05.0`) | Never (pinned) | Fully reproducible environments where no changes are acceptable |
 
-Starting with the end-of-March 2026 release, versioned Snowflake image tags follow
-[calendar versioning](https://calver.org/) in the `YYYY.MM.patch` format (for example, `2026.03.0`).
+Starting with the end-of-March 2026 release, versioned Snowflake image tags follow [calendar versioning](https://calver.org/) in the `YYYY.MM.patch` format (for example, `2026.03.0`).
 Refer to the available [tags on Docker Hub](https://hub.docker.com/r/localstack/snowflake/tags) for the latest releases.
+
 
 ## Alternatives
 


### PR DESCRIPTION
Fixes https://linear.app/localstack/issue/DOC-238/document-docker-image-tags-and-their-meanings 