### PR TITLE
Update to push K8s operator instead of Helm charts on installation page

### DIFF
--- a/src/content/docs/aws/developer-tools/security-testing/custom-tls-certificates.mdx
+++ b/src/content/docs/aws/developer-tools/security-testing/custom-tls-certificates.mdx
@@ -30,7 +30,7 @@ They all can be summarised as:
 
 ## Creating a custom docker image
 
-If you run LocalStack in a docker container (which includes using [the CLI](/aws/getting-started/installation/#installing-localstack-cli), [docker](/aws/getting-started/installation/#docker), [docker-compose](/aws/getting-started/installation/#docker-compose), or [helm](/aws/getting-started/installation/#helm)), to include a custom TLS root certificate a new docker image should be created.
+If you run LocalStack in a docker container (which includes using [the CLI](/aws/getting-started/installation/#installing-localstack-cli), [docker](/aws/getting-started/installation/#docker), [docker-compose](/aws/getting-started/installation/#docker-compose), or [helm](/aws/enterprise/kubernetes/deploy-helm-chart)), to include a custom TLS root certificate a new docker image should be created.
 
 Create a `Dockerfile` containing the following commands:
 

--- a/src/content/docs/aws/getting-started/installation.mdx
+++ b/src/content/docs/aws/getting-started/installation.mdx
@@ -258,7 +258,7 @@ Besides using the CLI, there are other ways of starting and managing your LocalS
   Use the Docker CLI to manually start the LocalStack Docker container.
 
 - [LocalStack Operator](#localStack-operator)\
-  Use the LocalStack Operator to to deploy and manage LocalStack instances in a Kubernetes cluster.
+  Use the LocalStack Operator to to deploy and manage LocalStack instances inside a Kubernetes cluster.
 
 LocalStack runs inside a Docker container, and the above options are different ways to start and manage the LocalStack Docker container.
 

--- a/src/content/docs/aws/getting-started/installation.mdx
+++ b/src/content/docs/aws/getting-started/installation.mdx
@@ -257,7 +257,7 @@ Besides using the CLI, there are other ways of starting and managing your LocalS
 - [Docker](#docker)\
   Use the Docker CLI to manually start the LocalStack Docker container.
 
-- [LocalStack Operator](#localStack-operator)\
+- [LocalStack Operator](#localstack-operator)\
   Use the LocalStack Operator to deploy and manage LocalStack instances inside a Kubernetes cluster.
 
 LocalStack runs inside a Docker container, and the above options are different ways to start and manage the LocalStack Docker container.
@@ -397,7 +397,7 @@ docker run \
 
 ### LocalStack Operator
 
-If you want to deploy LocalStack in your [Kubernetes](https://kubernetes.io) cluster, you can use the [LocalStack Operator](../enterprise/kubernetes/kubernetes-operator.mdx).
+If you want to deploy LocalStack in your [Kubernetes](https://kubernetes.io) cluster, you can use the [LocalStack Operator](/aws/enterprise/kubernetes/kubernetes-operator).
 
 ## What's next?
 

--- a/src/content/docs/aws/getting-started/installation.mdx
+++ b/src/content/docs/aws/getting-started/installation.mdx
@@ -257,8 +257,8 @@ Besides using the CLI, there are other ways of starting and managing your LocalS
 - [Docker](#docker)\
   Use the Docker CLI to manually start the LocalStack Docker container.
 
-- [Helm](#helm)\
-  Use Helm to create a LocalStack deployment in a Kubernetes cluster.
+- [LocalStack Operator](#localStack-operator)\
+  Use the LocalStack Operator to to deploy and manage LocalStack instances in a Kubernetes cluster.
 
 LocalStack runs inside a Docker container, and the above options are different ways to start and manage the LocalStack Docker container.
 
@@ -395,25 +395,9 @@ docker run \
 - To configure an Auth Token, refer to the [Auth Token](/aws/getting-started/auth-token) documentation.
   :::
 
-### Helm
+### LocalStack Operator
 
-If you want to deploy LocalStack in your [Kubernetes](https://kubernetes.io) cluster, you can use [Helm](https://helm.sh).
-
-#### Prerequisites
-
-- [Kubernetes](https://kubernetes.io)
-- [Helm](https://helm.sh/docs/intro/install/)
-
-#### Deploy LocalStack using Helm
-
-You can deploy LocalStack in a Kubernetes cluster by running these commands:
-
-```bash
-helm repo add localstack-repo https://helm.localstack.cloud
-helm upgrade --install localstack localstack-repo/localstack
-```
-
-The Helm charts are not maintained in the main repository, but in a [separate one](https://github.com/localstack/helm-charts).
+If you want to deploy LocalStack in your [Kubernetes](https://kubernetes.io) cluster, you can use the [LocalStack Operator](../enterprise/kubernetes/kubernetes-operator.mdx).
 
 ## What's next?
 

--- a/src/content/docs/aws/getting-started/installation.mdx
+++ b/src/content/docs/aws/getting-started/installation.mdx
@@ -258,7 +258,7 @@ Besides using the CLI, there are other ways of starting and managing your LocalS
   Use the Docker CLI to manually start the LocalStack Docker container.
 
 - [LocalStack Operator](#localStack-operator)\
-  Use the LocalStack Operator to to deploy and manage LocalStack instances inside a Kubernetes cluster.
+  Use the LocalStack Operator to deploy and manage LocalStack instances inside a Kubernetes cluster.
 
 LocalStack runs inside a Docker container, and the above options are different ways to start and manage the LocalStack Docker container.
 


### PR DESCRIPTION
We want to push users in the direction of using the LocalStack Operator over the Helm charts for running LocalStack on Kubernetes and highlight them more in the setup documentation over the Helm setup.
This PR adds the LocalStack Operator setup in the installation docs over the Helm charts.

Fixes: [DPX-565](https://linear.app/localstack/issue/DPX-565/update-ls-docs-to-push-operator)