### PR TITLE
docs(aws): remove ACTIVATE_PRO and update GATEWAY_LISTEN defaults (DOC-331)

### DIFF
--- a/src/content/docs/aws/customization/configuration-options.md
+++ b/src/content/docs/aws/customization/configuration-options.md
@@ -29,7 +29,7 @@ Options that affect the core LocalStack system.
 | `DEBUG` | `0` (default) \|`1`| Flag to increase log level and print more verbose logs (useful for troubleshooting issues)|
 | `IMAGE_NAME`| `localstack/localstack` (default), `localstack/localstack:0.11.0` | Specific name and tag of LocalStack Docker image to use.|
 | `LOCALSTACK_HOST`| `localhost.localstack.cloud:4566` (default) | This is interpolated into URLs and addresses that are returned by LocalStack. It has the form `<hostname>:<port>`. |
-| `GATEWAY_LISTEN` | `0.0.0.0:4566` (default in Docker mode), `127.0.0.1:4566` (default in host mode) | Configures the bind addresses of LocalStack. It has the form `<ip address>:<port>(,<ip address>:<port>)*`. LocalStack for AWS adds port `443`. |
+| `GATEWAY_LISTEN` | `0.0.0.0:4566,0.0.0.0:443` (default in Docker mode), `127.0.0.1:4566,127.0.0.1:443` (default in host mode) | Configures the bind addresses of LocalStack. It has the form `<ip address>:<port>(,<ip address>:<port>)*`. When unset, LocalStack listens on both the HTTP edge port (`4566`) and HTTPS (`443`). |
 | `USE_SSL` | `0` (default) | Whether to return URLs using HTTP (`0`) or HTTPS (`1`). Changed with 3.0.0. In earlier versions this was toggling SSL support on or off. |
 | `PERSISTENCE` | `0` (default) | Enable persistence. See [Persistence Mechanism](/aws/developer-tools/snapshots/persistence) and [Filesystem Layout](/aws/customization/advanced/filesystem). |
 | `MAIN_CONTAINER_NAME` | `localstack-main` (default) | Specify the main docker container name |
@@ -462,7 +462,6 @@ To learn more about these configuration options, see [DNS Server](/aws/customiza
 
 | Variable             | Example Values | Description |
 |----------------------|----------------|-------------|
-| `ACTIVATE_PRO`       | `0` \| `1`&nbsp;(default)    | Whether Pro should be activated or not. This is set to true by default if using the `localstack/localstack-pro` container image. If set to `1`, LocalStack will fail to start if the license key activation did not work. If set to `0`, an attempt is made to start LocalStack without Pro features. |
 | `LOCALSTACK_AUTH_TOKEN` |             | [Auth token](/aws/getting-started/auth-token) to activate LocalStack for AWS. |
 | `LOCALSTACK_API_KEY` |                | **Deprecated since 3.0.0** API key to activate LocalStack for AWS.<br/> **Use the `LOCALSTACK_AUTH_TOKEN` instead (except for [CI environments](/aws/ci-pipelines/)).** |
 | `LOG_LICENSE_ISSUES` | `0` \| `1`&nbsp;(default)    | Whether to log issues with the license activation to the console. |
@@ -476,6 +475,7 @@ These configurations have already been removed and **won't have any effect** on 
 
 | Variable | Removed in | Example Values | Description |
 | - | - | - | - |
+| `ACTIVATE_PRO` | 2026.7.0 | `0` \| `1` (default) | Whether Pro should be activated or not. Previously allowed starting LocalStack without Pro features when set to `0`. The flag had no remaining effect and was removed; use the community image (`localstack/localstack`) if you do not need Pro features. |
 | `EVENT_RULE_ENGINE` | 4.1.0 | `python` (default) \| `java` (deprecated) | Engine for [event pattern matching](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html) used in EventBridge, EventBridge Pipes, and Lambda Event Source Mapping. Our new `python` implementation introduced with version `4.0.3` makes the `java` engine (previously in preview) using AWS [event-ruler](https://github.com/aws/event-ruler) obsolete. |
 | `LAMBDA_EVENT_SOURCE_MAPPING` | 4.0.0 | `v2` (default since [3.8.0](https://blog.localstack.cloud/localstack-release-v-3-8-0/#new-default-lambda-event-source-mapping-implementation)) \| `v1` | Feature flag to switch Lambda Event Source Mapping (ESM) implementations. |
 | `PROVIDER_OVERRIDE_STEPFUNCTIONS` | 4.0.0 | `v2` (default) \| `legacy` | The new LocalStack-native StepFunctions provider (v2) is active by default since LocalStack 3.0. |

--- a/src/content/docs/aws/customization/other-installations/devcontainers.mdx
+++ b/src/content/docs/aws/customization/other-installations/devcontainers.mdx
@@ -157,7 +157,6 @@ The `devcontainer.json` will look similar to the following:
   "LOCALSTACK_AUTH_TOKEN": "${localEnv:LOCALSTACK_AUTH_TOKEN}",  // required for Pro, not processed via template due to security reasons
   "LOCALSTACK_API_KEY": "${localEnv:LOCALSTACK_API_KEY}",
   // LocalStack configuration: https://docs.localstack.cloud/references/configuration/
-  "ACTIVATE_PRO": false,
   "DEBUG": true,
   "LS_LOG": "debug",
   "PERSISTENCE": false,
@@ -414,7 +413,6 @@ FROM mcr.microsoft.com/devcontainers/base:bookworm
 LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}  # required for Pro, not processed via template due to security reasons
 LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY:-}
 # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
-ACTIVATE_PRO=false
 DEBUG=true
 LS_LOG=debug
 PERSISTENCE=false

--- a/src/content/docs/aws/getting-started/auth-token.mdx
+++ b/src/content/docs/aws/getting-started/auth-token.mdx
@@ -235,11 +235,10 @@ License activation failed! 🔑❌
 
 Reason: The credentials defined in your environment are invalid. Please make sure to either set the LOCALSTACK_AUTH_TOKEN variable to a valid auth token, or the LOCALSTACK_API_KEY variable to a valid LocalStack API key. You can find your Auth Token or API key in the LocalStack web app https://app.localstack.cloud.
 
-Due to this error, Localstack has quit. LocalStack for AWS features can only be used with a valid license.
+Due to this error, Localstack has quit. LocalStack pro features can only be used with a valid license.
 
 - Please check that your credentials are set up correctly and that you have an active license.
   You can find your credentials in our webapp at https://app.localstack.cloud.
-- If you want to continue using LocalStack without pro features you can set `ACTIVATE_PRO=0`.
 ```
 
 The key activation in LocalStack may fail for several reasons, and the most common ones are listed below in this section.

--- a/src/content/docs/aws/getting-started/faq.mdx
+++ b/src/content/docs/aws/getting-started/faq.mdx
@@ -699,7 +699,6 @@ Open a ticket by emailing `support@localstack.cloud`.
 | `LOCALSTACK_REQUESTS_CA_BUNDLE` | Prefixed form of `REQUESTS_CA_BUNDLE` that avoids the CLI auto-forward warning |
 | `SKIP_SSL_CERT_DOWNLOAD` | `1` to skip the per-org TLS cert download on startup |
 | `SSL_NO_VERIFY` | `1` to disable outbound TLS verification (debug only) |
-| `ACTIVATE_PRO` | `0` to start LocalStack without Pro features (lets the container boot even if license activation fails) |
 
 For the full configuration reference, see the [Configuration reference](/aws/customization/configuration-options/) and the broader [Networking documentation](/aws/customization/networking/).
 


### PR DESCRIPTION
## Summary
- Remove `ACTIVATE_PRO` from active docs (config reference, FAQ, auth-token troubleshooting, Dev Containers examples) and list it under Legacy as removed in 2026.7.0.
- Update `GATEWAY_LISTEN` defaults to include both `4566` and `443`, matching the core gateway default from [localstack-pro#7726](https://github.com/localstack/localstack-pro/pull/7726).

Linear: https://linear.app/localstack/issue/DOC-331/doc-decompose-move-licensegateway-config-and-inline-runtime-patches