### PR TITLE
Mention the lstk CLI in the localstack CLI docs

### DIFF
--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -212,7 +212,7 @@ def generate_documentation(
         "To install the LocalStack CLI, follow the [installation guide](/aws/getting-started/installation/#installing-localstack-cli).",
         "",
         ":::note",
-        "[`lstk`](/aws/tooling/lstk/) is our new Go-based CLI with an interactive terminal UI for lifecycle (`start`, `stop`), monitoring (`status`, `logs`), storage (`snapshot`), and more.",
+        "[`lstk`](/aws/developer-tools/running-localstack/lstk/) is our new Go-based CLI with an interactive terminal UI for lifecycle (`start`, `stop`), monitoring (`status`, `logs`), storage (`snapshot`), and more.",
         ":::",
         "",
         "## Global Options",

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -187,9 +187,8 @@ def generate_command_section(cmd: Command) -> list[str]:
 
 
 def generate_documentation(
-    regular_commands: list[Command], 
+    regular_commands: list[Command],
     advanced_commands: list[Command],
-    version: str
 ) -> str:
     """Generate the complete markdown documentation."""
     doc_lines = []
@@ -213,7 +212,7 @@ def generate_documentation(
         "To install the LocalStack CLI, follow the [installation guide](/aws/getting-started/installation/#installing-localstack-cli).",
         "",
         ":::note",
-        f"This documentation was auto-generated from LocalStack CLI version `{version}`.",
+        "[`lstk`](/aws/tooling/lstk/) is our new Go-based CLI with an interactive terminal UI for lifecycle (`start`, `stop`), monitoring (`status`, `logs`), storage (`snapshot`), and more.",
         ":::",
         "",
         "## Global Options",
@@ -282,10 +281,6 @@ def main() -> None:
     total = len(regular_commands) + len(advanced_commands)
     print(f"Found {len(regular_commands)} commands and {len(advanced_commands)} advanced commands", file=sys.stderr)
     
-    # Get version
-    version_output = run_command(["localstack", "--version"])
-    version = version_output.strip() if version_output else "latest"
-    
     # Populate details for each command (including subcommands)
     all_commands = regular_commands + advanced_commands
     for i, cmd in enumerate(all_commands):
@@ -293,7 +288,7 @@ def main() -> None:
         populate_command_details(cmd)
     
     print("Generating documentation...", file=sys.stderr)
-    documentation = generate_documentation(regular_commands, advanced_commands, version)
+    documentation = generate_documentation(regular_commands, advanced_commands)
     
     if args.dry_run:
         print(documentation)

--- a/src/content/docs/aws/developer-tools/running-localstack/localstack-cli.md
+++ b/src/content/docs/aws/developer-tools/running-localstack/localstack-cli.md
@@ -15,7 +15,7 @@ It provides convenience features to interact with LocalStack features like Cloud
 To install the LocalStack CLI, follow the [installation guide](/aws/getting-started/installation/#installing-localstack-cli).
 
 :::note
-This documentation was auto-generated from LocalStack CLI version `LocalStack CLI 2026.5.3`.
+[`lstk`](/aws/tooling/lstk/) is our new Go-based CLI with an interactive terminal UI for lifecycle (`start`, `stop`), monitoring (`status`, `logs`), storage (`snapshot`), and more.
 :::
 
 ## Global Options

--- a/src/content/docs/aws/developer-tools/running-localstack/localstack-cli.md
+++ b/src/content/docs/aws/developer-tools/running-localstack/localstack-cli.md
@@ -15,7 +15,7 @@ It provides convenience features to interact with LocalStack features like Cloud
 To install the LocalStack CLI, follow the [installation guide](/aws/getting-started/installation/#installing-localstack-cli).
 
 :::note
-[`lstk`](/aws/tooling/lstk/) is our new Go-based CLI with an interactive terminal UI for lifecycle (`start`, `stop`), monitoring (`status`, `logs`), storage (`snapshot`), and more.
+[`lstk`](/aws/developer-tools/running-localstack/lstk/) is our new Go-based CLI with an interactive terminal UI for lifecycle (`start`, `stop`), monitoring (`status`, `logs`), storage (`snapshot`), and more.
 :::
 
 ## Global Options

--- a/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
+++ b/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
@@ -455,14 +455,6 @@ Restart your shell after persisting completions.
 
 ## FAQ
 
-### What is the difference between `lstk` and the `localstack` CLI?
-
-Both tools can start, stop, and manage the LocalStack emulator, and both work with Cloud Pods — `lstk` via its `snapshot` command and the [`localstack` CLI](/aws/developer-tools/running-localstack/localstack-cli/) via its `pod` command.
-`lstk` is a newer CLI built in Go with a TUI; the `localstack` CLI is the established Python-based tool that additionally supports Extensions, Ephemeral Instances, and other advanced features `lstk` doesn't cover yet.
-
-Both can be installed side by side.
-Use `lstk` for fast daily workflows and the `localstack` CLI when you need its additional platform features.
-
 ### Can I use `lstk` with Docker Compose?
 
 No. `lstk` manages its own Docker container directly.

--- a/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
+++ b/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
@@ -24,7 +24,7 @@ Running `lstk` with no arguments takes you through the entire flow automatically
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) installed and running.
-- A [LocalStack account](https://app.localstack.cloud/sign-up) with a valid [Auth Token](/aws/getting-started/auth-token/).
+- A [LocalStack account](https://app.localstack.cloud/sign-up) with a [license](/aws/getting-started/auth-token/#managing-your-license), and `lstk` handles authentication for you (see [Authentication](#authentication)).
 
 ## Installation
 
@@ -77,14 +77,16 @@ lstk update
 lstk
 ```
 
-Running `lstk` without arguments performs the full startup sequence: resolves your auth token by opening the LocalStack Web Application, pulls the latest image if needed, and starts the LocalStack container.
+Running `lstk` without arguments performs the full startup sequence: authenticates you automatically, pulls the latest image if needed, and starts the LocalStack container.
 In an interactive terminal it launches the TUI; in a non-interactive environment it prints plain text output.
 
-For CI or headless environments, set `LOCALSTACK_AUTH_TOKEN` and use `--non-interactive`:
+For CI or headless environments, set a [CI Auth Token](/aws/getting-started/auth-token/#ci-environments) via `LOCALSTACK_AUTH_TOKEN` and use `--non-interactive`:
 
 ```bash
-LOCALSTACK_AUTH_TOKEN=<your-token> lstk --non-interactive
+LOCALSTACK_AUTH_TOKEN=<your-ci-auth-token> lstk --non-interactive
 ```
+
+CI environments require a CI Auth Token; a personal Developer Auth Token cannot be used there.
 
 ## Authentication
 
@@ -162,7 +164,7 @@ The default `config.toml` created on first run:
 
 ```toml
 [[containers]]
-type = "aws"     # Emulator type. Currently supported: "aws"
+type = "aws"     # Emulator type. Currently supported: "aws", "snowflake", "azure"
 tag  = "latest"  # Docker image tag, e.g. "latest", "2026.03"
 port = "4566"    # Host port the emulator will be accessible on
 # volume = ""    # Host directory for persistent state (default: OS cache dir)
@@ -173,7 +175,7 @@ port = "4566"    # Host port the emulator will be accessible on
 
 | Field    | Type     | Default    | Description                                                                                        |
 | :------- | :------- | :--------- | :------------------------------------------------------------------------------------------------- |
-| `type`   | string   | `"aws"`    | Emulator type. Only `"aws"` is supported.                                                          |
+| `type`   | string   | `"aws"`    | Emulator type. One of `"aws"`, `"snowflake"`, `"azure"`.                                                          |
 | `tag`    | string   | `"latest"` | Docker image tag (`"latest"`, `"2026.03"`, etc.). Useful for pinning a specific version.           |
 | `port`   | string   | `"4566"`   | Host port the emulator listens on.                                                                 |
 | `volume` | string   | (OS cache) | Host directory for persistent emulator state. Defaults to the OS cache directory if not specified. |
@@ -215,15 +217,27 @@ In addition to your custom profiles, `lstk` always injects the following into th
 | :---------------------- | :------------------------------------- |
 | `LOCALSTACK_AUTH_TOKEN` | Your resolved auth token               |
 | `GATEWAY_LISTEN`        | `:4566,:443`                           |
-| `MAIN_CONTAINER_NAME`   | Container name (e.g. `localstack-aws`) |
+| `MAIN_CONTAINER_NAME`   | Container name (`localstack-aws`), derived automatically; not configurable |
 
 ### Using a project-local config
 
 Place a `.lstk/config.toml` in your project directory.
 When you run `lstk` from that directory, the local config takes precedence over the global one.
-This is useful for pinning a specific image tag or environment profile per-project:
+This lets each project pin its own emulator type, image tag, and environment profiles.
+
+For example, a project that targets the Snowflake emulator can keep its own config:
 
 ```toml
+# .lstk/config.toml
+[[containers]]
+type = "snowflake"
+port = "4566"
+```
+
+An AWS project might instead pin a specific image tag and enable a debug profile:
+
+```toml
+# .lstk/config.toml
 [[containers]]
 type = "aws"
 tag  = "2026.03"
@@ -467,7 +481,7 @@ For Docker Compose configuration, see the [Docker Compose installation guide](/a
 
 No. LocalStack uses a single Docker image: `localstack/localstack`.
 There is no separate "community" or "pro" image.
-All plans (including the free Hobby tier) use the same image and require an auth token.
+All plans (including the free Hobby tier) use the same image and require a license.
 
 ### How do I pass configuration options like `DEBUG` or `PERSISTENCE` to the container?
 
@@ -565,7 +579,7 @@ No credentials were found in the environment.
 ### Image pull failed
 
 If `lstk` cannot pull the Docker image, check your network connection and Docker configuration.
-On corporate networks, you may need to configure Docker's proxy settings.
+On corporate networks, you may need to configure Docker's proxy settings, see [How do I configure LocalStack to use my corporate HTTP and HTTPS proxy?](/aws/getting-started/faq/#how-do-i-configure-localstack-to-use-my-corporate-http-and-https-proxy).
 
 ### Unknown environment profile
 
@@ -588,4 +602,4 @@ DEBUG = "1"
 
 ### Getting help
 
-If the steps above don't resolve your issue, [contact us](https://localstack.cloud/contact/) or open an issue on the [lstk GitHub repository](https://github.com/localstack/lstk/issues).
+If the steps above don't resolve your issue, see [Get Help](/aws/help-support/get-help/) for the available support channels, including the support email and in-app chat.

--- a/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
+++ b/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
@@ -457,7 +457,7 @@ Restart your shell after persisting completions.
 
 ### What is the difference between `lstk` and the `localstack` CLI?
 
-Both tools can start, stop, and manage the LocalStack emulator, and both work with Cloud Pods — `lstk` via its `snapshot` command and the [`localstack` CLI](/aws/tooling/localstack-cli/) via its `pod` command.
+Both tools can start, stop, and manage the LocalStack emulator, and both work with Cloud Pods — `lstk` via its `snapshot` command and the [`localstack` CLI](/aws/developer-tools/running-localstack/localstack-cli/) via its `pod` command.
 `lstk` is a newer CLI built in Go with a TUI; the `localstack` CLI is the established Python-based tool that additionally supports Extensions, Ephemeral Instances, and other advanced features `lstk` doesn't cover yet.
 
 Both can be installed side by side.

--- a/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
+++ b/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
@@ -18,8 +18,7 @@ It provides a built-in terminal UI (TUI) for interactive use and plain text outp
 Running `lstk` with no arguments takes you through the entire flow automatically.
 
 :::note
-`lstk` is in early release and does not yet support advanced features like **Cloud Pods**, **Extensions**, and **Ephemeral Instances**. For these features, use the [LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/).
-Both tools can be installed and used on the same machine.
+`lstk` covers the everyday emulator workflow: lifecycle (`start`, `stop`), monitoring (`status`, `logs`), storage (`snapshot`), and more.
 :::
 
 ## Prerequisites
@@ -458,11 +457,11 @@ Restart your shell after persisting completions.
 
 ### What is the difference between `lstk` and the `localstack` CLI?
 
-Both tools can start, stop, and manage the LocalStack emulator.
-`lstk` is a newer CLI built in Go with a TUI, while the `localstack` CLI is the established Python-based tool with support for Cloud Pods, Extensions, Ephemeral Instances, and other advanced features.
+Both tools can start, stop, and manage the LocalStack emulator, and both work with Cloud Pods — `lstk` via its `snapshot` command and the [`localstack` CLI](/aws/tooling/localstack-cli/) via its `pod` command.
+`lstk` is a newer CLI built in Go with a TUI; the `localstack` CLI is the established Python-based tool that additionally supports Extensions, Ephemeral Instances, and other advanced features `lstk` doesn't cover yet.
 
 Both can be installed side by side.
-Use `lstk` for fast daily start/stop workflows and `localstack` for advanced platform features.
+Use `lstk` for fast daily workflows and the `localstack` CLI when you need its additional platform features.
 
 ### Can I use `lstk` with Docker Compose?
 


### PR DESCRIPTION
## Summary

Adds a short note to the top of the LocalStack CLI reference pointing readers to [`lstk`](/aws/developer-tools/running-localstack/lstk/), our new Go-based CLI, and updates the `lstk` page itself — keeping its positioning `lstk`-only and addressing the review feedback left on it.

It also replaces the auto-generated *"This documentation was auto-generated from LocalStack CLI version* `…`*"* note, which wasn't useful and was reliably **out of date**. That version is captured only when the monthly `update-cli-docs` workflow runs (the 15th), so it always trails the actual release — the page read `2026.4.0` while `2026.5.x` had been on PyPI for weeks (`2026.5.0` shipped 5 days after the last regeneration). A stamp that's accurate for ~1 day a month is worse than none.

## Changes

The LocalStack CLI page is auto-generated by `scripts/generate_cli_docs.py`, so that change is made in the generator and mirrored into the current output:

* `scripts/generate_cli_docs.py` — replace the version provenance `:::note` with a pointer to `lstk`; remove the now-dead version plumbing (the `localstack --version` call + unused parameter).
* `localstack-cli.md` — the regenerated note.
* `lstk.mdx` — update the top note to reflect that `lstk` covers lifecycle, monitoring, and storage (`snapshot`), and remove the "difference between `lstk` and the `localstack` CLI" FAQ so the page stays focused on `lstk` (the `localstack` CLI is being deprecated).

Rendered notes:

> **LocalStack CLI page:** [`lstk`](/aws/developer-tools/running-localstack/lstk/) is our new Go-based CLI with an interactive terminal UI for lifecycle (`start`, `stop`), monitoring (`status`, `logs`), storage (`snapshot`), and more.

> **lstk page:** `lstk` covers the everyday emulator workflow: lifecycle (`start`, `stop`), monitoring (`status`, `logs`), storage (`snapshot`), and more.

## Follow-up

Documenting the `lstk` `snapshot` command in detail and the `terraform`/`az`/`setup` proxy commands is tracked separately and will land in its own PR.

Fix [PRO-312](https://linear.app/localstack/issue/PRO-312/mention-lstk-cli-in-localstack-cli-docs)
