### PR TITLE
Fixed missing variable in Windows link

### DIFF
--- a/src/content/docs/aws/getting-started/installation.mdx
+++ b/src/content/docs/aws/getting-started/installation.mdx
@@ -121,7 +121,7 @@ Then extract the LocalStack CLI from the terminal:
 You can download the pre-built binary for your architecture using the link below:
 
 <LinkButton
-  href={`https://github.com/localstack/localstack-cli/releases/download/v2026.3.0/localstack-cli-2026.3.0-windows-amd64-onefile.zip`}
+  href={`https://github.com/localstack/localstack-cli/releases/download/v${LOCALSTACK_AWS_VERSION}/localstack-cli-${LOCALSTACK_AWS_VERSION}-windows-amd64-onefile.zip`}
   icon="download"
   variant="minimal"
 >


### PR DESCRIPTION
This addresses the final issue in [DOC 231](https://linear.app/localstack/issue/DOC-231/outdated-localstack-cli-binaries-download-link)