### PR TITLE
DOC-257 add IAM condition keys

### DIFF
--- a/src/content/docs/aws/capabilities/security-testing/iam-coverage.md
+++ b/src/content/docs/aws/capabilities/security-testing/iam-coverage.md
@@ -147,6 +147,8 @@ It only includes operations performed with a principal, not as root, so test set
 |                | - StringLike                                                                         |
 |                | - ArnLike/ArnEquals                                                                  |
 |                | Supported condition keys:                                                            |
+|                | - aws:RequestedRegion                                                                |
+|                | - aws:PrincipalArn                                                                   |
 |                | - aws:SourceArn                                                                      |
 |                | Supported condition tags:                                                                  |
 |                | - aws:ResourceTag                                                                     |


### PR DESCRIPTION
## Summary
- Add `aws:RequestedRegion` and `aws:PrincipalArn` to the IAM coverage page's supported condition keys.

Fixes [DOC-257](https://linear.app/localstack/issue/DOC-257/doc-additional-condition-keys-for-iam-coverage-page)