### PR TITLE
docs(lambda): correct ESM behaviour coverage (ScalingConfig, ProvisionedPollerConfig, FunctionResponseTypes)

### DIFF
--- a/src/content/docs/aws/services/lambda.mdx
+++ b/src/content/docs/aws/services/lambda.mdx
@@ -290,8 +290,8 @@ import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '@
       <TableCell className="text-center">🟢</TableCell>
       <TableCell className="text-center">🟢</TableCell>
       <TableCell className="text-center">🟢</TableCell>
-      <TableCell className="text-center">➖</TableCell>
-      <TableCell className="text-center">➖</TableCell>
+      <TableCell className="text-center">🟠</TableCell>
+      <TableCell className="text-center">🟠</TableCell>
     </TableRow>
     <TableRow>
       <TableCell className="font-medium">BisectBatchOnFunctionError</TableCell>
@@ -305,9 +305,9 @@ import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '@
     </TableRow>
     <TableRow>
       <TableCell className="font-medium">ScalingConfig</TableCell>
-      <TableCell>The scaling configuration for the event source.</TableCell>
-      <TableCell className="text-center">🟠</TableCell>
-      <TableCell className="text-center">🟠</TableCell>
+      <TableCell>The scaling configuration for the event source. [^3]</TableCell>
+      <TableCell className="text-center">🟡</TableCell>
+      <TableCell className="text-center">🟡</TableCell>
       <TableCell className="text-center">➖</TableCell>
       <TableCell className="text-center">➖</TableCell>
       <TableCell className="text-center">➖</TableCell>
@@ -375,9 +375,9 @@ import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '@
     </TableRow>
     <TableRow>
       <TableCell className="font-medium">ProvisionedPollerConfig</TableCell>
-      <TableCell>Control throughput via min-max limits.</TableCell>
-      <TableCell className="text-center">➖</TableCell>
-      <TableCell className="text-center">➖</TableCell>
+      <TableCell>Control throughput via min-max limits. [^4]</TableCell>
+      <TableCell className="text-center">🟡</TableCell>
+      <TableCell className="text-center">🟡</TableCell>
       <TableCell className="text-center">➖</TableCell>
       <TableCell className="text-center">➖</TableCell>
       <TableCell className="text-center">🟠</TableCell>
@@ -428,6 +428,8 @@ import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '@
 
 [^1]: Read more at [Control which events Lambda sends to your function](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html)
 [^2]: The available Metadata properties may not have full parity with AWS depending on the event source (read more at [Understanding event filtering basics](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html#filtering-basics)).
+[^3]: For SQS Standard, `ScalingConfig` is accepted but not automatically applied — the poller count is currently hard-coded rather than scaled based on `MaximumConcurrency`. For SQS FIFO, a single poller is always used to preserve message-group ordering, so the scaling configuration is accepted but has no effect.
+[^4]: For SQS Standard, only `MinimumPollers` is honored (it sets the poller count); `MaximumPollers` has no effect. For SQS FIFO, the single-poller model means the configuration is accepted but ignored.
 
 Create a [GitHub Discussion](https://github.com/orgs/localstack/discussions/new/choose) or reach out to [LocalStack Support](/aws/help-support/get-help/) if you experience any challenges.
 


### PR DESCRIPTION
## Motivation

The Lambda ESM behavior coverage docs became outdated after AWS released new features (e.g., FunctionResponseTypes support for MSK/Kafka), and @nik-localstack shipped provisioned poller support for SQS

## Summary

Corrects the Lambda **Event Source Mapping Behaviour Coverage** table (`aws/services/lambda` → Behaviour Coverage) based on a review of LocalStack's actual ESM implementation.

| Parameter | Source | Was | Now | Reason |
|---|---|---|---|---|
| ScalingConfig | SQS Standard | 🟠 | 🟡 | Config accepted, but poller count is hard-coded — not auto-scaled from `MaximumConcurrency` |
| ScalingConfig | SQS FIFO | 🟠 | 🟡 | Single poller always used to preserve message-group ordering; config accepted but ignored |
| ProvisionedPollerConfig | SQS Standard | ➖ | 🟡 | `MinimumPollers` honored; `MaximumPollers` has no effect |
| ProvisionedPollerConfig | SQS FIFO | ➖ | 🟡 | Single-poller model ignores the config |
| FunctionResponseTypes | Amazon MSK | ➖ | 🟠 | AWS supports `ReportBatchItemFailures` for Kafka; not yet implemented in LocalStack |
| FunctionResponseTypes | Self-Managed | ➖ | 🟠 | Same as above |

Adds footnotes `[^3]`/`[^4]` explaining the partial SQS behaviour.

## Notes / open questions

- **ProvisionedPollerConfig for SQS (`➖ → 🟡`)**: framed as LocalStack *behavioural* coverage (the code partially honors `MinimumPollers`). If reviewers prefer strict AWS-parity framing (ProvisionedPollerConfig as Kafka-only, hence `➖` for SQS), this can be reverted.
- **ProvisionedPollerConfig for Kafka** intentionally left `🟠` (not `➖`): AWS supports it there, LocalStack doesn't implement it.
- Deliberately **not** touched: `Batch ≥ 6 MB` (mini-batching isn't a true by-size implementation) and `MaximumRecordAgeInSeconds` (fix landing soon).

## Preview

https://d13ec91a.localstack-docs.pages.dev/aws/services/lambda/#behaviour-coverage
<img width="686" height="722" alt="Screenshot 2026-07-02 at 15 04 38" src="https://github.com/user-attachments/assets/13f8b1bb-0e36-4a45-a1e7-90d20ccfb8b5" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)