### PR TITLE
DOC-305: feat(lambda): add ProvisionedPollerConfig support for SQS ESM

### DIFF
--- a/src/content/docs/aws/services/lambda.mdx
+++ b/src/content/docs/aws/services/lambda.mdx
@@ -375,9 +375,9 @@ import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '@
     </TableRow>
     <TableRow>
       <TableCell className="font-medium">ProvisionedPollerConfig</TableCell>
-      <TableCell>Control throughput via min-max limits.</TableCell>
-      <TableCell className="text-center">➖</TableCell>
-      <TableCell className="text-center">➖</TableCell>
+      <TableCell>Control throughput via min-max limits. [^3]</TableCell>
+      <TableCell className="text-center">🟡</TableCell>
+      <TableCell className="text-center">🟡</TableCell>
       <TableCell className="text-center">➖</TableCell>
       <TableCell className="text-center">➖</TableCell>
       <TableCell className="text-center">🟠</TableCell>
@@ -428,6 +428,7 @@ import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '@
 
 [^1]: Read more at [Control which events Lambda sends to your function](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html)
 [^2]: The available Metadata properties may not have full parity with AWS depending on the event source (read more at [Understanding event filtering basics](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html#filtering-basics)).
+[^3]: `ProvisionedPollerConfig` is accepted and validated to match AWS (including rejecting it when combined with `ScalingConfig.MaximumConcurrency`). Dynamic autoscaling between `MinimumPollers` and `MaximumPollers` is not yet implemented.
 
 Create a [GitHub Discussion](https://github.com/orgs/localstack/discussions/new/choose) or reach out to [LocalStack Support](/aws/help-support/get-help/) if you experience any challenges.
 


### PR DESCRIPTION
## Summary

Documents `ProvisionedPollerConfig` support for SQS event source mappings in the Lambda Behaviour Coverage table, per DOC-305 / [localstack-pro#7391](https://github.com/localstack/localstack-pro/pull/7391).
