### PR TITLE
Add agent/contributor guide pointing to docs guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# LocalStack Docs — Agent Guide
+
+This repo has documented contribution guidelines. They can change over time, so the
+**single source of truth is the live Notion page — never a copy.** This file
+deliberately contains none of the actual rules; it only points you to them.
+
+**Guidelines:** Guide: LocalStack Docs Workflows & Management
+https://www.notion.so/localstack/Guide-LocalStack-Docs-Workflows-Management-1d1fc2a234318044b044fc6554fcc9e4
+
+## What the agent should do
+
+1. **Load the guidelines.** When a session will create or change docs, fetch the
+   Notion page above and follow it throughout the work.
+
+2. **Tell the user, lightly.** Once per session, let them know the guidelines exist
+   — don't recite them:
+
+   > 📌 Heads up: contributing to these docs follows LocalStack's guidelines. I'll
+   > read them and follow them for you. Full guide: <Notion link>
+
+   Non-blocking, once per session. If the user says they know the process, drop it.
+
+3. **At wrap-up, apply them.** Before the work is finalized (e.g. opening a PR),
+   re-check the guidelines and make sure the change complies.
+
+## If you can't access Notion
+
+If you can't fetch the page in this session, don't guess. Tell the user and offer
+two paths — preferred first:
+
+- **Preferred:** ask them to give you Notion access so you can read and follow it.
+- **Fallback:** give them the link and ask them to read it and own compliance.
+  At that point your part is done.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This is just the Starlight starter for now. We can begin moving existing content into `/content/docs`.
 
+## Contributing
+
+Docs contributions follow LocalStack's contribution guidelines. Please read them
+before opening a PR — they're the single source of truth and cover the ticket,
+branching, and release workflow:
+
+**[Guide: LocalStack Docs Workflows & Management](https://www.notion.so/localstack/Guide-LocalStack-Docs-Workflows-Management-1d1fc2a234318044b044fc6554fcc9e4)**
+
 ## Starlight Starter Kit: Basics
 
 [![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)


### PR DESCRIPTION
Linear: [DOC-347](https://linear.app/localstack/issue/DOC-347/add-agentcontributor-guide-surfacing-docs-contribution-guidelines)

## What

Makes the repo's documented contribution guidelines discoverable for both **agents** and **humans**:

- `AGENTS.md` (and a `CLAUDE.md` that imports it) — agents load the guide, follow it, tell the user lightly that guidelines exist, and re-check compliance at PR time.
- `README.md` — a short **Contributing** pointer so people browsing the repo on GitHub see the guidelines too.

## Why

New contributors (human or agent) currently have no in-repo signal that a docs contribution workflow exists in Notion. This surfaces it in the two places each audience actually looks.

## Design notes

- **No rules are copied into any file.** The live Notion page is the single source of truth, so nothing here goes stale when the ticket/branch/release workflow changes. The only concrete detail is the Notion link itself.
- `AGENTS.md` includes a fallback: if the agent can't reach Notion in a session, it asks the user to grant access (preferred) or to read the guide and own compliance.
- This PR targets `main` because it's process/meta only — no docs content — so the monthly feature-branch rule doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)