### PR TITLE
fix(gitignore): add .idea IDE directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pnpm-debug.log*
 .DS_Store
 .kiro
 .vscode
+.idea
 
 # Python
 .venv/


### PR DESCRIPTION
`.idea/` is the per-developer settings directory created by JetBrains IDEs (WebStorm, IntelliJ, PyCharm, etc.). It holds machine and user-specific state - local run configurations, workspace layout, module paths, indexing caches, and editor preferences - none of which is part of the project's source or build.