### PR TITLE
DOC-346: Deprecate Libvirt VM manager in EC2 docs

### DIFF
--- a/src/content/docs/aws/customization/configuration-options.md
+++ b/src/content/docs/aws/customization/configuration-options.md
@@ -185,13 +185,13 @@ This section covers configuration options that are specific to certain AWS servi
 | `EC2_DOCKER_INIT` | `0`\|`1` (default) | Start container instances with docker-init system, learn more [here](https://docs.docker.com/reference/cli/docker/container/run/#init). Disable this if you want to use a custom init system. |
 | `EC2_DOWNLOAD_DEFAULT_IMAGES` | `0`\|`1` (default) | At startup, LocalStack for AWS downloads latest Ubuntu images from Docker Hub for use as AMIs. This can be disabled for security reasons. |
 | `EC2_EBS_MAX_VOLUME_SIZE` | `1000` (default) | Maximum size (in MiBs) of user-specified EBS block devices mounted into EC2 container instances. |
-| `EC2_HYPERVISOR_URI` | `qemu:///system` (default) | [Libvirt connection URI](https://libvirt.org/uri.html#remote-uris) that indicates the hypervisor host. Only QEMU drivers are supported at this time. |
-| `EC2_LIBVIRT_NETWORK` | `default` (default) | Name of the Libvirt network to use for all instances when using the Libvirt VM manager. |
-| `EC2_LIBVIRT_POOL` | `default` (default) | Name of the Libvirt storage pool to use for all images when using the Libvirt VM manager. |
+| `EC2_HYPERVISOR_URI` | `qemu:///system` (default) | **Deprecated**. [Libvirt connection URI](https://libvirt.org/uri.html#remote-uris) that indicates the hypervisor host. Only QEMU drivers are supported at this time. Used with the deprecated Libvirt VM manager. |
+| `EC2_LIBVIRT_NETWORK` | `default` (default) | **Deprecated**. Name of the Libvirt network to use for all instances when using the Libvirt VM manager. |
+| `EC2_LIBVIRT_POOL` | `default` (default) | **Deprecated**. Name of the Libvirt storage pool to use for all images when using the Libvirt VM manager. |
 | `EC2_MOUNT_BLOCK_DEVICES` | `1`\|`0` (default) | Whether to create and mount user-specified EBS block devices into EC2 container instances. |
-| `EC2_REFERENCE_DOMAIN` | `my-template-vm` | Name of a shut-off Libvirt domain whose configuration will be cloned for all new VMs created by LocalStack. If unset or the domain is not found/not shut-off, LocalStack uses a generic configuration. |
+| `EC2_REFERENCE_DOMAIN` | `my-template-vm` | **Deprecated**. Name of a shut-off Libvirt domain whose configuration will be cloned for all new VMs created by LocalStack. If unset or the domain is not found/not shut-off, LocalStack uses a generic configuration. Used with the deprecated Libvirt VM manager. |
 | `EC2_REMOVE_CONTAINERS` | `0`\|`1` (default) | Controls whether created Docker containers are removed at instance termination or LocalStack shuts down. Disable this if there is a need to examine the container filesystem for debugging. |
-| `EC2_VM_MANAGER` | `docker`(default)\|`libvirt`\|`mock` | Emulation method to use in LocalStack for AWS. |
+| `EC2_VM_MANAGER` | `docker` (default) \| `kubernetes` (Enterprise) \| `libvirt` (deprecated) \| `mock` | Emulation method to use in LocalStack for AWS. The `kubernetes` value runs instances as Kubernetes pods. The `libvirt` value is **Deprecated** and will be removed in a future release. |
 
 ### EKS
 

--- a/src/content/docs/aws/services/ec2.mdx
+++ b/src/content/docs/aws/services/ec2.mdx
@@ -207,7 +207,8 @@ All tiers support the mock/CRUD capability.
 For advanced setups, LocalStack for AWS comes with emulation capability for certain resource types so that they behave more closely like AWS.
 
 The underlying method for this can be controlled using the [`EC2_VM_MANAGER`](/aws/customization/configuration-options#ec2) configuration option.
-You may choose between plain mocked resources, containerized or virtualized.
+You may choose between plain mocked resources, containerized emulation, or the [Kubernetes executor](/aws/customization/kubernetes/kubernetes-executor/#ec2-kubernetes-executor).
+Fully virtualized instances via the [Libvirt VM manager](#libvirt-vm-manager) are deprecated and will be removed in a future release.
 
 ## Mock VM Manager
 
@@ -456,10 +457,9 @@ Any operation not listed below will use the mock VM manager.
 
 ## Libvirt VM Manager
 
-:::note
-The Libvirt VM manager is under active development.
-It is currently offered as a preview and will be part of the Ultimate plan upon release.
-If a functionality you desire is missing, please create a feature request on the [GitHub issue tracker](https://github.com/orgs/localstack/discussions/new/choose).
+:::caution[Deprecated]
+The Libvirt VM manager is deprecated and will be removed in a future release.
+Prefer the [Docker VM manager](#docker-vm-manager) or [Mock VM manager](#mock-vm-manager) instead.
 :::
 
 The Libvirt VM manager uses the [Libvirt](https://libvirt.org/index.html) API to create fully virtualized EC2 resources.


### PR DESCRIPTION
## Summary
- Mark the Libvirt VM manager as deprecated in the EC2 docs, replacing the preview note and pointing users to Docker or Mock
- Mark Libvirt-related EC2 config options (`EC2_HYPERVISOR_URI`, `EC2_LIBVIRT_*`, `EC2_REFERENCE_DOMAIN`, and the `libvirt` value of `EC2_VM_MANAGER`) as **Deprecated**

Tracks the product change in [localstack-pro#7870](https://github.com/localstack/localstack-pro/pull/7870).

Fixes [DOC-346](https://linear.app/localstack/issue/DOC-346/doc-ec2-deprecate-libvirt-vmm)
