### PR TITLE
DOCS: update k8 supported versions in EKS

### DIFF
--- a/src/content/docs/aws/services/eks.mdx
+++ b/src/content/docs/aws/services/eks.mdx
@@ -862,17 +862,18 @@ spec:
 
 LocalStack uses [k3s](https://github.com/k3s-io/k3s) under the hood for creating EKS clusters.
 Below is the list of supported Kubernetes versions and their corresponding k3s versions.
+
 The default version is `1.35`.
 
 | Kubernetes Version   | k3s Version   | EKS Platform Version   |
 |----------------------|---------------|------------------------|
 | 1.36                 | v1.36.1-k3s1  | eks.3                  |
-| 1.35                 | v1.35.3-k3s1  | eks.9                  |
-| 1.34                 | v1.34.6-k3s1  | eks.19                 |
-| 1.33                 | v1.33.10-k3s1 | eks.33                 |
-| 1.32                 | v1.32.13-k3s1 | eks.40                 |
-| 1.31                 | v1.31.14-k3s1 | eks.56                 |
-| 1.30                 | v1.30.14-k3s2 | eks.64                 |
+| 1.35                 | v1.35.5-k3s1  | eks.13                 |
+| 1.34                 | v1.34.8-k3s1  | eks.23                 |
+| 1.33                 | v1.33.12-k3s1 | eks.37                 |
+| 1.32                 | v1.32.13-k3s1 | eks.44                 |
+| 1.31                 | v1.31.14-k3s1 | eks.60                 |
+| 1.30                 | v1.30.14-k3s2 | eks.68                 |
 
 Users can specify the desired version when creating an EKS cluster in LocalStack using the `EKS_K3S_IMAGE_TAG` configuration variable when starting LocalStack.
 

--- a/src/content/docs/aws/services/eks.mdx
+++ b/src/content/docs/aws/services/eks.mdx
@@ -866,6 +866,7 @@ The default version is `1.35`.
 
 | Kubernetes Version   | k3s Version   | EKS Platform Version   |
 |----------------------|---------------|------------------------|
+| 1.36                 | v1.36.1-k3s1  | eks.3                  |
 | 1.35                 | v1.35.3-k3s1  | eks.9                  |
 | 1.34                 | v1.34.6-k3s1  | eks.19                 |
 | 1.33                 | v1.33.10-k3s1 | eks.33                 |


### PR DESCRIPTION
fixes: https://linear.app/localstack/issue/DOC-278/doc-update-eks-static-data 