### PR TITLE
Update get started pricing link

### DIFF
--- a/src/components/LanguageSelectWithGetStarted.astro
+++ b/src/components/LanguageSelectWithGetStarted.astro
@@ -1,17 +1,13 @@
 ---
 import Default from '@astrojs/starlight/components/LanguageSelect.astro';
 
-// Get the current page route
 const route = Astro.locals.starlightRoute;
 const isSnowflakePage = route.id.startsWith('snowflake');
-const isAzurePage = route.id.startsWith('azure');
 
-let getStartedUrl = 'https://app.localstack.cloud/sign-up';
+let getStartedUrl = 'https://localstack.cloud/pricing';
 
 if (isSnowflakePage) {
-  getStartedUrl += '?emulator=snowflake';
-} else if (isAzurePage) {
-  getStartedUrl += '?emulator=azure';
+  getStartedUrl = 'https://www.localstack.cloud/pricing?tab=snowflake';
 }
 ---
 


### PR DESCRIPTION
## Summary
- Point the header Get Started for Free button to the pricing page.
- Keep Snowflake docs routed to the Snowflake pricing tab.

## Test plan
- ReadLints: no linter errors for src/components/LanguageSelectWithGetStarted.astro