### PR TITLE
DOCS: remove nightly tags mentions for AWS, Azure and Snowflake

### DIFF
--- a/src/content/docs/aws/capabilities/config/docker-images.md
+++ b/src/content/docs/aws/capabilities/config/docker-images.md
@@ -37,12 +37,14 @@ The following tags are available for the LocalStack Docker image:
 |---|---|---|
 | `latest` / `stable` | Tagged releases only (e.g. `2026.05.0`) | Most users — stable, release-quality builds |
 | `dev` | Every merged commit on `main` | Users who need the latest unreleased changes |
-| `nightly` | Scheduled nightly builds | CI pipelines that need a fresh build on a regular cadence |
 | `YYYY.MM` (e.g. `2026.05`) | Each patch release within that month | Users who want bugfixes but want to avoid feature changes |
 | `YYYY.MM.patch` (e.g. `2026.05.0`) | Never (pinned) | Fully reproducible environments where no changes are acceptable |
 
 :::note
 As of May 2026, `latest` was changed to mirror `stable` and is only updated on official tagged releases. If you previously relied on `latest` for the most recent unreleased changes, switch to the `dev` tag.
+
+The `nightly` tag is no longer published for LocalStack for AWS. Use the `dev` tag to track untagged changes from `main`.
+
 :::
 
 Visit the [LocalStack for AWS tag](https://hub.docker.com/r/localstack/localstack-pro/tags?page=1&ordering=last_updated) page on Docker Hub.

--- a/src/content/docs/aws/getting-started/faq.mdx
+++ b/src/content/docs/aws/getting-started/faq.mdx
@@ -79,7 +79,6 @@ We publish a set of image tags with different semantics, updated on different oc
 - **`latest`**: Updated only on official tagged releases  (e.g. `2026.05.0`, `2026.05.1`). Equivalent to `stable`. Recommended for most users who want a stable, release-quality image. As of May 2026, this tag no longer tracks untagged commits on `main`, use `dev` for that behavior.
 - **`stable`**: Same as `latest`. Updated with every official release.
 - **`dev`**: Contains all merged, untagged commits from the `main` branch. Use this if you want the latest unreleased changes.
-- **`nightly`**: Pushed from scheduled nightly builds. Useful for CI pipelines that benefit from a fresh build on a predictable cadence.
 - **`YYYY.MM`** (e.g. `2026.05`): Updated with each patch release within that month. Use this to get the latest security fixes and dependency updates.
 - **`YYYY.MM.patch`** (e.g. `2026.05.0`): Pinned to an exact release and never updated. Use this for fully reproducible environments where even minor bugfix changes are undesirable.
 

--- a/src/content/docs/azure/getting-started/index.mdx
+++ b/src/content/docs/azure/getting-started/index.mdx
@@ -84,7 +84,6 @@ The following tags are available for the LocalStack for Azure Docker image:
 |---|---|---|
 | `latest` | Tagged releases only (e.g. `2026.05.0`) | Most users, stable, release-quality builds |
 | `dev` | Every merged commit on `main` | Users who need the latest unreleased changes |
-| `nightly` | Scheduled nightly builds | CI pipelines that need a fresh build on a regular cadence |
 
 Starting with the end-of-March 2026 release, versioned Azure image tags follow
 [calendar versioning](https://calver.org/) in the `YYYY.MM.patch` format (for example, `2026.03.0`).


### PR DESCRIPTION
fixes: https://linear.app/localstack/issue/DOC-289/doc-ci-docker-helper-clean-ups 