### PR TITLE
DOCS-345 (`hotfix`): Point sign-up links to marketing pricing page

### DIFF
--- a/src/content/docs/aws/connecting/ides/vscode-extension.md
+++ b/src/content/docs/aws/connecting/ides/vscode-extension.md
@@ -21,7 +21,7 @@ The setup wizard ensures LocalStack is installed and configured for a seamless i
 
 LocalStack can be installed either locally for the current user or globally for all users.
 
-You can [start using LocalStack for free by signing up for a free account](https://app.localstack.cloud/sign-up?plan=free) or signing into an existing one. The setup wizard facilitates this process and configures your authentication token required to start LocalStack.
+You can [start using LocalStack for free by signing up for a free account](https://www.localstack.cloud/pricing) or signing into an existing one. The setup wizard facilitates this process and configures your authentication token required to start LocalStack.
 
 The LocalStack Toolkit integrates seamlessly with AWS tools like the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html). It automatically configures a dedicated `localstack` AWS profile in your `.aws/config` and `.aws/credentials` files, if one is not already present.
 

--- a/src/content/docs/aws/developer-tools/lambda-tools/remote-debugging.mdx
+++ b/src/content/docs/aws/developer-tools/lambda-tools/remote-debugging.mdx
@@ -47,7 +47,7 @@ This guide describes how to use the AWS Toolkit for VS Code to debug Lambda func
 * [AWS Toolkit for VS Code](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-toolkit-vscode) (>= v3.74)
 * [LocalStack Toolkit for VS Code](https://marketplace.visualstudio.com/items?itemName=LocalStack.localstack) (>= v1.2.0)
 * [Docker](https://www.docker.com/)
-* A valid LocalStack Auth Token. Sign up for a [free LocalStack account](https://app.localstack.cloud/sign-up).
+* A valid LocalStack Auth Token. Sign up for a [free LocalStack account](https://www.localstack.cloud/pricing).
 * A valid **auth token** 
 * VS Code running on the **same machine** as LocalStack (container-based setups like Kubernetes are not yet supported).
 

--- a/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
+++ b/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
@@ -25,7 +25,7 @@ Running `lstk` with no arguments takes you through the entire startup flow autom
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) installed and running.
-- A [LocalStack account](https://app.localstack.cloud/sign-up) with a [license](/aws/getting-started/auth-token/#managing-your-license), and `lstk` handles authentication for you (see [Authentication](#authentication)).
+- A [LocalStack account](https://www.localstack.cloud/pricing) with a [license](/aws/getting-started/auth-token/#managing-your-license), and `lstk` handles authentication for you (see [Authentication](#authentication)).
 
 ## Installation
 

--- a/src/content/docs/aws/getting-started/auth-token.mdx
+++ b/src/content/docs/aws/getting-started/auth-token.mdx
@@ -34,7 +34,7 @@ Both the **Developer Auth Token** and **CI Auth Token** can be managed on the [A
 ## Managing your License
 
 To use LocalStack, a license is required.
-You can get a license by registering on the [LocalStack Web Application](https://app.localstack.cloud/sign-up).
+You can get a license by [signing up for a free LocalStack account](https://www.localstack.cloud/pricing).
 Choose between a 14-day trial or explore additional features with our paid offering.
 During the trial period, you are welcome to use all the features of LocalStack.
 

--- a/src/content/docs/aws/getting-started/quickstart.mdx
+++ b/src/content/docs/aws/getting-started/quickstart.mdx
@@ -39,7 +39,7 @@ An internal SES LocalStack testing endpoint (`/_localstack/aws/ses`) is configur
 ## Prerequisites
 
 - [LocalStack CLI](/aws/getting-started/installation/#installing-localstack-cli)
-- [LocalStack Web Application account](https://app.localstack.cloud/sign-up) & [Auth Token](/aws/getting-started/auth-token/)
+- [LocalStack account](https://www.localstack.cloud/pricing) & [Auth Token](/aws/getting-started/auth-token/)
 - [Docker](https://docs.docker.com/get-docker/)
 - [Python 3.11+](https://www.python.org/downloads/) & `pip`
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) & [`awslocal` wrapper](/aws/connecting/aws-cli/#localstack-aws-cli-awslocal)

--- a/src/content/docs/aws/tutorials/aws-proxy-localstack-extension.mdx
+++ b/src/content/docs/aws/tutorials/aws-proxy-localstack-extension.mdx
@@ -32,7 +32,7 @@ In this tutorial, you will learn how to install the AWS Cloud Proxy extension an
 - [LocalStack CLI](/aws/getting-started/installation#localstack-cli)  with  [`LOCALSTACK_AUTH_TOKEN`](/aws/getting-started/auth-token)
 - [Docker](https://docs.docker.com/)
 - [AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-install.html) with  [`awslocal` wrapper](https://github.com/localstack/awscli-local)
-- [LocalStack Web Application account](https://app.localstack.cloud/sign-up)
+- [LocalStack account](https://www.localstack.cloud/pricing)
 - [AWS Account](https://aws.amazon.com/) with an [`AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY`](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey)
 
 ## Install the AWS Cloud Proxy extension

--- a/src/content/docs/aws/tutorials/iam-policy-stream.mdx
+++ b/src/content/docs/aws/tutorials/iam-policy-stream.mdx
@@ -45,7 +45,7 @@ Additionally, it serves as a useful learning tool, helping users understand the 
 - [Docker](https://docs.docker.com/get-docker/)
 - [Terraform](https://developer.hashicorp.com/terraform/install) & [`tflocal` wrapper](https://github.com/localstack/terraform-local)
 - [AWS](https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-install.html)  CLI with  [`awslocal` wrapper](https://github.com/localstack/awscli-local)
-- [LocalStack Web Application account](https://app.localstack.cloud/sign-up)
+- [LocalStack account](https://www.localstack.cloud/pricing)
 - [`jq`](https://jqlang.github.io/jq/download/)
 
 ## Architecture diagram

--- a/src/content/docs/azure/getting-started/auth-token.mdx
+++ b/src/content/docs/azure/getting-started/auth-token.mdx
@@ -44,7 +44,7 @@ To access it, you need a LocalStack account with **any active subscription**. Th
 During the private preview, Azure access is enabled manually and cannot be self-served:
 
 - If you already have a LocalStack subscription (any type), [contact support](https://localstack.cloud/contact/) to have Azure access added.
-- If you don't have a LocalStack subscription yet, sign up for a [Hobby subscription](https://app.localstack.cloud/sign-up) and then [contact support](https://localstack.cloud/contact/) to have Azure access added.
+- If you don't have a LocalStack subscription yet, choose a [Hobby subscription](https://www.localstack.cloud/pricing) and then [contact support](https://localstack.cloud/contact/) to have Azure access added.
 
 Once Azure access is enabled on your subscription, you can use the emulator with your Developer Auth Token or CI Auth Token, just like any other LocalStack product.
 :::

--- a/src/content/docs/snowflake/getting-started/auth-token.mdx
+++ b/src/content/docs/snowflake/getting-started/auth-token.mdx
@@ -38,7 +38,7 @@ Both the **Developer Auth Token** and **CI Auth Token** can be managed on the [A
 ## Managing your License
 
 To use the LocalStack for Snowflake emulator, a license with access to Snowflake is required.
-You can get a license by registering on the [LocalStack Web Application](https://app.localstack.cloud/sign-up) and starting a trial, or by exploring additional features with a paid offering.
+You can get a license by [signing up for a free LocalStack account](https://www.localstack.cloud/pricing) and starting a trial, or by exploring additional features with a paid offering.
 
 After initiating your trial or acquiring a license, assign it to a user by following these steps:
 


### PR DESCRIPTION
## Overview

Docs currently link directly to the app's `/sign-up` page in several places. We want users to go through the marketing pricing page first, so they can review and get educated about our offering before landing on sign-up. This repoints those links to `https://www.localstack.cloud/pricing`.

Resolves [DOC-345](https://linear.app/localstack/issue/DOC-345/replace-direct-sign-up-docs-links-with-pricing-page).


**Please merge once approved**

🤖 Generated with [Claude Code](https://claude.com/claude-code)