### PR TITLE
DOC-287: Drop Flink 1.13 runtime

### DIFF
--- a/src/content/docs/aws/services/kinesisanalyticsv2.mdx
+++ b/src/content/docs/aws/services/kinesisanalyticsv2.mdx
@@ -259,7 +259,6 @@ awslocal kinesisanalyticsv2 untag-resource \
 | 1.19.1 | yes | yes |
 | 1.18.1 | yes | yes |
 | 1.15.2 | yes | no |
-| 1.13.1 | yes | no |
 
 ## Limitations
 


### PR DESCRIPTION
docs(managed-flink): remove Flink 1.13 from supported versions

Flink 1.13 is no longer supported by AWS.

This PR closes [DOC-287](https://linear.app/localstack/issue/DOC-287/doc-featflink-drop-flink-113-runtime)