### PR TITLE
Migrate image references to localstack/localstack-azure

### DIFF
--- a/src/content/docs/azure/getting-started/index.mdx
+++ b/src/content/docs/azure/getting-started/index.mdx
@@ -13,11 +13,11 @@ You can set up the Azure emulator by utilizing LocalStack for Azure Docker image
 Before starting, ensure you have a valid `LOCALSTACK_AUTH_TOKEN` to access the Azure emulator.
 Refer to the [Auth Token guide](/aws/getting-started/auth-token/) to obtain your Auth Token and specify it in the `LOCALSTACK_AUTH_TOKEN` environment variable.
 
-The Azure Docker image is available on the [LocalStack Docker Hub](https://hub.docker.com/r/localstack/localstack-azure-alpha).
+The Azure Docker image is available on the [LocalStack Docker Hub](https://hub.docker.com/r/localstack/localstack-azure).
 To pull the Azure Docker image, execute the following command:
 
 ```
-$ docker pull localstack/localstack-azure-alpha
+$ docker pull localstack/localstack-azure
 ```
 
 You can start the Azure emulator using the following methods:
@@ -32,7 +32,7 @@ To start the Azure emulator using the `localstack` CLI, execute the following co
 
 ```
 $ export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-$ IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+$ IMAGE_NAME=localstack/localstack-azure localstack start
 ```
 
 ### `docker` CLI
@@ -46,7 +46,7 @@ $ docker run \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ~/.localstack/volume:/var/lib/localstack \
     -e LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?} \
-    localstack/localstack-azure-alpha
+    localstack/localstack-azure
 ```
 
 ### Docker Compose
@@ -59,7 +59,7 @@ version: "3.8"
 services:
   localstack:
     container_name: "localstack-main"
-    image: localstack/localstack-azure-alpha
+    image: localstack/localstack-azure
     ports:
       - "127.0.0.1:4566:4566"
     environment:
@@ -88,4 +88,4 @@ The following tags are available for the LocalStack for Azure Docker image:
 
 Starting with the end-of-March 2026 release, versioned Azure image tags follow
 [calendar versioning](https://calver.org/) in the `YYYY.MM.patch` format (for example, `2026.03.0`).
-Refer to the available [tags on Docker Hub](https://hub.docker.com/r/localstack/localstack-azure-alpha/tags) for the latest releases.
+Refer to the available [tags on Docker Hub](https://hub.docker.com/r/localstack/localstack-azure/tags) for the latest releases.


### PR DESCRIPTION
## Motivation

The Azure emulator's Docker image has been renamed from
`localstack/localstack-azure-alpha` to **`localstack/localstack-azure`** (the
permanent name, chosen for brand/legal consistency with `localstack` /
`localstack-pro`). The producer change has merged in `localstack-pro` and the
new image is now published — see SMF-642.

This PR updates this repository's references to use the new image name.

## Changes

- Replace `localstack/localstack-azure-alpha` → `localstack/localstack-azure`
  in this repo (pull/run commands, CI `IMAGE_NAME`, Docker Hub links, and/or
  docs as applicable).

This is **non-breaking and can merge independently**: during a grace period the
old `localstack-azure-alpha` name is still published in parallel, and both names
resolve to the exact same image — so nothing breaks whether this lands before or
after other consumers migrate.

## Tests

- The new image is live on Docker Hub; `localstack/localstack-azure:latest` and
  `localstack/localstack-azure-alpha:latest` resolve to the identical multi-arch
  manifest digest (same `amd64` + `arm64` images), confirming the new name pulls
  the same artifact.
- Any CI in this repo that pulls/runs the image now uses the new name; the run
  on this PR exercises it.

## Related

- Rename tracking: **SMF-642** (related **SMF-246**, **SMF-586**).
- Producer PR (localstack-pro, merged): <link>
- Sibling consumer PRs migrating the same name: `localstack-azure-samples`,
  `azure-docs`, `localstack-azure-mcp-server`, `azcli-local`.

<!--
## Release notes
-->
<!-- docs:needed only for azure-docs — users should now pull localstack/localstack-azure. -->
