### PR TITLE
Document drop of PostgreSQL 11 and 12 in RDS

### DIFF
--- a/src/content/docs/aws/services/rds.mdx
+++ b/src/content/docs/aws/services/rds.mdx
@@ -173,12 +173,18 @@ For instance, the `storage-encrypted` flag is returned as configured, but active
 ### PostgreSQL Engine
 
 When you establish an RDS DB cluster or instance using the `postgres`/`aurora-postgresql` DB engine along with a specified `EngineVersion`, LocalStack will dynamically install and configure the corresponding PostgreSQL version as required.
-Presently, you have the option to choose major versions ranging from 11 to 17.
+Presently, you have the option to choose major versions ranging from 13 to 17.
 If you select a major version beyond this range, the system will automatically default to version 17.
 
 It's important to note that the selection of minor versions is not available.
 The latest major version will be installed within the Docker environment.
 If you wish to prevent the installation of customized versions, adjusting the `RDS_PG_CUSTOM_VERSIONS` environment variable to `0` will enforce the use of the default PostgreSQL version 17.
+
+:::note
+PostgreSQL 11 and 12 are no longer available in LocalStack following the move to a Debian `sid` base image.
+Both versions remain in [Amazon RDS Extended Support](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html), but LocalStack no longer ships them.
+If you require one of these older versions, use a LocalStack image released before v2026.05.0.
+:::
 
 :::note
 While the [`DescribeDbCluster`](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBClusters.html) and [`DescribeDbInstances`](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html) APIs will still reflect the initially defined `engine-version`, the actual installed PostgreSQL engine might differ.


### PR DESCRIPTION
Fixes [DOC-244](https://linear.app/localstack/issue/DOC-244/document-drop-of-postgresql-12-in-rds)