### PR TITLE
docs(aws/services): migrate /aws/services section to use `lstk`

### DIFF
--- a/src/content/docs/aws/services/account.mdx
+++ b/src/content/docs/aws/services/account.mdx
@@ -23,7 +23,7 @@ It's important to note that LocalStack doesn't offer a programmatic interface to
 
 ## Getting started
 
-This guide is designed for users who are new to Account and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users who are new to Account and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to put contact information, fetch account details, and attach an alternate contact to your account.
@@ -34,7 +34,7 @@ You can use the [`PutContactInformation`](https://docs.aws.amazon.com/accounts/l
 Run the following command to add contact information to your account:
 
 ```bash showshowLineNumbers
-awslocal account put-contact-information \
+lstk aws account put-contact-information \
     --contact-information '{
         "FullName": "Jane Doe",
         "PhoneNumber": "+XXXXXXXXX",
@@ -52,7 +52,7 @@ You can use the [`GetContactInformation`](https://docs.aws.amazon.com/accounts/l
 Run the following command to fetch the contact information for your account:
 
 ```bash
-awslocal account get-contact-information
+lstk aws account get-contact-information
 ```
 
 ```bash title="Output" showshowLineNumbers
@@ -75,7 +75,7 @@ You can attach an alternate contact using [`PutAlternateContact`](https://docs.a
 Run the following command to attach an alternate contact to your account:
 
 ```bash showshowLineNumbers
-awslocal account put-alternate-contact \
+lstk aws account put-alternate-contact \
     --alternate-contact-type "BILLING" \
     --email-address "bill@ing.com" \
     --name "Bill Ing" \

--- a/src/content/docs/aws/services/acm-pca.mdx
+++ b/src/content/docs/aws/services/acm-pca.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users who are new to ACM PCA and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users who are new to ACM PCA and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 We will follow the procedure to create and install a certificate for a single-level hierarchy CA hosted by ACM PCA.
 
 ### Create a CA
@@ -27,7 +27,7 @@ Start by creating a new Certificate Authority with ACM PCA using the [`CreateCer
 This command sets up a new CA with specified configurations for key algorithm, signing algorithm, and subject information.
 
 ```bash
-awslocal acm-pca create-certificate-authority \
+lstk aws acm-pca create-certificate-authority \
      --certificate-authority-configuration '{
         "KeyAlgorithm":"RSA_2048",
         "SigningAlgorithm":"SHA256WITHRSA",
@@ -53,7 +53,7 @@ To retrieve the detailed information about the created Certificate Authority, us
 This command returns the detailed information about the CA, including the CA's ARN, status, and configuration.
 
 ```bash
-awslocal acm-pca describe-certificate-authority \
+lstk aws acm-pca describe-certificate-authority \
     --certificate-authority-arn arn:aws:acm-pca:eu-central-1:000000000000:certificate-authority/0b20353f-ce7a-4de4-9b82-e06903a893ff
 ```
 
@@ -94,7 +94,7 @@ In the following steps, we will create and attach a certificate for this CA.
 Use the [`GetCertificateAuthorityCsr`](https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificateAuthorityCsr.html) operation to obtain the Certificate Signing Request (CSR) for the CA.
 
 ```bash
-awslocal acm-pca get-certificate-authority-csr \
+lstk aws acm-pca get-certificate-authority-csr \
     --certificate-authority-arn arn:aws:acm-pca:eu-central-1:000000000000:certificate-authority/0b20353f-ce7a-4de4-9b82-e06903a893ff \
     --output text | tee ca.csr
 ```
@@ -102,7 +102,7 @@ awslocal acm-pca get-certificate-authority-csr \
 Next, issue the certificate for the CA using this CSR.
 
 ```bash
-awslocal acm-pca issue-certificate \
+lstk aws acm-pca issue-certificate \
     --csr fileb://ca.csr \
     --signing-algorithm SHA256WITHRSA \
     --template-arn arn:aws:acm-pca:::template/RootCACertificate/V1 \
@@ -123,14 +123,14 @@ The CA certificate is now created and its ARN is indicated by the `CertificateAr
 Finally, we retrieve the signed certificate with [`GetCertificate`](https://docs.aws.amazon.com/privateca/latest/APIReference/API_GetCertificate.html) and import it using [`ImportCertificateAuthorityCertificate`](https://docs.aws.amazon.com/privateca/latest/APIReference/API_ImportCertificateAuthorityCertificate.html).
 
 ```bash
-awslocal acm-pca get-certificate \
+lstk aws acm-pca get-certificate \
     --certificate-authority-arn arn:aws:acm-pca:eu-central-1:000000000000:certificate-authority/0b20353f-ce7a-4de4-9b82-e06903a893ff \
     --certificate-arn arn:aws:acm-pca:eu-central-1:000000000000:certificate-authority/0b20353f-ce7a-4de4-9b82-e06903a893ff/certificate/17ef7bbf3cc6471ba3ef0707119b8392 \
     --output text | tee cert.pem
 ```
 
 ```bash
-awslocal acm-pca import-certificate-authority-certificate \
+lstk aws acm-pca import-certificate-authority-certificate \
      --certificate-authority-arn arn:aws:acm-pca:eu-central-1:000000000000:certificate-authority/0b20353f-ce7a-4de4-9b82-e06903a893ff \
      --certificate fileb://cert.pem
 ```
@@ -139,7 +139,7 @@ The CA is now ready for use.
 You can verify this by checking its status:
 
 ```bash
-awslocal acm-pca describe-certificate-authority \
+lstk aws acm-pca describe-certificate-authority \
     --certificate-authority-arn arn:aws:acm-pca:eu-central-1:000000000000:certificate-authority/0b20353f-ce7a-4de4-9b82-e06903a893ff \
     --query CertificateAuthority.Status \
     --output text
@@ -196,7 +196,7 @@ Next, using [`IssueCertificate`](https://docs.aws.amazon.com/privateca/latest/AP
 Note that there is no [certificate template](https://docs.aws.amazon.com/privateca/latest/userguide/UsingTemplates.html) specified which causes the end-entity certificate to be issued by default.
 
 ```bash
-awslocal acm-pca issue-certificate \
+lstk aws acm-pca issue-certificate \
       --certificate-authority-arn arn:aws:acm-pca:eu-central-1:000000000000:certificate-authority/0b20353f-ce7a-4de4-9b82-e06903a893ff \
       --csr fileb://local-csr.pem \
       --signing-algorithm "SHA256WITHRSA" \
@@ -231,7 +231,7 @@ Use the [`TagCertificateAuthority`](https://docs.aws.amazon.com/privateca/latest
 This command adds the specified tags to the specified CA.
 
 ```bash
-awslocal acm-pca tag-certificate-authority \
+lstk aws acm-pca tag-certificate-authority \
     --certificate-authority-arn arn:aws:acm-pca:us-east-1:000000000000:certificate-authority/f38ee966-bc23-40f8-8143-e981aee73600 \
     --tags Key=Admin,Value=Alice
 ```
@@ -240,7 +240,7 @@ After tagging your Certificate Authority, you may want to view these tags.
 You can use the [`ListTags`](https://docs.aws.amazon.com/privateca/latest/APIReference/API_ListTags.html) API to list all the tags associated with the specified CA.
 
 ```bash
-awslocal acm-pca list-tags \
+lstk aws acm-pca list-tags \
     --certificate-authority-arn arn:aws:acm-pca:us-east-1:000000000000:certificate-authority/f38ee966-bc23-40f8-8143-e981aee73600 \
     --max-results 10
 ```

--- a/src/content/docs/aws/services/acm.mdx
+++ b/src/content/docs/aws/services/acm.mdx
@@ -20,7 +20,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users who are new to ACM and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users who are new to ACM and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 ### Request a public certificate
 
@@ -29,7 +29,7 @@ Specify the domain name you want to request the certificate for, and any additio
 Here's an example command:
 
 ```bash showshowLineNumbers
-awslocal acm request-certificate \
+lstk aws acm request-certificate \
    --domain-name www.example.com \
    --validation-method DNS \
    --idempotency-token 1234 \
@@ -51,7 +51,7 @@ This command returns a list of the ARNs of all the certificates that have been r
 Here's an example command:
 
 ```bash
-awslocal acm list-certificates --max-items 10
+lstk aws acm list-certificates --max-items 10
 ```
 
 ### Describe the certificate
@@ -61,7 +61,7 @@ Provide the ARN of the certificate you want to view, and this command will retur
 Here's an example command:
 
 ```bash
-awslocal acm describe-certificate --certificate-arn arn:aws:acm:<region>:account:certificate/<certificate_ID>
+lstk aws acm describe-certificate --certificate-arn arn:aws:acm:<region>:account:certificate/<certificate_ID>
 ```
 
 ### Delete the certificate
@@ -70,7 +70,7 @@ Finally you can use the [`DeleteCertificate` API](https://docs.aws.amazon.com/ac
 Here's an example command:
 
 ```bash
-awslocal acm delete-certificate --certificate-arn arn:aws:acm:<region>:account:certificate/<certificate_ID>
+lstk aws acm delete-certificate --certificate-arn arn:aws:acm:<region>:account:certificate/<certificate_ID>
 ```
 
 ## Resource Browser

--- a/src/content/docs/aws/services/apigateway.mdx
+++ b/src/content/docs/aws/services/apigateway.mdx
@@ -21,7 +21,7 @@ The supported APIs are available on the API coverage section for [API Gateway V1
 
 ## Getting started
 
-This guide is designed for users new to API Gateway and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to API Gateway and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will use the Lambda proxy integration to integrate an API method with a Lambda function.
@@ -49,12 +49,12 @@ module.exports = {
 ```
 
 The above code defines a function named `apiHandler` that returns a response with a status code of `200` and a body containing the string `Hello from Lambda`.
-Zip the file and upload it to LocalStack using the `awslocal` CLI.
+Zip the file and upload it to LocalStack using the `lstk aws` command.
 Run the following command:
 
 ```bash showshowLineNumbers
 zip function.zip lambda.js
-awslocal lambda create-function \
+lstk aws lambda create-function \
   --function-name apigw-lambda \
   --runtime nodejs16.x \
   --handler lambda.apiHandler \
@@ -71,7 +71,7 @@ We will use the API Gateway's [`CreateRestApi`](https://docs.aws.amazon.com/apig
 Here's an example command:
 
 ```bash
-awslocal apigateway create-rest-api --name 'API Gateway Lambda integration'
+lstk aws apigateway create-rest-api --name 'API Gateway Lambda integration'
 ```
 
 This creates a new REST API named `API Gateway Lambda integration`.
@@ -99,7 +99,7 @@ You'll need this ID for the next step.
 Use the REST API ID generated in the previous step to fetch the resources for the API, using the [`GetResources`](https://docs.aws.amazon.com/apigateway/latest/api/API_GetResources.html) API:
 
 ```bash
-awslocal apigateway get-resources --rest-api-id <REST_API_ID>
+lstk aws apigateway get-resources --rest-api-id <REST_API_ID>
 ```
 
 ```bash title="Output"
@@ -122,7 +122,7 @@ Create a new resource for the API using the [`CreateResource`](https://docs.aws.
 Use the ID of the resource returned in the previous step as the parent ID:
 
 ```bash showshowLineNumbers
-awslocal apigateway create-resource \
+lstk aws apigateway create-resource \
   --rest-api-id <REST_API_ID> \
   --parent-id <PARENT_ID> \
   --path-part "{somethingId}"
@@ -146,7 +146,7 @@ Add a `GET` method to the resource using the [`PutMethod`](https://docs.aws.amaz
 Use the ID of the resource returned in the previous step as the Resource ID:
 
 ```bash showshowLineNumbers
-awslocal apigateway put-method \
+lstk aws apigateway put-method \
   --rest-api-id <REST_API_ID> \
   --resource-id <RESOURCE_ID> \
   --http-method GET \
@@ -168,7 +168,7 @@ awslocal apigateway put-method \
 Now, create a new integration for the method using the [`PutIntegration`](https://docs.aws.amazon.com/apigateway/latest/api/API_PutIntegration.html) API.
 
 ```bash showshowLineNumbers
-awslocal apigateway put-integration \
+lstk aws apigateway put-integration \
   --rest-api-id <REST_API_ID> \
   --resource-id <RESOURCE_ID> \
   --http-method GET \
@@ -186,7 +186,7 @@ We can now proceed with the deployment before invoking the API.
 Create a new deployment for the API using the [`CreateDeployment`](https://docs.aws.amazon.com/apigateway/latest/api/API_CreateDeployment.html) API:
 
 ```bash
-awslocal apigateway create-deployment \
+lstk aws apigateway create-deployment \
   --rest-api-id <REST_API_ID> \
   --stage-name dev
 ```
@@ -346,10 +346,10 @@ functions:
 ```
 
 Upon deployment of the Serverless project, LocalStack creates a new API Gateway V2 endpoint.
-To retrieve the list of APIs and verify the WebSocket endpoint, you can use the `awslocal` CLI:
+To retrieve the list of APIs and verify the WebSocket endpoint, you can use the `lstk aws` CLI:
 
 ```bash
-awslocal apigatewayv2 get-apis
+lstk aws apigatewayv2 get-apis
 ```
 
 ```bash title="Output"
@@ -377,7 +377,7 @@ To push data from a backend service to the WebSocket connection, you can use the
 In LocalStack, use the following CLI command (replace `<connectionId>` with your WebSocket connection ID):
 
 ```bash
-awslocal apigatewaymanagementapi \
+lstk aws apigatewaymanagementapi \
   post-to-connection \
   --connection-id '<connectionId>' \
   --data '{"msg": "Hi"}'
@@ -392,7 +392,7 @@ To assign a custom ID to an API Gateway REST API, use the `create-rest-api` comm
 The following example assigns the custom ID `"myid123"` to the API:
 
 ```bash
-awslocal apigateway create-rest-api --name my-api --tags '{"_custom_id_":"myid123"}'
+lstk aws apigateway create-rest-api --name my-api --tags '{"_custom_id_":"myid123"}'
 ```
 
 ```bash title="Output"
@@ -405,7 +405,7 @@ awslocal apigateway create-rest-api --name my-api --tags '{"_custom_id_":"myid12
 You can also configure the protocol type, the possible values being `HTTP` and `WEBSOCKET`:
 
 ```bash showshowLineNumbers
-awslocal apigatewayv2 create-api \
+lstk aws apigatewayv2 create-api \
   --name=my-api \
   --protocol-type=HTTP --tags="_custom_id_=my-api"
 {

--- a/src/content/docs/aws/services/appconfig.mdx
+++ b/src/content/docs/aws/services/appconfig.mdx
@@ -15,7 +15,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to AppConfig and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to AppConfig and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an AppConfig application, environment, configuration profiles & feature flags, and deploy the configuration with the AWS CLI.
@@ -27,7 +27,7 @@ The application is a folder/directory that contains the configuration data for y
 The following command creates an application named `my-app`:
 
 ```bash
-awslocal appconfig create-application \
+lstk aws appconfig create-application \
     --name my-app \
     --description "My application"
 ```
@@ -47,7 +47,7 @@ An environment consists of the deployment group of your AppConfig applications.
 The following command creates an environment named `my-app-env`:
 
 ```bash
-awslocal appconfig create-environment \
+lstk aws appconfig create-environment \
     --application-id 400c285 \
     --name my-app-env \
     --description "My application environment"
@@ -73,7 +73,7 @@ A configuration profile contains for the configurations of your AppConfig applic
 The following command creates a configuration profile named `my-app-config`:
 
 ```bash
-awslocal appconfig create-configuration-profile \
+lstk aws appconfig create-configuration-profile \
     --application-id 400c285 \
     --name my-app-config \
     --location-uri hosted \
@@ -110,7 +110,7 @@ You can now use the [`CreateHostedConfigurationVersion`](https://docs.aws.amazon
 The following command creates a hosted configuration version for the configuration profile you created in the previous step:
 
 ```bash
-awslocal appconfig create-hosted-configuration-version \
+lstk aws appconfig create-hosted-configuration-version \
     --application-id 400c285 \
     --configuration-profile-id 7d748f9 \
     --content-type "application/json" \
@@ -134,7 +134,7 @@ A deployment strategy defines important criteria for rolling out your configurat
 The following command creates a deployment strategy named `my-app-deployment-strategy`:
 
 ```bash
-awslocal appconfig create-deployment-strategy \
+lstk aws appconfig create-deployment-strategy \
     --name my-app-deployment-strategy \
     --description "My application deployment strategy" \
     --deployment-duration-in-minutes 10 \
@@ -155,7 +155,7 @@ You can now use the [`StartDeployment`](https://docs.aws.amazon.com/appconfig/la
 The following command deploys the configuration to the environment you created in the previous step:
 
 ```bash
-awslocal appconfig start-deployment \
+lstk aws appconfig start-deployment \
     --application-id 400c285 \
     --environment-id 3695ea3 \
     --deployment-strategy-id f2f2225 \

--- a/src/content/docs/aws/services/application-autoscaling.mdx
+++ b/src/content/docs/aws/services/application-autoscaling.mdx
@@ -19,7 +19,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting Started
 
-This guide is designed for users new to Application Auto Scaling and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Application Auto Scaling and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can configure auto scaling to handle a heavy workload for your Lambda function.
@@ -42,7 +42,7 @@ Run the following command to create a new Lambda function using the [`CreateFunc
 
 ```bash
 zip function.zip index.js
-awslocal lambda create-function \
+lstk aws lambda create-function \
     --function-name autoscaling-example \
     --runtime nodejs18.x \
     --zip-file fileb://function.zip \
@@ -57,8 +57,8 @@ We will use the [`PublishVersion`](https://docs.aws.amazon.com/cli/latest/refere
 Run the following commands:
 
 ```bash
-awslocal lambda publish-version --function-name autoscaling-example
-awslocal lambda create-alias \
+lstk aws lambda publish-version --function-name autoscaling-example
+lstk aws lambda create-alias \
     --function-name autoscaling-example \
     --description "alias for blue version of function" \
     --function-version 1 \
@@ -73,7 +73,7 @@ We will specify the `--service-namespace` as `lambda`, `--scalable-dimension` as
 Run the following command to register the scalable target:
 
 ```bash
-awslocal application-autoscaling register-scalable-target \
+lstk aws application-autoscaling register-scalable-target \
     --service-namespace lambda \
     --scalable-dimension lambda:function:ProvisionedConcurrency \
     --resource-id function:autoscaling-example:BLUE \
@@ -86,7 +86,7 @@ You can create a scheduled action that scales out by specifying the `--schedule`
 Run the following command to create a scheduled action using the [`PutScheduledAction`](https://docs.aws.amazon.com/cli/latest/reference/application-autoscaling/put-scheduled-action.html) API:
 
 ```bash
-awslocal application-autoscaling put-scheduled-action \
+lstk aws application-autoscaling put-scheduled-action \
     --service-namespace lambda \
     --scalable-dimension lambda:function:ProvisionedConcurrency \
     --resource-id function:autoscaling-example:BLUE \
@@ -98,7 +98,7 @@ awslocal application-autoscaling put-scheduled-action \
 You can confirm if the scheduled action exists using [`DescribeScheduledActions`](https://docs.aws.amazon.com/cli/latest/reference/application-autoscaling/describe-scheduled-actions.html) API:
 
 ```bash
-awslocal application-autoscaling describe-scheduled-actions \
+lstk aws application-autoscaling describe-scheduled-actions \
     --service-namespace lambda
 ```
 
@@ -111,7 +111,7 @@ When metrics lack data due to minimal application load, Application Auto Scaling
 Run the following command to create a target-tracking scaling policy:
 
 ```bash
-awslocal application-autoscaling put-scaling-policy \
+lstk aws application-autoscaling put-scaling-policy \
     --service-namespace lambda \
     --scalable-dimension lambda:function:ProvisionedConcurrency \
     --resource-id function:events-example:BLUE \

--- a/src/content/docs/aws/services/appsync.mdx
+++ b/src/content/docs/aws/services/appsync.mdx
@@ -14,7 +14,7 @@ AWS AppSync is a fully managed API management service that connects applications
 LocalStack allows you to use the AppSync APIs in your local environment to connect your applications and services to data and events.
 The supported APIs are available on our [API Coverage section](#api-coverage), which provides information on the extent of AppSync's integration with LocalStack.
 
-This guide is designed for users new to **AppSync** in LocalStack, and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to **AppSync** in LocalStack, and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 LocalStack supports two primary ways to work with AppSync, GraphQL and Events API. 
 
@@ -32,7 +32,7 @@ Use schemas and resolvers to interact with data sources like DynamoDB.
 Create serverless GraphQL APIs to query databases, microservices, and other APIs.
 AppSync allows you to define your data models and business logic using a declarative approach, and connect to various data sources, including other AWS services, relational databases, and custom data sources.
 
-This guide is designed for users new to AppSync and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to AppSync and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an AppSync API with a DynamoDB data source using the AWS CLI.
@@ -43,7 +43,7 @@ You can create a DynamoDB table using the [`CreateTable`](https://docs.aws.amazo
 Execute the following command to create a table named `DynamoDBNotesTable` with a primary key named `NoteId`:
 
 ```bash
-awslocal dynamodb create-table \
+lstk aws dynamodb create-table \
     --table-name DynamoDBNotesTable \
     --attribute-definitions AttributeName=NoteId,AttributeType=S \
     --key-schema AttributeName=NoteId,KeyType=HASH \
@@ -54,7 +54,7 @@ After the table is created, you can use the [`ListTables`](https://docs.aws.amaz
 Run the following command to list all tables in your running LocalStack container:
 
 ```bash
-awslocal dynamodb list-tables
+lstk aws dynamodb list-tables
 ```
 
 ```bash title="Output"
@@ -71,7 +71,7 @@ You can create a GraphQL API using the [`CreateGraphqlApi`](https://docs.aws.ama
 Execute the following command to create a GraphQL API named `NotesApi`:
 
 ```bash
-awslocal appsync create-graphql-api \
+lstk aws appsync create-graphql-api \
     --name NotesApi \
     --authentication-type API_KEY
 ```
@@ -97,7 +97,7 @@ You can now create an API key for your GraphQL API using the [`CreateApiKey`](ht
 Execute the following command to create an API key for your GraphQL API:
 
 ```bash
-awslocal appsync create-api-key \
+lstk aws appsync create-api-key \
     --api-id 014d18d0c2b149ee8b66f39173
 ```
 
@@ -142,7 +142,7 @@ You can start the schema creation process using the [`StartSchemaCreation`](http
 Execute the following command to start the schema creation process:
 
 ```bash
-awslocal appsync start-schema-creation \
+lstk aws appsync start-schema-creation \
     --api-id 014d18d0c2b149ee8b66f39173 \
     --definition file://schema.graphql
 ```
@@ -159,7 +159,7 @@ You can create a data source using the [`CreateDataSource`](https://docs.aws.ama
 Execute the following command to create a data source named `DynamoDBNotesTable`:
 
 ```bash
-awslocal appsync create-data-source \
+lstk aws appsync create-data-source \
     --name AppSyncDB \
     --api-id 014d18d0c2b149ee8b66f39173 \
     --type AMAZON_DYNAMODB \
@@ -187,7 +187,7 @@ You can create a custom `request-mapping-template.vtl` and `response-mapping-tem
 Execute the following command to create a VTL resolver attached to the `PaginatedNotes.notes` field:
 
 ```bash
-awslocal appsync create-resolver \
+lstk aws appsync create-resolver \
     --api-id 014d18d0c2b149ee8b66f39173 \
     --type Query \
     --field PaginatedNotes.notes \
@@ -410,7 +410,7 @@ You can create an Events API using the [CreateApi](https://docs.aws.amazon.com/a
 Note the `apiId`, `dns.REALTIME` and `dns.HTTP` in the outputs as it will be reused as `<api-id>`, `<realtime-domain>` and `<http-domain>` for the remainder of this example.
 
 ```bash
-awslocal appsync create-api \
+lstk aws appsync create-api \
     --name my-api \
     --event-config '{
         "authProviders":[{"authType": "API_KEY"}],
@@ -442,7 +442,7 @@ awslocal appsync create-api \
 You can create an `channelNamespace` using the [CreateChannelNamespace](https://docs.aws.amazon.com/appsync/latest/APIReference/API_CreateChannelNamespace.html) API. At least one `channelNamespace` is required in order to subscribe and publish to it.
 
 ```bash
-awslocal appsync create-channel-namespace \
+lstk aws appsync create-channel-namespace \
     --api-id <api-id> \
     --name "default"
 ```
@@ -468,7 +468,7 @@ You can create an Api Key using the [CreateApiKey](https://docs.aws.amazon.com/a
 
 
 ```bash
-awslocal appsync create-api-key --api-id <api-id>
+lstk aws appsync create-api-key --api-id <api-id>
 ```
 
 ```bash title="Output"
@@ -619,7 +619,7 @@ You can employ a pre-defined ID during the creation of AppSync APIs by utilizing
 For example, the following command will create a GraphQL API with the ID `faceb00c`. `--tags` can also be passed when creating an Events API, and both the API id and the endpoint id will use the provided id.
 
 ```bash
-awslocal appsync create-graphql-api \
+lstk aws appsync create-graphql-api \
     --name my-api \
     --authentication-type API_KEY \
     --tags _custom_id_=faceb00c
@@ -666,7 +666,7 @@ See the AWS documentation for [`evaluate-mapping-template`](https://awscli.amazo
 ### VTL template evaluation
 
 ```bash
-awslocal appsync evaluate-mapping-template \
+lstk aws appsync evaluate-mapping-template \
     --template '$ctx.result' \
     --context '{"result":"ok"}'
 ```
@@ -681,7 +681,7 @@ awslocal appsync evaluate-mapping-template \
 ### JavaScript code evaluation
 
 ```bash
-awslocal appsync evaluate-code \
+lstk aws appsync evaluate-code \
     --runtime name=APPSYNC_JS,runtimeVersion=1.0.0 \
     --function request \
     --code 'export function request(ctx) { return ctx.result; } export function response(ctx) {}' \

--- a/src/content/docs/aws/services/athena.mdx
+++ b/src/content/docs/aws/services/athena.mdx
@@ -19,7 +19,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Athena and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Athena and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an Athena table and run a query against it in addition to reading the results with the AWS CLI.
@@ -37,7 +37,7 @@ You can create an S3 bucket using the [`mb`](https://docs.aws.amazon.com/cli/lat
 Run the following command to create a bucket named `athena-bucket`:
 
 ```bash
-awslocal s3 mb s3://athena-bucket
+lstk aws s3 mb s3://athena-bucket
 ```
 
 You can create some sample data using the following commands:
@@ -50,7 +50,7 @@ echo "LocalStack,Athena" >> data.csv
 You can upload the data to your bucket using the [`cp`](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html) command:
 
 ```bash
-awslocal s3 cp data.csv s3://athena-bucket/data/
+lstk aws s3 cp data.csv s3://athena-bucket/data/
 ```
 
 ### Create an Athena table
@@ -59,7 +59,7 @@ You can create an Athena table using the [`CreateTable`](https://docs.aws.amazon
 Run the following command to create a table named `athena_table`:
 
 ```bash
-awslocal athena start-query-execution \
+lstk aws athena start-query-execution \
     --query-string "create external table tbl01 (name STRING, surname STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' LOCATION 's3://athena-bucket/data/';" --result-configuration "OutputLocation=s3://athena-bucket/output/"
 ```
 
@@ -73,7 +73,7 @@ You can retrieve information about the query execution using the [`GetQueryExecu
 Run the following command:
 
 ```bash
-awslocal athena get-query-execution --query-execution-id 593acab7
+lstk aws athena get-query-execution --query-execution-id 593acab7
 ```
 
 Replace `593acab7` with the `QueryExecutionId` returned by the [`StartQueryExecution`](https://docs.aws.amazon.com/athena/latest/APIReference/API_StartQueryExecution.html) API.
@@ -84,14 +84,14 @@ You can get the output of the query using the [`GetQueryResults`](https://docs.a
 Run the following command:
 
 ```bash
-awslocal athena get-query-results --query-execution-id 593acab7
+lstk aws athena get-query-results --query-execution-id 593acab7
 ```
 
 You can now read the data from the `tbl01` table and retrieve the data from S3 that was mentioned in your table creation statement.
 Run the following command:
 
 ```bash
-awslocal athena start-query-execution \
+lstk aws athena start-query-execution \
     --query-string "select * from tbl01;" --result-configuration "OutputLocation=s3://athena-bucket/output/"
 ```
 
@@ -101,7 +101,7 @@ You can copy the `ResultConfiguration` from the output and use it to retrieve th
 Run the following command:
 
 ```bash
-awslocal s3 cp s3://athena-bucket/output/593acab7.csv .
+lstk aws s3 cp s3://athena-bucket/output/593acab7.csv .
 cat 593acab7.csv
 ```
 
@@ -124,17 +124,17 @@ wget https://localstack-assets.s3.amazonaws.com/aws-sample-athena-delta-lake.zip
 unzip aws-sample-athena-delta-lake.zip; rm aws-sample-athena-delta-lake.zip
 ```
 
-We can then create an S3 bucket in LocalStack using the [`awslocal`](https://github.com/localstack/awscli-local) command line, and upload the files to the bucket:
+We can then create an S3 bucket in LocalStack using the [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command line, and upload the files to the bucket:
 
 ```bash
-awslocal s3 mb s3://test
-awslocal s3 sync /tmp/delta-lake-sample s3://test
+lstk aws s3 mb s3://test
+lstk aws s3 sync /tmp/delta-lake-sample s3://test
 ```
 
 Next, we create the table definitions in Athena:
 
 ```bash
-awslocal athena start-query-execution \
+lstk aws athena start-query-execution \
     --query-string "CREATE EXTERNAL TABLE test (product_id string, product_name string, \
     price bigint, currency string, category string, updated_at double) \
     LOCATION 's3://test/' TBLPROPERTIES ('table_type'='DELTA')"
@@ -147,11 +147,11 @@ Finally, we can now run a `SELECT` query to extract data from the Delta Lake tab
 To query Delta Lake tables, specify `Catalog=deltalake` in the `QueryExecutionContext`:
 
 ```bash
-queryId=$(awslocal athena start-query-execution \
+queryId=$(lstk aws athena start-query-execution \
     --query-string "SELECT * FROM test" \
     --query-execution-context "Database=default,Catalog=deltalake" \
     --result-configuration "OutputLocation=s3://test/output/" | jq -r .QueryExecutionId)
-awslocal athena get-query-results --query-execution-id $queryId
+lstk aws athena get-query-results --query-execution-id $queryId
 ```
 
 The query should yield a result similar to the output below:
@@ -196,7 +196,7 @@ LOCATION 's3://mybucket/prefix/' TBLPROPERTIES ( 'table_type' = 'ICEBERG' )
 To query Iceberg tables, specify `Catalog=iceberg` in the `QueryExecutionContext`:
 
 ```bash
-awslocal athena start-query-execution \
+lstk aws athena start-query-execution \
     --query-string "SELECT * FROM mytable" \
     --query-execution-context "Database=default,Catalog=iceberg" \
     --result-configuration "OutputLocation=s3://mybucket/output/"
@@ -236,7 +236,7 @@ Create a table bucket and a namespace in S3 Tables.
 The bucket holds your Iceberg tables and the namespace organizes them.
 
 ```bash
-awslocal s3tables create-table-bucket --name athena-doc-bucket
+lstk aws s3tables create-table-bucket --name athena-doc-bucket
 ```
 
 ```bash title="Output"
@@ -246,7 +246,7 @@ awslocal s3tables create-table-bucket --name athena-doc-bucket
 ```
 
 ```bash
-awslocal s3tables create-namespace \
+lstk aws s3tables create-namespace \
     --table-bucket-arn arn:aws:s3tables:us-east-1:000000000000:bucket/athena-doc-bucket \
     --namespace sales
 ```
@@ -266,7 +266,7 @@ Register a Glue catalog that federates to S3 Tables using the [`CreateCatalog`](
 The catalog name `s3tablescatalog` matches the AWS convention used by Athena, EMR, and Redshift.
 
 ```bash
-awslocal glue create-catalog \
+lstk aws glue create-catalog \
     --name s3tablescatalog \
     --catalog-input '{
         "FederatedCatalog": {
@@ -279,7 +279,7 @@ awslocal glue create-catalog \
 You can verify the federated catalog with:
 
 ```bash
-awslocal glue get-catalogs
+lstk aws glue get-catalogs
 ```
 
 ### Register an Athena data catalog
@@ -288,7 +288,7 @@ Register an Athena data catalog that points at a specific table bucket using the
 The `catalog-id` parameter follows the format `s3tablescatalog/<bucket-name>` so that Athena routes queries through the federated catalog path.
 
 ```bash
-awslocal athena create-data-catalog \
+lstk aws athena create-data-catalog \
     --name s3tables-catalog \
     --type GLUE \
     --parameters "catalog-id=s3tablescatalog/athena-doc-bucket"
@@ -297,7 +297,7 @@ awslocal athena create-data-catalog \
 Confirm the data catalog status:
 
 ```bash
-awslocal athena get-data-catalog --name s3tables-catalog
+lstk aws athena get-data-catalog --name s3tables-catalog
 ```
 
 ```bash title="Output"
@@ -319,7 +319,7 @@ Once the data catalog is registered, Athena resolves S3 Tables namespaces as dat
 List the databases exposed by the federated catalog:
 
 ```bash
-awslocal athena list-databases --catalog-name s3tables-catalog
+lstk aws athena list-databases --catalog-name s3tables-catalog
 ```
 
 ```bash title="Output"
@@ -339,7 +339,7 @@ awslocal athena list-databases --catalog-name s3tables-catalog
 You can also describe a single namespace with [`GetDatabase`](https://docs.aws.amazon.com/athena/latest/APIReference/API_GetDatabase.html):
 
 ```bash
-awslocal athena get-database \
+lstk aws athena get-database \
     --catalog-name s3tables-catalog \
     --database-name sales
 ```
@@ -350,7 +350,7 @@ To query S3 Tables data from Athena, reference the data catalog name in the `Que
 The `Catalog` field maps to the Athena data catalog you registered, and `Database` maps to the S3 Tables namespace:
 
 ```bash
-awslocal athena start-query-execution \
+lstk aws athena start-query-execution \
     --query-string "CREATE TABLE orders (id int, customer string, amount double) TBLPROPERTIES ('table_type' = 'ICEBERG')" \
     --query-execution-context "Catalog=s3tables-catalog,Database=sales" \
     --result-configuration "OutputLocation=s3://athena-doc-output/results/"
@@ -359,14 +359,14 @@ awslocal athena start-query-execution \
 Insert and read data using the same `QueryExecutionContext`:
 
 ```bash
-awslocal athena start-query-execution \
+lstk aws athena start-query-execution \
     --query-string "INSERT INTO orders VALUES (1, 'alice', 100.0), (2, 'bob', 250.5)" \
     --query-execution-context "Catalog=s3tables-catalog,Database=sales" \
     --result-configuration "OutputLocation=s3://athena-doc-output/results/"
 ```
 
 ```bash
-awslocal athena start-query-execution \
+lstk aws athena start-query-execution \
     --query-string "SELECT * FROM orders ORDER BY id" \
     --query-execution-context "Catalog=s3tables-catalog,Database=sales" \
     --result-configuration "OutputLocation=s3://athena-doc-output/results/"

--- a/src/content/docs/aws/services/autoscaling.mdx
+++ b/src/content/docs/aws/services/autoscaling.mdx
@@ -16,7 +16,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Auto Scaling and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Auto Scaling and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can create a launch template, an Auto Scaling group, and attach an instance to the Auto Scaling group using the AWS CLI.
@@ -27,7 +27,7 @@ You can create a launch template that defines the launch configuration for the i
 Run the following command to create a launch template:
 
 ```bash
-awslocal ec2 create-launch-template \
+lstk aws ec2 create-launch-template \
     --launch-template-name my-template-for-auto-scaling \
     --version-description version1 \
     --launch-template-data '{"ImageId":"ami-ff0fea8310f3","InstanceType":"t2.micro"}'
@@ -53,14 +53,14 @@ Before creating an Auto Scaling group, you need to fetch the subnet ID.
 Run the following command to describe the subnets:
 
 ```bash
-awslocal ec2 describe-subnets --output text --query Subnets[0].SubnetId
+lstk aws ec2 describe-subnets --output text --query Subnets[0].SubnetId
 ```
 
 Copy the subnet ID from the output and use it to create the Auto Scaling group.
 Run the following command to create an Auto Scaling group using the [`CreateAutoScalingGroup`](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_CreateAutoScalingGroup.html) API:
 
 ```bash
-awslocal autoscaling create-auto-scaling-group \
+lstk aws autoscaling create-auto-scaling-group \
     --auto-scaling-group-name my-asg \
     --launch-template LaunchTemplateId=lt-5ccdf1a84f178ba44 \
     --min-size 1 \
@@ -74,7 +74,7 @@ You can describe the Auto Scaling group using the [`DescribeAutoScalingGroups`](
 Run the following command to describe the Auto Scaling group:
 
 ```bash
-awslocal autoscaling describe-auto-scaling-groups
+lstk aws autoscaling describe-auto-scaling-groups
 ```
 
 ```bash title="Output"
@@ -117,7 +117,7 @@ Before that, create an EC2 instance using the [`RunInstances`](https://docs.aws.
 Run the following command to create an EC2 instance locally:
 
 ```bash
-awslocal ec2 run-instances \
+lstk aws ec2 run-instances \
     --image-id ami-ff0fea8310f3 --count 1
 ```
 
@@ -125,7 +125,7 @@ Fetch the instance ID from the output and use it to attach the instance to the A
 Run the following command to attach the instance to the Auto Scaling group:
 
 ```bash
-awslocal autoscaling attach-instances \
+lstk aws autoscaling attach-instances \
     --instance-ids i-0d678c4ecf6018dde \
     --auto-scaling-group-name my-asg
 ```

--- a/src/content/docs/aws/services/backup.mdx
+++ b/src/content/docs/aws/services/backup.mdx
@@ -19,7 +19,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Backup and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Backup and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a backup job and specify a set of resources to the backup plan name and backup rules with the AWS CLI.
@@ -30,7 +30,7 @@ You can create a backup vault which acts as a logical container where backups ar
 Run the following command to create a backup vault named `my-vault`:
 
 ```bash
-awslocal backup create-backup-vault \
+lstk aws backup create-backup-vault \
     --backup-vault-name primary
 ```
 
@@ -73,7 +73,7 @@ You can use the [`CreateBackupPlan`](https://docs.aws.amazon.com/aws-backup/late
 Run the following command to create a backup plan:
 
 ```bash
-awslocal backup create-backup-plan \
+lstk aws backup create-backup-plan \
     --backup-plan file://backup-plan.json
 ```
 
@@ -109,7 +109,7 @@ You can use the [`CreateBackupSelection`](https://docs.aws.amazon.com/aws-backup
 Run the following command to create a backup selection:
 
 ```bash
-awslocal backup create-backup-selection \
+lstk aws backup create-backup-selection \
     --backup-plan-id 9337aba3 \
     --backup-selection file://backup-plan-resources.json
 ```

--- a/src/content/docs/aws/services/batch.mdx
+++ b/src/content/docs/aws/services/batch.mdx
@@ -19,7 +19,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to AWS Batch and assumes basic knowledge of the AWS CLI and our `awslocal` wrapper script.
+This guide is designed for users new to AWS Batch and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you create and run a Batch job by following these steps:
@@ -39,7 +39,7 @@ LocalStack requires the role to exist with a valid trust policy. When [enforcing
 Run the following command to create a role for ECS task execution:
 
 ```bash
-awslocal iam create-role \
+lstk aws iam create-role \
     --role-name myrole \
     --assume-role-policy-document '{
   "Version": "2025-10-17",
@@ -58,7 +58,7 @@ awslocal iam create-role \
 Then attach the ECS task execution policy:
 
 ```bash
-awslocal iam attach-role-policy \
+lstk aws iam attach-role-policy \
     --role-name myrole \
     --policy-arn arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
 ```
@@ -71,7 +71,7 @@ You can use the [`CreateComputeEnvironment`](https://docs.aws.amazon.com/cli/lat
 Run the following command using the role ARN above (arn:aws:iam::000000000000:role/myrole) to create a managed compute environment with FARGATE:
 
 ```bash
-awslocal batch create-compute-environment \
+lstk aws batch create-compute-environment \
     --compute-environment-name myenv \
     --type MANAGED \
     --state ENABLED \
@@ -91,7 +91,7 @@ You can fetch the ARN using the [`DescribeComputeEnvironments`](https://docs.aws
 Run the following command to fetch the ARN of the compute environment:
 
 ```bash
-awslocal batch describe-compute-environments --compute-environments myenv
+lstk aws batch describe-compute-environments --compute-environments myenv
 ```
 
 ```bash title="Output"
@@ -115,7 +115,7 @@ You can use the ARN to create the job queue using [`CreateJobQueue`](https://doc
 Run the following command to create the job queue:
 
 ```bash
-awslocal batch create-job-queue \
+lstk aws batch create-job-queue \
     --job-queue-name myqueue \
     --priority 1 \
     --compute-environment-order order=0,computeEnvironment=arn:aws:batch:us-east-1:000000000000:compute-environment/myenv \
@@ -130,7 +130,7 @@ Run the following command to create the job definition using the [`RegisterJobDe
 
 
 ```bash
-awslocal batch register-job-definition \
+lstk aws batch register-job-definition \
     --job-definition-name myjobdefn \
     --type container \
     --platform-capabilities FARGATE \
@@ -153,7 +153,7 @@ If you want to pass arguments to the command as [parameters](https://docs.aws.am
 This allows the dynamic passing of values at runtime for specific job definitions.
 
 ```bash
-awslocal batch register-job-definition \
+lstk aws batch register-job-definition \
     --job-definition-name myjobdefn \
     --type container \
     --parameters '{"time":"10"}' \
@@ -181,7 +181,7 @@ This command simulates work being done in the container.
 Run the following command to submit a job to the job queue using the [`SubmitJob`](https://docs.aws.amazon.com/cli/latest/reference/batch/submit-job.html) API:
 
 ```bash
-awslocal batch submit-job \
+lstk aws batch submit-job \
     --job-name myjob \
     --job-queue myqueue \
     --job-definition myjobdefn \
@@ -198,7 +198,7 @@ MNP jobs run on EC2-backed compute environments only. Fargate is not supported.
 To run one, register a job definition with `--type multinode` and a `nodeProperties` object that sets the main node, the number of nodes, and a container per node range:
 
 ```bash
-awslocal batch register-job-definition \
+lstk aws batch register-job-definition \
     --job-definition-name mnp-jobdefn \
     --type multinode \
     --node-properties '{
@@ -223,7 +223,7 @@ awslocal batch register-job-definition \
 Then submit it to an EC2-backed queue:
 
 ```bash
-awslocal batch submit-job \
+lstk aws batch submit-job \
     --job-name mnp-job \
     --job-queue mnp-queue \
     --job-definition mnp-jobdefn
@@ -232,7 +232,7 @@ awslocal batch submit-job \
 The submitted job is the parent. Each node is addressable as a child job using the `<jobId>#<nodeIndex>` notation, which you can inspect with `describe-jobs`:
 
 ```bash
-awslocal batch describe-jobs --jobs "<jobId>#0" "<jobId>#1"
+lstk aws batch describe-jobs --jobs "<jobId>#0" "<jobId>#1"
 ```
 
 Each node also receives additional [environment variables](#environment-variables), such as `AWS_BATCH_JOB_NODE_INDEX` and `AWS_BATCH_JOB_MAIN_NODE_PRIVATE_IPV4_ADDRESS`, that let the nodes coordinate.

--- a/src/content/docs/aws/services/bedrock.mdx
+++ b/src/content/docs/aws/services/bedrock.mdx
@@ -16,7 +16,7 @@ The supported APIs are available on the API coverage section for [Bedrock](#api-
 
 ## Getting started
 
-This guide is designed for users new to AWS Bedrock and assumes basic knowledge of the AWS CLI and our `awslocal` wrapper script.
+This guide is designed for users new to AWS Bedrock and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method with or without pre-warming the Bedrock engine.
 We will demonstrate how to use Bedrock by following these steps:
@@ -49,7 +49,7 @@ You can define the used model with `DEFAULT_BEDROCK_MODEL`
 Run the following command:
 
 ```bash
-awslocal bedrock list-foundation-models
+lstk aws bedrock list-foundation-models
 ```
 
 ### Invoke a model
@@ -61,7 +61,7 @@ However, the actual model will be defined by the `DEFAULT_BEDROCK_MODEL` environ
 Run the following command:
 
 ```bash
-awslocal bedrock-runtime invoke-model \
+lstk aws bedrock-runtime invoke-model \
     --model-id "meta.llama3-8b-instruct-v1:0" \
     --body '{
         "prompt": "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\nSay Hello!\n<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>",
@@ -80,7 +80,7 @@ You can specify both system prompts and user messages.
 Run the following command:
 
 ```bash
-awslocal bedrock-runtime converse \
+lstk aws bedrock-runtime converse \
     --model-id "meta.llama3-8b-instruct-v1:0" \
     --messages '[{
         "role": "user",
@@ -108,15 +108,15 @@ First, you need to create a `JSONL` file named `batch_input.jsonl` that contains
 Then, you need to define buckets for the input as well as the output and upload the file in the input bucket:
 
 ```bash
-awslocal s3 mb s3://in-bucket
-awslocal s3 cp batch_input.jsonl s3://in-bucket
-awslocal s3 mb s3://out-bucket
+lstk aws s3 mb s3://in-bucket
+lstk aws s3 cp batch_input.jsonl s3://in-bucket
+lstk aws s3 mb s3://out-bucket
 ```
 
 Afterwards you can run the invocation job like this:
 
 ```bash
-awslocal bedrock create-model-invocation-job \
+lstk aws bedrock create-model-invocation-job \
   --job-name "my-batch-job" \
   --model-id "mistral.mistral-small-2402-v1:0" \
   --role-arn "arn:aws:iam::123456789012:role/MyBatchInferenceRole" \
@@ -150,7 +150,7 @@ You can also define models directly in the request, by setting the `model-id` pa
 For example, if you want to access `deepseek-r1`, you can do it like this:
 
 ```bash
-awslocal bedrock-runtime converse \
+lstk aws bedrock-runtime converse \
     --model-id "ollama.deepseek-r1" \
     --messages '[{
         "role": "user",

--- a/src/content/docs/aws/services/bedrock.mdx
+++ b/src/content/docs/aws/services/bedrock.mdx
@@ -143,7 +143,7 @@ LocalStack will pull the model from Ollama and use it for emulation.
 For example, to use the Mistral model, set the environment variable while starting LocalStack:
 
 ```bash
-DEFAULT_BEDROCK_MODEL=mistral localstack start
+LOCALSTACK_DEFAULT_BEDROCK_MODEL=mistral lstk start
 ```
 
 You can also define models directly in the request, by setting the `model-id` parameter to `ollama.<ollama-model-id>`.

--- a/src/content/docs/aws/services/ce.mdx
+++ b/src/content/docs/aws/services/ce.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Cost Explorer and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Cost Explorer and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to mock the Cost Explorer APIs with the AWS CLI.
@@ -28,7 +28,7 @@ You can create a Cost Category definition using the [`CreateCostCategoryDefiniti
 The following example creates a Cost Category definition using an empty rule condition of type "REGULAR":
 
 ```bash
-awslocal ce create-cost-category-definition --name test \
+lstk aws ce create-cost-category-definition --name test \
     --rule-version "CostCategoryExpression.v1" --rules '[{"Value": "test", "Rule": {}, "Type": "REGULAR"}]'
 ```
 
@@ -42,7 +42,7 @@ You can describe the Cost Category definition using the [`DescribeCostCategoryDe
 Run the following command:
 
 ```bash
-awslocal ce describe-cost-category-definition \
+lstk aws ce describe-cost-category-definition \
     --cost-category-arn arn:aws:ce::000000000000:costcategory/test
 ```
 
@@ -69,7 +69,7 @@ You can add an alert subscription to a cost anomaly detection monitor to define 
 The following example creates a cost anomaly subscription:
 
 ```bash
-awslocal ce create-anomaly-subscription --anomaly-subscription '{
+lstk aws ce create-anomaly-subscription --anomaly-subscription '{
     "AccountId": "12345",
     "SubscriptionName": "sub1",
     "Frequency": "DAILY",
@@ -89,7 +89,7 @@ You can retrieve the cost anomaly subscriptions using the [`GetAnomalySubscripti
 Run the following command:
 
 ```bash
-awslocal ce get-anomaly-subscriptions
+lstk aws ce get-anomaly-subscriptions
 ```
 
 ```bash title="Output"
@@ -114,7 +114,7 @@ You can create a new cost anomaly detection subscription with the requested type
 The following example creates a cost anomaly monitor:
 
 ```bash
-awslocal ce create-anomaly-monitor --anomaly-monitor '{
+lstk aws ce create-anomaly-monitor --anomaly-monitor '{
     "MonitorName": "mon5463",
     "MonitorType": "DIMENSIONAL"
 }'
@@ -130,7 +130,7 @@ You can retrieve the cost anomaly monitors using the [`GetAnomalyMonitors`](http
 Run the following command:
 
 ```bash
-awslocal ce get-anomaly-monitors
+lstk aws ce get-anomaly-monitors
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/cloudcontrol.mdx
+++ b/src/content/docs/aws/services/cloudcontrol.mdx
@@ -16,7 +16,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Cloud Control and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Cloud Control and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to get and list resources using the Cloud Control API.
@@ -28,13 +28,13 @@ You can list resources using the [`ListResources`](https://docs.aws.amazon.com/c
 Create an S3 bucket using the following command:
 
 ```bash
-awslocal s3 mb s3://my-bucket
+lstk aws s3 mb s3://my-bucket
 ```
 
 List the resources using the following command:
 
 ```bash
-awslocal cloudcontrol list-resources --type-name AWS::S3::Bucket
+lstk aws cloudcontrol list-resources --type-name AWS::S3::Bucket
 ```
 
 You should see the S3 bucket in the output.
@@ -56,7 +56,7 @@ You should see the S3 bucket in the output.
 You can get a resource using the [`GetResource`](https://docs.aws.amazon.com/cloudcontrolapi/latest/APIReference/API_GetResource.html) API.
 
 ```bash
-awslocal cloudcontrol get-resource --type-name AWS::S3::Bucket --identifier my-bucket
+lstk aws cloudcontrol get-resource --type-name AWS::S3::Bucket --identifier my-bucket
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/cloudformation.mdx
+++ b/src/content/docs/aws/services/cloudformation.mdx
@@ -56,7 +56,7 @@ The [API Coverage section](#api-coverage) and [feature coverage](#feature-covera
 
 ## Getting started
 
-This guide is designed for users new to CloudFormation and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to CloudFormation and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to deploy a simple CloudFormation stack consisting of a single S3 Bucket with the AWS CLI.
@@ -100,7 +100,7 @@ The `deploy` command creates and updates CloudFormation stacks.
 Run the following command to deploy the stack:
 
 ```bash
-awslocal cloudformation deploy \
+lstk aws cloudformation deploy \
     --stack-name cfn-quickstart-stack \
     --template-file "./cfn-quickstart-stack.yaml"
 ```
@@ -109,7 +109,7 @@ You can verify that the stack was created successfully by listing the S3 buckets
 Run the following command to list the buckets:
 
 ```bash
-awslocal s3api list-buckets
+lstk aws s3api list-buckets
 ```
 
 ### Delete the CloudFormation Stack
@@ -118,7 +118,7 @@ You can delete the CloudFormation stack using the [`delete-stack`](https://docs.
 Run the following command to delete the stack along with all the resources created by the stack:
 
 ```bash
-awslocal cloudformation delete-stack \
+lstk aws cloudformation delete-stack \
     --stack-name cfn-quickstart-stack
 ```
 
@@ -134,7 +134,7 @@ When a private extension is activated, LocalStack deploys and invokes the embedd
 Build and package your extension using the CloudFormation CLI, then upload the package to S3 and register the type:
 
 ```bash
-awslocal cloudformation register-type \
+lstk aws cloudformation register-type \
     --type RESOURCE \
     --type-name MyOrg::MyService::MyResource \
     --schema-handler-package s3://my-bucket/my-extension.zip

--- a/src/content/docs/aws/services/cloudfront.mdx
+++ b/src/content/docs/aws/services/cloudfront.mdx
@@ -19,7 +19,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 ## Getting started
 
 This guide is intended for users who wish to get more acquainted with CloudFront over LocalStack.
-It assumes you have basic knowledge of the AWS CLI (and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script).
+It assumes you have basic knowledge of the AWS CLI (and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command).
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can create an S3 bucket, put a text file named `hello.txt` to the bucket, and then create a CloudFront distribution which makes the file accessible via a `https://abc123.cloudfront.net/hello.txt` proxy URL (where `abc123` is a placeholder for the real distribution ID).
@@ -27,21 +27,21 @@ We will demonstrate how you can create an S3 bucket, put a text file named `hell
 To get started, create an S3 bucket using the `mb` command:
 
 ```bash
-awslocal s3 mb s3://abc123
+lstk aws s3 mb s3://abc123
 ```
 
 You can now go ahead, create a new text file named `hello.txt` and upload it to the bucket:
 
 ```bash
 echo 'Hello World' > /tmp/hello.txt
-awslocal s3 cp /tmp/hello.txt s3://abc123/hello.txt --acl public-read
+lstk aws s3 cp /tmp/hello.txt s3://abc123/hello.txt --acl public-read
 ```
 
 After uploading the file to S3, you can create a CloudFront distribution using the [`CreateDistribution`](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateDistribution.html) API call.
 Run the following command to create a distribution with the default settings:
 
 ```bash
-domain=$(awslocal cloudfront create-distribution \
+domain=$(lstk aws cloudfront create-distribution \
    --origin-domain-name abc123.s3.amazonaws.com | jq -r '.Distribution.DomainName')
 curl -k https://$domain/hello.txt
 ```

--- a/src/content/docs/aws/services/cloudtrail.mdx
+++ b/src/content/docs/aws/services/cloudtrail.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to CloudTrail and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to CloudTrail and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to enable S3 object logging to CloudTrail using AWS CLI.
@@ -28,7 +28,7 @@ Before you create a trail, you need to create an S3 bucket where CloudTrail can 
 You can use the [`mb`](https://docs.aws.amazon.com/cli/latest/reference/s3/mb.html) command to create a bucket:
 
 ```bash
-awslocal s3 mb s3://my-bucket
+lstk aws s3 mb s3://my-bucket
 ```
 
 ### Create a trail
@@ -38,7 +38,7 @@ You can use the [`CreateTrail`](https://docs.aws.amazon.com/awscloudtrail/latest
 Run the following command to create a trail:
 
 ```bash
-awslocal cloudtrail create-trail \
+lstk aws cloudtrail create-trail \
     --name MyTrail \
     --s3-bucket-name my-bucket
 ```
@@ -50,7 +50,7 @@ You can use the [`StartLogging`](https://docs.aws.amazon.com/awscloudtrail/lates
 Run the following command to enable logging:
 
 ```bash
-awslocal cloudtrail start-logging --name MyTrail
+lstk aws cloudtrail start-logging --name MyTrail
 ```
 
 You can further configure event selectors for the trail.
@@ -59,7 +59,7 @@ You can use the [`PutEventSelectors`](https://docs.aws.amazon.com/awscloudtrail/
 Run the following command to configure event selectors:
 
 ```bash
-awslocal cloudtrail put-event-selectors \
+lstk aws cloudtrail put-event-selectors \
     --trail-name MyTrail \
     --event-selectors '[{"ReadWriteType": "All", "IncludeManagementEvents":true, "DataResources": [{"Type": "AWS::S3::Object", "Values": ["arn:aws:s3:::my-bucket/"]}]}]'
 ```
@@ -68,7 +68,7 @@ You can verify if your configuration is correct by using the [`GetEventSelectors
 Run the following command to verify your configuration:
 
 ```bash
-awslocal cloudtrail get-event-selectors \
+lstk aws cloudtrail get-event-selectors \
     --trail-name MyTrail
 ```
 
@@ -99,8 +99,8 @@ You can use the [`cp`](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.ht
 
 ```bash
 echo "hello world" > /tmp/hello-world
-awslocal s3 cp /tmp/hello-world s3://my-bucket/hello-world
-awslocal s3 ls s3://my-bucket
+lstk aws s3 cp /tmp/hello-world s3://my-bucket/hello-world
+lstk aws s3 ls s3://my-bucket
 ```
 
 You can verify that the object was created in the S3 bucket.
@@ -108,7 +108,7 @@ You can also verify that the object level event was logged by CloudTrail using t
 Run the following command to verify the event:
 
 ```bash
-awslocal cloudtrail lookup-events \
+lstk aws cloudtrail lookup-events \
     --lookup-attributes AttributeKey=EventName,AttributeValue=PutObject \
     --max-results 1
 ```

--- a/src/content/docs/aws/services/cloudwatch.mdx
+++ b/src/content/docs/aws/services/cloudwatch.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to CloudWatch and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to CloudWatch and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method and deploy your Lambda functions that will generate some logs.
 You can get the name for your Lambda Functions using the [`ListFunctions`](https://docs.aws.amazon.com/lambda/latest/dg/API_ListFunctions.html) API.
@@ -27,7 +27,7 @@ Fetch the Log Groups using the [`DescribeLogGroups`](https://docs.aws.amazon.com
 Run the following command to get the Log Group name:
 
 ```bash
-awslocal logs describe-log-groups
+lstk aws logs describe-log-groups
 ```
 
 ```bash title="Output"
@@ -55,7 +55,7 @@ Get the log streams for the Log Group using the [`DescribeLogStreams`](https://d
 Run the following command to get the Log Stream name:
 
 ```bash
-awslocal logs describe-log-streams \
+lstk aws logs describe-log-streams \
     --log-group-name /aws/lambda/serverless-local-hello
 ```
 
@@ -80,7 +80,7 @@ You can now fetch the log events using the [`GetLogEvents`](https://docs.aws.ama
 Run the following command to get the logs:
 
 ```bash
-awslocal logs get-log-events \
+lstk aws logs get-log-events \
     --log-group-name '/aws/lambda/serverless-local-hello' --log-stream-name '2023/05/02/[$LATEST]853a59d0767cfaf10d6b29a6790d8b03'
 ```
 
@@ -125,10 +125,10 @@ These features enable you to define and evaluate alarms based on various statist
 Metric alarms in CloudWatch allow you to evaluate the state of a metric by analyzing its data points over a specified period.
 With metric alarms, you can create customized thresholds and define actions based on the metric's behavior.
 
-To get started with creating an alarm in LocalStack using the `awslocal` integration, use the following command:
+To get started with creating an alarm in LocalStack using the `lstk aws` integration, use the following command:
 
 ```bash
-awslocal cloudwatch put-metric-alarm \
+lstk aws cloudwatch put-metric-alarm \
   --alarm-name my-alarm \
   --metric-name Orders \
   --namespace test \
@@ -143,13 +143,13 @@ awslocal cloudwatch put-metric-alarm \
 To monitor the status of the alarm, open a separate terminal and execute the following command:
 
 ```bash
-watch "awslocal cloudwatch describe-alarms --alarm-names my-alarm | jq '.MetricAlarms[0].StateValue'"
+watch "lstk aws cloudwatch describe-alarms --alarm-names my-alarm | jq '.MetricAlarms[0].StateValue'"
 ```
 
 Afterward, you can add some data that will cause a breach and set the `metric-alarm` state to **ALARM** using the following command:
 
 ```bash
-awslocal cloudwatch put-metric-data \
+lstk aws cloudwatch put-metric-data \
     --namespace test \
     --metric-data '[{"MetricName": "Orders", "Value": -1}]'
 ```
@@ -167,7 +167,7 @@ Here's an example demonstrating how to set up an alarm that sends a message to t
 Make sure to replace `<topic-arn>` with the valid ARN of an existing SNS topic.
 
 ```bash
-awslocal cloudwatch put-metric-alarm \
+lstk aws cloudwatch put-metric-alarm \
   --alarm-name my-alarm \
   --metric-name Orders \
   --namespace test \

--- a/src/content/docs/aws/services/codeartifact.mdx
+++ b/src/content/docs/aws/services/codeartifact.mdx
@@ -19,9 +19,9 @@ It also has full support to create and use NPM repositories.
 
 ## Getting Started
 
-This guide will help you create a domain, repository, and manage package publishing workflows using the `awslocal` CLI.
+This guide will help you create a domain, repository, and manage package publishing workflows using the `lstk aws` command.
 
-Basic knowledge of the AWS CLI and the [`awslocal`](https://github.com/localstack/awscli-local) wrapper is expected.
+Basic knowledge of the AWS CLI and the [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command is expected.
 
 Start LocalStack using your preferred method.
 
@@ -32,7 +32,7 @@ Domains are the top-level containers for repositories in CodeArtifact.
 Create a domain with the [`CreateDomain`](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_CreateDomain.html) API.
 
 ```bash
-awslocal codeartifact create-domain --domain demo-domain
+lstk aws codeartifact create-domain --domain demo-domain
 ```
 
 ```json title="Output"
@@ -52,7 +52,7 @@ awslocal codeartifact create-domain --domain demo-domain
 You can use the [`DescribeDomain`](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_DescribeDomain.html), [`UpdateDomain`](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_UpdateDomain.html), and [`DeleteDomain`](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_DeleteDomain.html) APIs for domain management.
 
 ```bash
-awslocal codeartifact describe-domain --domain demo-domain
+lstk aws codeartifact describe-domain --domain demo-domain
 ```
 
 ```json title="Output"
@@ -72,7 +72,7 @@ awslocal codeartifact describe-domain --domain demo-domain
 You can list all domains using the [`ListDomains`](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_ListDomains.html) API.
 
 ```bash
-awslocal codeartifact list-domains
+lstk aws codeartifact list-domains
 ```
 
 ```json title="Output"
@@ -96,7 +96,7 @@ Repositories store packages and are associated with a domain.
 Create a repository using the [`CreateRepository`](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_CreateRepository.html) API.
 
 ```bash
-awslocal codeartifact create-repository --domain demo-domain \
+lstk aws codeartifact create-repository --domain demo-domain \
     --repository demo-repo
 ```
 
@@ -118,7 +118,7 @@ awslocal codeartifact create-repository --domain demo-domain \
 You can use the [`DescribeRepository`](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_DescribeRepository.html), [`UpdateRepository`](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_UpdateRepository.html), and [`DeleteRepository`](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_DeleteRepository.html) APIs to manage repositories.
 
 ```bash
-awslocal codeartifact describe-repository --domain demo-domain \
+lstk aws codeartifact describe-repository --domain demo-domain \
     --repository demo-repo
 ```
 
@@ -140,7 +140,7 @@ awslocal codeartifact describe-repository --domain demo-domain \
 Use the [`ListRepositories`](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_ListRepositories.html) API to view all of the repositories.
 
 ```bash
-awslocal codeartifact list-repositories
+lstk aws codeartifact list-repositories
 ```
 
 ```json title="Output"
@@ -161,7 +161,7 @@ awslocal codeartifact list-repositories
 Otherwise, list repositories in a specific domain using the [`ListRepositoriesInDomain`](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_ListRepositoriesInDomain.html) API.
 
 ```bash
-awslocal codeartifact list-repositories-in-domain --domain demo-domain
+lstk aws codeartifact list-repositories-in-domain --domain demo-domain
 ```
 
 ```json title="Output"
@@ -191,7 +191,7 @@ This makes it possible to consume open-source dependencies used by your applicat
 Repositories can be associated with external connections using [AssociateExternalConnection](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_AssociateExternalConnection.html) and [DisassociateExternalConnection](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_DisassociateExternalConnection.html) APIs.
 
 ```bash
-awslocal codeartifact associate-external-connection --domain demo-domain \
+lstk aws codeartifact associate-external-connection --domain demo-domain \
     --repository demo-repo \
     --external-connection "public:npmjs"
 ```
@@ -220,7 +220,7 @@ awslocal codeartifact associate-external-connection --domain demo-domain \
 Alternatively, repositories can be configured with upstream repositories using the `upstreams` property of [CreateRepository](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_CreateRepository.html) and [UpdateRepository](https://docs.aws.amazon.com/codeartifact/latest/APIReference/API_UpdateRepository.html).
 
 ```bash
-awslocal codeartifact create-repository --domain demo-domain \
+lstk aws codeartifact create-repository --domain demo-domain \
     --repository demo-repo2 \
     --upstreams repositoryName=demo-repo
 ```
@@ -252,10 +252,10 @@ Please note, a repository can have one or more upstream repositories, or an exte
 
 ### Configuring npm with the login command
 
-Use the `awslocal codeartifact login` command to fetch credentials for use with npm.
+Use the `lstk aws codeartifact login` command to fetch credentials for use with npm.
 
 ```bash
-awslocal codeartifact login --tool npm --domain demo-domain --repository demo-repo
+lstk aws codeartifact login --tool npm --domain demo-domain --repository demo-repo
 ```
 
 This command makes the following changes to your `~/.npmrc` file:
@@ -269,20 +269,20 @@ For more information about the authorization token created with the login comman
 
 ### Configuring npm manually
 
-You can configure npm with your CodeArtifact repository without the `awslocal codeartifact login` command by manually updating the npm configuration.
+You can configure npm with your CodeArtifact repository without the `lstk aws codeartifact login` command by manually updating the npm configuration.
 
 1. In a command line, fetch a CodeArtifact authorization token and store it in an environment variable.
   npm will use this token to authenticate with your CodeArtifact repository.
 
     ```bash
-    export CODEARTIFACT_AUTH_TOKEN=$(awslocal codeartifact get-authorization-token --domain demo-domain --query authorizationToken --output text)
+    export CODEARTIFACT_AUTH_TOKEN=$(lstk aws codeartifact get-authorization-token --domain demo-domain --query authorizationToken --output text)
     ```
 
 2. Get your CodeArtifact repository's endpoint by running the following command.
   Your repository endpoint is used to point npm to your repository to install or publish packages.
 
     ```bash
-    awslocal codeartifact get-repository-endpoint --domain demo-domain --repository demo-repo --format npm --output text
+    lstk aws codeartifact get-repository-endpoint --domain demo-domain --repository demo-repo --format npm --output text
     ```
 
     The following URL is an example repository endpoint.

--- a/src/content/docs/aws/services/codebuild.mdx
+++ b/src/content/docs/aws/services/codebuild.mdx
@@ -22,7 +22,7 @@ AWS CodeBuild emulation is powered by the [AWS CodeBuild agent](https://docs.aws
 
 This tutorial will show you how to use AWS CodeBuild to test and build a deployable version of a Java executable.
 
-It assumes basic knowledge of the [`awslocal`](https://github.com/localstack/awscli-local) wrapper, Apache Maven, and Java.
+It assumes basic knowledge of the [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command, Apache Maven, and Java.
 
 ### Create the source code
 
@@ -178,8 +178,8 @@ Now we have to create two S3 buckets:
 Create the buckets with the following commands:
 
 ```bash
-awslocal s3 mb s3://codebuild-demo-input
-awslocal s3 mb s3://codebuild-demo-output
+lstk aws s3 mb s3://codebuild-demo-input
+lstk aws s3 mb s3://codebuild-demo-output
 ```
 
 Finally, zip the content of the source code directory and upload it to the created source bucket.
@@ -192,7 +192,7 @@ zip -r MessageUtil.zip <source-directory>
 Then, upload `MessageUtil.zip` to the `codebuild-demo-input` bucket with the following command:
 
 ```bash
-awslocal s3 cp MessageUtil.zip s3://codebuild-demo-input
+lstk aws s3 cp MessageUtil.zip s3://codebuild-demo-input
 ```
 
 ### Configuring IAM
@@ -218,7 +218,7 @@ Create a `create-role.json` file with following content:
 Then, run the following command to create the necessary IAM role:
 
 ```bash
-awslocal iam create-role --role-name CodeBuildServiceRole --assume-role-policy-document file://create-role.json
+lstk aws iam create-role --role-name CodeBuildServiceRole --assume-role-policy-document file://create-role.json
 ```
 
 From the command's response, keep note of the role ARN:
@@ -282,7 +282,7 @@ Create a `put-role-policy.json` file with the following content:
 Finally, assign the policy to the role with the following command:
 
 ```bash
-awslocal put-role-policy \
+lstk aws put-role-policy \
     --role-name CodeBuildServiceRole \
     --policy-name CodeBuildServiceRolePolicy \
     --policy-document file://put-role-policy.json
@@ -296,7 +296,7 @@ You can use the CLI to generate the skeleton of the `CreateBuild` request, which
 Save the output of the following command to a file named `create-project.json`.
 
 ```bash
-awslocal codebuild create-project --generate-cli-skeleton
+lstk aws codebuild create-project --generate-cli-skeleton
 ```
 
 From the generated file, change the source and the artifact location to match the S3 bucket names you just created.
@@ -325,7 +325,7 @@ Similarly, fill in the ARN of the CodeBuild service role.
 Now create the project with the following command:
 
 ```bash
-awslocal codebuild create-project --cli-input-json file://create-project.json
+lstk aws codebuild create-project --cli-input-json file://create-project.json
 ```
 
 You have now created a CodeBuild project called `codebuild-demo-project` that uses the S3 buckets you just created as source and artifact.
@@ -340,7 +340,7 @@ See the [Build Environments](#build-environments) section for more details.
 In this final step, you can now execute your build with the following command:
 
 ```bash
-awslocal codebuild start-build --project-name codebuild-demo-project
+lstk aws codebuild start-build --project-name codebuild-demo-project
 ```
 
 Make note of the `id` information given in output, since it can be used to query the status of the build.
@@ -350,7 +350,7 @@ This container will be responsible to start a Docker compose stack that executes
 As said, you can inspect the status of the build with the following command:
 
 ```bash
-awslocal codebuild batch-get-builds --ids <build-id>
+lstk aws codebuild batch-get-builds --ids <build-id>
 ```
 
 The command returns a list of builds.
@@ -365,7 +365,7 @@ Currently, it reports only the final status of the build.
 Once the build is completed, you can verify that the JAR artifact has been uploaded to the correct S3 bucket with the following command:
 
 ```bash
-awslocal s3 ls s3://codebuild-demo-output
+lstk aws s3 ls s3://codebuild-demo-output
 ```
 
 

--- a/src/content/docs/aws/services/codecommit.mdx
+++ b/src/content/docs/aws/services/codecommit.mdx
@@ -19,7 +19,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to CodeCommit and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to CodeCommit and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can create a CodeCommit repository, clone a repository, and push a commit to the repository.
@@ -32,7 +32,7 @@ You need to specify the repository name, repository description, and tags.
 Run the following command to create a new repository named `localstack-repo`:
 
 ```bash
-awslocal codecommit create-repository \
+lstk aws codecommit create-repository \
     --repository-name localstack-repo \
     --repository-description "A demo repository to showcase LocalStack's CodeCommit" \
     --tags Team=LocalStack

--- a/src/content/docs/aws/services/codeconnections.mdx
+++ b/src/content/docs/aws/services/codeconnections.mdx
@@ -20,7 +20,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to CodeConnections and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to CodeConnections and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a connection to a code repository using the CodeConnections API.
@@ -30,7 +30,7 @@ We will demonstrate how to create a connection to a code repository using the Co
 You can create a connection to a code repository using the [`CreateConnection`](https://docs.aws.amazon.com/codeconnections/latest/APIReference/API_CreateConnection.html) API.
 
 ```bash
-awslocal codeconnections create-connection \
+lstk aws codeconnections create-connection \
     --connection-name my-connection
 ```
 
@@ -46,7 +46,7 @@ You should see the connection in the output.
 You can list connections using the [`ListConnections`](https://docs.aws.amazon.com/codeconnections/latest/APIReference/API_ListConnections.html) API.
 
 ```bash
-awslocal codeconnections list-connections
+lstk aws codeconnections list-connections
 ```
 
 ```bash title="Output"
@@ -68,7 +68,7 @@ awslocal codeconnections list-connections
 You can get a connection using the [`GetConnection`](https://docs.aws.amazon.com/codeconnections/latest/APIReference/API_GetConnection.html) API.
 
 ```bash
-awslocal codeconnections get-connection --connection-arn arn:aws:codeconnections:us-east-1:000000000000:connection/023ff7e3
+lstk aws codeconnections get-connection --connection-arn arn:aws:codeconnections:us-east-1:000000000000:connection/023ff7e3
 ```
 
 Replace the `connection-arn` with the ARN of the connection you want to get.
@@ -90,7 +90,7 @@ Replace the `connection-arn` with the ARN of the connection you want to get.
 You can delete a connection using the [`DeleteConnection`](https://docs.aws.amazon.com/codeconnections/latest/APIReference/API_DeleteConnection.html) API.
 
 ```bash
-awslocal codeconnections delete-connection --connection-arn arn:aws:codeconnections:us-east-1:000000000000:connection/023ff7e3
+lstk aws codeconnections delete-connection --connection-arn arn:aws:codeconnections:us-east-1:000000000000:connection/023ff7e3
 ```
 
 Replace the `connection-arn` with the ARN of the connection you want to delete.

--- a/src/content/docs/aws/services/codedeploy.mdx
+++ b/src/content/docs/aws/services/codedeploy.mdx
@@ -19,7 +19,7 @@ The supported operations are listed on the [API Coverage section](#api-coverage)
 
 This guide will walk through the process of creating CodeDeploy applications, deployment configuration, deployment groups, and deployments.
 
-Basic knowledge of the AWS CLI and the [`awslocal`](https://github.com/localstack/awscli-local) wrapper is expected.
+Basic knowledge of the AWS CLI and the [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command is expected.
 
 Start LocalStack using your preferred method.
 
@@ -29,7 +29,7 @@ An application is a CodeDeploy construct that uniquely identifies your targetted
 Create an application with the [CreateApplication](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_CreateApplication.html) operation:
 
 ```bash
-awslocal deploy create-application --application-name hello --compute-platform Server
+lstk aws deploy create-application --application-name hello --compute-platform Server
 ```
 
 ```bash title="Output"
@@ -41,7 +41,7 @@ awslocal deploy create-application --application-name hello --compute-platform S
 Make note of the application name, which can be used with other operations such as [GetApplication](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_GetApplication.html), [UpdateApplication](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_UpdateApplication.html) and [DeleteApplication](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_DeleteApplication.html).
 
 ```bash
-awslocal deploy get-application --application-name hello
+lstk aws deploy get-application --application-name hello
 ```
 
 ```bash title="Output"
@@ -58,7 +58,7 @@ awslocal deploy get-application --application-name hello
 You can list all application using [ListApplications](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_ListApplications.html).
 
 ```bash
-awslocal deploy list-applications
+lstk aws deploy list-applications
 ```
 
 ```bash title="Output"
@@ -76,7 +76,7 @@ A deployment configuration consists of rules for deployment along with success a
 Create a deployment configuration using [CreateDeploymentConfig](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_CreateDeploymentConfig.html):
 
 ```bash
-awslocal deploy create-deployment-config --deployment-config-name hello-conf \
+lstk aws deploy create-deployment-config --deployment-config-name hello-conf \
     --compute-platform Server  \
     --minimum-healthy-hosts '{"type": "HOST_COUNT", "value": 1}'
 ```
@@ -90,7 +90,7 @@ awslocal deploy create-deployment-config --deployment-config-name hello-conf \
 [ListDeploymentConfigs](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_ListDeploymentConfigs.html) can be used to list all available configs:
 
 ```bash
-awslocal deploy list-deployment-configs
+lstk aws deploy list-deployment-configs
 ```
 
 ```bash title="Output"
@@ -104,7 +104,7 @@ awslocal deploy list-deployment-configs
 Use [GetDeploymentConfig](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_GetDeploymentConfig.html) and [DeleteDeploymentConfig](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_DeleteDeploymentConfig.html) to manage deployment configurations.
 
 ```bash
-awslocal deploy get-deployment-config --deployment-config-name hello-conf
+lstk aws deploy get-deployment-config --deployment-config-name hello-conf
 ```
 
 ```bash title="Output"
@@ -135,7 +135,7 @@ Deployment groups can be managed with:
 Create a deployment group with [CreateDeploymentGroup](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_CreateDeploymentGroup.html):
 
 ```bash
-awslocal deploy create-deployment-group \
+lstk aws deploy create-deployment-group \
     --application-name hello \
     --service-role-arn arn:aws:iam::000000000000:role/role \
     --deployment-group-name hello-group
@@ -150,7 +150,7 @@ awslocal deploy create-deployment-group \
 List all deployment groups for an application with [ListDeploymentGroups](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_ListDeploymentGroups.html):
 
 ```bash
-awslocal deploy list-deployment-groups --application-name hello
+lstk aws deploy list-deployment-groups --application-name hello
 ```
 
 ```bash title="Output"
@@ -164,7 +164,7 @@ awslocal deploy list-deployment-groups --application-name hello
 Get a deployment group with [GetDeploymentGroup](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_GetDeploymentGroup.html):
 
 ```bash
-awslocal deploy get-deployment-group --application-name hello \
+lstk aws deploy get-deployment-group --application-name hello \
     --deployment-group-name hello-group
 ```
 
@@ -200,7 +200,7 @@ Operations related to deployment management are:
 Create a deployment with [CreateDeployment](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_CreateDeployment.html):
 
 ```bash
-awslocal deploy create-deployment \
+lstk aws deploy create-deployment \
     --application-name hello \
     --deployment-group-name hello-group \
     --revision '{"revisionType": "S3", "s3Location": {"bucket": "placeholder", "key": "placeholder", "bundleType": "tar"}}'
@@ -215,7 +215,7 @@ awslocal deploy create-deployment \
 List all deployments for an application with [ListDeployments](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_ListDeployments.html):
 
 ```bash
-awslocal deploy list-deployments
+lstk aws deploy list-deployments
 ```
 
 ```bash title="Output"
@@ -229,7 +229,7 @@ awslocal deploy list-deployments
 Get a deployment with [GetDeployment](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_GetDeployment.html):
 
 ```bash
-awslocal deploy get-deployment --deployment-id d-TU3TNCSTO
+lstk aws deploy get-deployment --deployment-id d-TU3TNCSTO
 ```
 
 ```bash title="Output"
@@ -269,13 +269,13 @@ Furthermore, [ContinueDeployment](https://docs.aws.amazon.com/codedeploy/latest/
 Continue a deployment with [ContinueDeployment](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_StopDeployment.html):
 
 ```bash
-awslocal deploy continue-deployment --deployment-id d-TU3TNCSTO
+lstk aws deploy continue-deployment --deployment-id d-TU3TNCSTO
 ```
 
 Stop a deployment with [StopDeployment](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_StopDeployment.html):
 
 ```bash
-awslocal deploy stop-deployment --deployment-id d-TU3TNCSTO
+lstk aws deploy stop-deployment --deployment-id d-TU3TNCSTO
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/codepipeline.mdx
+++ b/src/content/docs/aws/services/codepipeline.mdx
@@ -18,7 +18,7 @@ The available operations can be found on the [API coverage](#api-coverage) page.
 ## Getting started
 
 In this guide, we will create a simple pipeline that fetches an object from an S3 bucket and uploads it to a different S3 bucket.
-It is for users that are new to CodePipeline and have a basic knowledge of the AWS CLI and the [`awslocal`](https://github.com/localstack/awscli-local) wrapper.
+It is for users that are new to CodePipeline and have a basic knowledge of the AWS CLI and the [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start LocalStack using your preferred method.
 
@@ -27,15 +27,15 @@ Start LocalStack using your preferred method.
 Begin by creating the S3 buckets that will serve as the source and target.
 
 ```bash
-awslocal s3 mb s3://source-bucket
-awslocal s3 mb s3://target-bucket
+lstk aws s3 mb s3://source-bucket
+lstk aws s3 mb s3://target-bucket
 ```
 
 It is important to note the CodePipeline requires source S3 buckets to have versioning enabled.
 This can be done using the S3 [`PutBucketVersioning`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html) operation.
 
 ```bash
-awslocal s3api put-bucket-versioning \
+lstk aws s3api put-bucket-versioning \
     --bucket source-bucket \
     --versioning-configuration Status=Enabled
 ```
@@ -44,13 +44,13 @@ Now create a placeholder file that will flow through the pipeline and upload it 
 
 ```bash
 echo "Hello LocalStack!" > file
-awslocal s3 cp file s3://source-bucket
+lstk aws s3 cp file s3://source-bucket
 ```
 
 Pipelines also require an artifact store, which is also an S3 bucket that is used as intermediate storage.
 
 ```bash
-awslocal s3 mb s3://artifact-store-bucket
+lstk aws s3 mb s3://artifact-store-bucket
 ```
 
 ### Configure IAM
@@ -80,7 +80,7 @@ Create the role and make note of the role ARN:
 Create the role with the following command:
 
 ```bash
-awslocal iam create-role --role-name role --assume-role-policy-document file://role.json | jq .Role.Arn
+lstk aws iam create-role --role-name role --assume-role-policy-document file://role.json | jq .Role.Arn
 ```
 
 Now add a permissions policy to this role that permits read and write access to S3.
@@ -105,7 +105,7 @@ The permissions in the above example policy are relatively broad.
 You might want to use a more focused policy for better security on production systems.
 
 ```bash
-awslocal iam put-role-policy --role-name role --policy-name policy --policy-document file://policy.json
+lstk aws iam put-role-policy --role-name role --policy-name policy --policy-document file://policy.json
 ```
 
 ### Create pipeline
@@ -193,7 +193,7 @@ These correspond to the resources we created earlier.
 Create the pipeline using the following command:
 
 ```bash
-awslocal codepipeline create-pipeline --pipeline file://./declaration.json
+lstk aws codepipeline create-pipeline --pipeline file://./declaration.json
 ```
 
 ### Verify pipeline execution
@@ -204,7 +204,7 @@ The [`CreatePipeline`](https://docs.aws.amazon.com/codepipeline/latest/APIRefere
 This can be confirmed using:
 
 ```bash
-awslocal codepipeline list-pipeline-executions --pipeline-name pipeline
+lstk aws codepipeline list-pipeline-executions --pipeline-name pipeline
 ```
 
 ```bash title="Output"
@@ -231,7 +231,7 @@ The above pipeline execution was successful.
 This means that we can retrieve the `output-file` object from the `target-bucket` S3 bucket.
 
 ```bash
-awslocal s3 cp s3://target-bucket/output-file output-file
+lstk aws s3 cp s3://target-bucket/output-file output-file
 ```
 
 To verify that it is the same file as the original input:
@@ -252,7 +252,7 @@ Using the [`ListActionExecutions`](https://docs.aws.amazon.com/codepipeline/late
 This is useful when debugging the pipeline.
 
 ```bash
-awslocal codepipeline list-action-executions --pipeline-name pipeline
+lstk aws codepipeline list-action-executions --pipeline-name pipeline
 ```
 
 ```bash title="Output"
@@ -354,11 +354,11 @@ Pipelines resources can be [tagged](https://docs.aws.amazon.com/codepipeline/lat
 Tag the pipeline with the following command:
 
 ```bash
-awslocal codepipeline tag-resource \
+lstk aws codepipeline tag-resource \
     --resource-arn arn:aws:codepipeline:eu-central-1:000000000000:pipeline \
     --tags key=purpose,value=tutorial
 
-awslocal codepipeline list-tags-for-resource \
+lstk aws codepipeline list-tags-for-resource \
     --resource-arn arn:aws:codepipeline:eu-central-1:000000000000:pipeline
 ```
 
@@ -376,7 +376,7 @@ awslocal codepipeline list-tags-for-resource \
 Untag the pipeline with the following command:
 
 ```bash
-awslocal codepipeline untag-resource \
+lstk aws codepipeline untag-resource \
     --resource-arn arn:aws:codepipeline:eu-central-1:000000000000:pipeline \
     --tag-keys purpose
 ```

--- a/src/content/docs/aws/services/cognito-idp.mdx
+++ b/src/content/docs/aws/services/cognito-idp.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [Cognito Identity coverage section](#api
 
 ## Getting started
 
-This guide is designed for users new to Cognito and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Cognito and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can create a Cognito user pool and client, and then sign up and authenticate a new user in the pool.
@@ -29,7 +29,7 @@ To create a user pool, you can use the [`CreateUserPool`](https://docs.aws.amazo
 The following command creates a user pool named `test`:
 
 ```bash
-awslocal cognito-idp create-user-pool --pool-name test
+lstk aws cognito-idp create-user-pool --pool-name test
 ```
 
 ```bash title="Output"
@@ -72,7 +72,7 @@ pool_id=<your-pool-id>
 Alternatively, you can use JSON processor like [`jq`](https://stedolan.github.io/jq/) to extract the essential information right from the outset when creating a pool.
 
 ```bash
-pool_id=$(awslocal cognito-idp create-user-pool --pool-name test | jq -rc ".UserPool.Id")
+pool_id=$(lstk aws cognito-idp create-user-pool --pool-name test | jq -rc ".UserPool.Id")
 ```
 
 ### Adding a Client
@@ -83,7 +83,7 @@ You can use the [`CreateUserPoolClient`](https://docs.aws.amazon.com/cognito-use
 Run the following command:
 
 ```bash
-client_id=$(awslocal cognito-idp create-user-pool-client --user-pool-id $pool_id --client-name test-client | jq -rc ".UserPoolClient.ClientId")
+client_id=$(lstk aws cognito-idp create-user-pool-client --user-pool-id $pool_id --client-name test-client | jq -rc ".UserPoolClient.ClientId")
 ```
 
 ### Using Predefined IDs for Pool Creation
@@ -95,7 +95,7 @@ Please note that a valid custom id must be in the format `<region>_<custom_pool_
 Run the following command to create a user pool with a predefined ID:
 
 ```bash
-awslocal cognito-idp create-user-pool --pool-name p1 --user-pool-tags "_custom_id_=us-east-1_myid123"
+lstk aws cognito-idp create-user-pool --pool-name p1 --user-pool-tags "_custom_id_=us-east-1_myid123"
 ```
 
 ```bash title="Output"
@@ -109,7 +109,7 @@ awslocal cognito-idp create-user-pool --pool-name p1 --user-pool-tags "_custom_i
 You also have the possibility to create a Cognito user pool client with a predefined ID by specifying a `ClientName` with the specific format: `_custom_id_:<custom_client_id>`.
 
 ```bash
-awslocal cognito-idp create-user-pool-client --user-pool-id us-east-1_myid123 --client-name _custom_id_:myclient123
+lstk aws cognito-idp create-user-pool-client --user-pool-id us-east-1_myid123 --client-name _custom_id_:myclient123
 ```
 
 ```bash title="Output"
@@ -127,7 +127,7 @@ You can now use the [`SignUp`](https://docs.aws.amazon.com/cognito-user-identity
 Run the following command:
 
 ```bash
-awslocal cognito-idp sign-up \
+lstk aws cognito-idp sign-up \
   --client-id $client_id \
   --username example_user \
   --password 12345678Aa! \
@@ -154,7 +154,7 @@ You can confirm the user with the activation code, using the [`ConfirmSignUp`](h
 Execute the following command:
 
 ```bash
-awslocal cognito-idp confirm-sign-up \
+lstk aws cognito-idp confirm-sign-up \
   --client-id $client_id \
   --username example_user \
   --confirmation-code <received-confirmation-code>
@@ -164,7 +164,7 @@ Since the above command does not provide a direct response, we need to verify th
 Run the following command to use the [`ListUsers`](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ListUsers.html) API to list the users in the pool:
 
 ```bash
-awslocal cognito-idp list-users --user-pool-id $pool_id
+lstk aws cognito-idp list-users --user-pool-id $pool_id
 ```
 
 ```bash title="Output"
@@ -218,7 +218,7 @@ First, enable software token MFA at the pool level.
 Setting `MfaConfiguration` to `OPTIONAL` enforces MFA per-user based on their preferences:
 
 ```bash
-awslocal cognito-idp set-user-pool-mfa-config \
+lstk aws cognito-idp set-user-pool-mfa-config \
   --user-pool-id $pool_id \
   --software-token-mfa-configuration Enabled=true \
   --mfa-configuration OPTIONAL
@@ -228,7 +228,7 @@ Sign in once to obtain an access token, then associate a software token for the 
 This returns a `SecretCode` that you register in your authenticator app:
 
 ```bash
-awslocal cognito-idp associate-software-token --access-token <access-token>
+lstk aws cognito-idp associate-software-token --access-token <access-token>
 ```
 
 ```bash title="Output"
@@ -240,11 +240,11 @@ awslocal cognito-idp associate-software-token --access-token <access-token>
 Verify the token by submitting a code generated from the secret, then set the software token as the user's preferred MFA factor:
 
 ```bash
-awslocal cognito-idp verify-software-token \
+lstk aws cognito-idp verify-software-token \
   --access-token <access-token> \
   --user-code <totp-code>
 
-awslocal cognito-idp set-user-mfa-preference \
+lstk aws cognito-idp set-user-mfa-preference \
   --access-token <access-token> \
   --software-token-mfa-settings Enabled=true,PreferredMfa=true
 ```
@@ -252,7 +252,7 @@ awslocal cognito-idp set-user-mfa-preference \
 On the next sign-in, the authentication flow now returns a `SOFTWARE_TOKEN_MFA` challenge instead of issuing tokens directly:
 
 ```bash
-awslocal cognito-idp initiate-auth \
+lstk aws cognito-idp initiate-auth \
   --client-id $client_id \
   --auth-flow USER_PASSWORD_AUTH \
   --auth-parameters USERNAME=example_user,PASSWORD=12345678Aa!
@@ -271,7 +271,7 @@ awslocal cognito-idp initiate-auth \
 Respond to the challenge with a fresh TOTP code to complete authentication:
 
 ```bash
-awslocal cognito-idp respond-to-auth-challenge \
+lstk aws cognito-idp respond-to-auth-challenge \
   --client-id $client_id \
   --challenge-name SOFTWARE_TOKEN_MFA \
   --session <session> \
@@ -286,7 +286,7 @@ Enable email MFA at the pool level by providing an `EmailMfaConfiguration`.
 The configuration is persisted and returned by [`GetUserPoolMfaConfig`](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_GetUserPoolMfaConfig.html):
 
 ```bash
-awslocal cognito-idp set-user-pool-mfa-config \
+lstk aws cognito-idp set-user-pool-mfa-config \
   --user-pool-id $pool_id \
   --email-mfa-configuration 'Message="Your code is {####}",Subject="Your verification code"' \
   --mfa-configuration OPTIONAL
@@ -296,7 +296,7 @@ Set email as the user's preferred MFA factor.
 The user must have a verified `email` attribute:
 
 ```bash
-awslocal cognito-idp admin-set-user-mfa-preference \
+lstk aws cognito-idp admin-set-user-mfa-preference \
   --user-pool-id $pool_id \
   --username example_user \
   --email-mfa-settings Enabled=true,PreferredMfa=true
@@ -305,7 +305,7 @@ awslocal cognito-idp admin-set-user-mfa-preference \
 `AdminGetUser` now surfaces `EMAIL_OTP` in the user's MFA settings:
 
 ```bash
-awslocal cognito-idp admin-get-user --user-pool-id $pool_id --username example_user
+lstk aws cognito-idp admin-get-user --user-pool-id $pool_id --username example_user
 ```
 
 ```bash title="Output"
@@ -340,7 +340,7 @@ INFO --- [et.reactor-0] l.p.c.s.c.auth_flows       : Code verification sent via 
 Respond to the challenge with the emailed code to complete authentication:
 
 ```bash
-awslocal cognito-idp respond-to-auth-challenge \
+lstk aws cognito-idp respond-to-auth-challenge \
   --client-id $client_id \
   --challenge-name EMAIL_OTP \
   --session <session> \
@@ -455,7 +455,7 @@ Enter the following commands to create the Lambda function:
 
 ```bash
 zip function.zip index.js
-awslocal lambda create-function \
+lstk aws lambda create-function \
     --function-name migrate_users \
     --runtime nodejs18.x \
     --zip-file fileb://function.zip \
@@ -466,7 +466,7 @@ awslocal lambda create-function \
 Subsequently, you can define the corresponding `--lambda-config` when creating the user pool to link it with the Lambda function:
 
 ```bash
-awslocal cognito-idp create-user-pool \
+lstk aws cognito-idp create-user-pool \
   --pool-name test2 \
   --lambda-config '{"UserMigration":"arn:aws:lambda:us-east-1:000000000000:function:migrate_users"}'
 ```
@@ -526,13 +526,13 @@ To get started, follow the example below:
 
 ```bash
 #Create client user pool with a client.
-export client_id=$(awslocal cognito-idp create-user-pool-client --user-pool-id $pool_id --client-name test-client --generate-secret  | jq -rc ".UserPoolClient.ClientId")
+export client_id=$(lstk aws cognito-idp create-user-pool-client --user-pool-id $pool_id --client-name test-client --generate-secret  | jq -rc ".UserPoolClient.ClientId")
 
 #Retrieve secret.
-export client_secret=$(awslocal cognito-idp describe-user-pool-client --user-pool-id $pool_id --client-id $client_id | jq -r '.UserPoolClient.ClientSecret')
+export client_secret=$(lstk aws cognito-idp describe-user-pool-client --user-pool-id $pool_id --client-id $client_id | jq -r '.UserPoolClient.ClientSecret')
 
 #Create resource server
-awslocal cognito-idp create-resource-server \
+lstk aws cognito-idp create-resource-server \
   --user-pool-id $pool_id \
   --identifier "api-client-organizations" \
   --name "Resource Server Name" \

--- a/src/content/docs/aws/services/config.mdx
+++ b/src/content/docs/aws/services/config.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Config and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Config and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to specify the resource types you want Config to record and grant it the needful permissions to access an S3 bucket and SNS topic with the AWS CLI.
@@ -30,8 +30,8 @@ The SNS topic will be used to notify you when a configuration snapshot is availa
 You can create a new S3 bucket and SNS topic using the AWS CLI:
 
 ```bash
-awslocal s3 mb s3://config-test
-awslocal sns create-topic --name config-test-topic
+lstk aws s3 mb s3://config-test
+lstk aws sns create-topic --name config-test-topic
 ```
 
 ### Create a new configuration recorder
@@ -40,7 +40,7 @@ You can now create a new configuration recorder to record configuration changes 
 Run the following command to create a new configuration recorder:
 
 ```bash
-awslocal configservice put-configuration-recorder \
+lstk aws configservice put-configuration-recorder \
     --configuration-recorder name=default,roleARN=arn:aws:iam::000000000000:role/config-role
 ```
 
@@ -54,7 +54,7 @@ You can now create a delivery channel object to deliver configuration informatio
 You have already created the S3 bucket and SNS topic, so you can now create the delivery channel object using the [`PutDeliveryChannel`](https://docs.aws.amazon.com/config/latest/APIReference/API_PutDeliveryChannel.html) API.
 
 We're going to create a delivery channel with the following configuration.
-You can inline the JSON into the `awslocal` command.
+You can inline the JSON into the `lstk aws` command.
 
 ```json
 {
@@ -70,7 +70,7 @@ You can inline the JSON into the `awslocal` command.
 Run the following command to create the delivery channel:
 
 ```bash
-awslocal configservice put-delivery-channel \
+lstk aws configservice put-delivery-channel \
     --delivery-channel '{
     "name": "default",
     "s3BucketName": "config-test",
@@ -88,15 +88,15 @@ You can use the [`StartConfigurationRecorder`](https://docs.aws.amazon.com/confi
 Run the following command to start the configuration recorder:
 
 ```bash
-awslocal configservice start-configuration-recorder \
+lstk aws configservice start-configuration-recorder \
     --configuration-recorder-name default
 ```
 
 You can list the delivery channels and configuration recorders using the [`DescribeDeliveryChannels`](https://docs.aws.amazon.com/config/latest/APIReference/API_DescribeDeliveryChannels.html) and [`DescribeConfigurationRecorderStatus`](https://docs.aws.amazon.com/config/latest/APIReference/API_DescribeConfigurationRecorderStatus.html) APIs respectively.
 
 ```bash
-awslocal configservice describe-delivery-channels
-awslocal configservice describe-configuration-recorder-status
+lstk aws configservice describe-delivery-channels
+lstk aws configservice describe-configuration-recorder-status
 ```
 
 ## Current Limitations

--- a/src/content/docs/aws/services/docdb.mdx
+++ b/src/content/docs/aws/services/docdb.mdx
@@ -19,7 +19,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 To create a new DocumentDB cluster we use the `create-db-cluster` command as follows:
 
 ```bash
-awslocal docdb create-db-cluster \
+lstk aws docdb create-db-cluster \
   --db-cluster-identifier test-docdb-cluster \
   --engine docdb
 ```
@@ -67,7 +67,7 @@ As we did not specify a `MasterUsername` or `MasterUserPassword` for the creatio
 To create a new database, we can use the `create-db-instance` command, like in this example:
 
 ```bash
-awslocal docdb create-db-instance \
+lstk aws docdb create-db-instance \
   --db-instance-identifier test-company \
   --db-instance-class db.r5.large \
   --engine docdb \
@@ -122,7 +122,7 @@ Some noticeable fields:
 To obtain detailed information about the cluster, we use the `describe-db-cluster` command:
 
 ```bash
-awslocal docdb describe-db-clusters \
+lstk aws docdb describe-db-clusters \
   --db-cluster-identifier test-docdb-cluster
 ```
 
@@ -227,7 +227,7 @@ We included a snippet at the very end.
 We assume you have a `MasterUsername` and `MasterUserPassword` set for DocDB e.g:
 
 ```bash
-awslocal docdb create-db-cluster \
+lstk aws docdb create-db-cluster \
   --db-cluster-identifier test-docdb \
    --engine docdb \
    --master-user-password S3cretPwd! \
@@ -306,10 +306,10 @@ Make sure you are inside `resources` directory and run:
 zip -r function.zip .
 ```
 
-Finally, we can create the `lambda` function using `awslocal`:
+Finally, we can create the `lambda` function using `lstk aws`:
 
 ```bash
-awslocal lambda create-function \
+lstk aws lambda create-function \
   --function-name MyNodeLambda \
   --runtime nodejs16.x \
   --role arn:aws:iam::000000000000:role/lambda-role \
@@ -321,7 +321,7 @@ awslocal lambda create-function \
 You can invoke the lambda by calling:
 
 ```bash
-awslocal lambda invoke \
+lstk aws lambda invoke \
   --function-name MyNodeLambda \
   outfile
 ```

--- a/src/content/docs/aws/services/dsql.mdx
+++ b/src/content/docs/aws/services/dsql.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Aurora DSQL and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Aurora DSQL and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a cluster, inspect it, and clean it up using the AWS CLI.
@@ -29,7 +29,7 @@ You can create a cluster using the [`CreateCluster`](https://docs.aws.amazon.com
 Run the following command to create a cluster:
 
 ```bash
-awslocal dsql create-cluster
+lstk aws dsql create-cluster
 ```
 
 ```bash title="Output"
@@ -58,7 +58,7 @@ You can retrieve the details of a cluster using the [`GetCluster`](https://docs.
 Replace the identifier with the one returned in the previous step:
 
 ```bash
-awslocal dsql get-cluster --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
+lstk aws dsql get-cluster --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
 ```
 
 ```bash title="Output"
@@ -80,7 +80,7 @@ awslocal dsql get-cluster --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
 You can list all clusters in the current account and region using the [`ListClusters`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_ListClusters.html) API:
 
 ```bash
-awslocal dsql list-clusters
+lstk aws dsql list-clusters
 ```
 
 ```bash title="Output"
@@ -130,7 +130,7 @@ Because clusters are created with deletion protection enabled, you must first di
 Attempting to delete a protected cluster returns a `ValidationException`.
 
 ```bash
-awslocal dsql update-cluster \
+lstk aws dsql update-cluster \
     --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6 \
     --no-deletion-protection-enabled
 ```
@@ -138,7 +138,7 @@ awslocal dsql update-cluster \
 You can then delete the cluster using the [`DeleteCluster`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_DeleteCluster.html) API:
 
 ```bash
-awslocal dsql delete-cluster --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
+lstk aws dsql delete-cluster --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
 ```
 
 ```bash title="Output"
@@ -155,13 +155,13 @@ awslocal dsql delete-cluster --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
 You can attach tags at creation time with `--tags`, and manage them afterwards using the [`TagResource`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_TagResource.html), [`UntagResource`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_UntagResource.html), and [`ListTagsForResource`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_ListTagsForResource.html) APIs.
 
 ```bash
-awslocal dsql create-cluster --tags Name=my-cluster,Env=dev
+lstk aws dsql create-cluster --tags Name=my-cluster,Env=dev
 ```
 
 Add or update tags on an existing cluster:
 
 ```bash
-awslocal dsql tag-resource \
+lstk aws dsql tag-resource \
     --resource-arn arn:aws:dsql:us-east-1:000000000000:cluster/8a71d298-c086-4fb4-a698-d7b4eeb657e6 \
     --tags Team=platform
 ```
@@ -169,7 +169,7 @@ awslocal dsql tag-resource \
 List the tags on a resource:
 
 ```bash
-awslocal dsql list-tags-for-resource \
+lstk aws dsql list-tags-for-resource \
     --resource-arn arn:aws:dsql:us-east-1:000000000000:cluster/8a71d298-c086-4fb4-a698-d7b4eeb657e6
 ```
 
@@ -186,7 +186,7 @@ awslocal dsql list-tags-for-resource \
 Remove tags by key:
 
 ```bash
-awslocal dsql untag-resource \
+lstk aws dsql untag-resource \
     --resource-arn arn:aws:dsql:us-east-1:000000000000:cluster/8a71d298-c086-4fb4-a698-d7b4eeb657e6 \
     --tag-keys Env
 ```
@@ -196,7 +196,7 @@ awslocal dsql untag-resource \
 You can attach a resource-based policy to a cluster using the [`PutClusterPolicy`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_PutClusterPolicy.html) API, then read and remove it with [`GetClusterPolicy`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_GetClusterPolicy.html) and [`DeleteClusterPolicy`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_DeleteClusterPolicy.html).
 
 ```bash
-awslocal dsql put-cluster-policy \
+lstk aws dsql put-cluster-policy \
     --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6 \
     --policy '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::000000000000:root"},"Action":"dsql:DbConnect","Resource":"*"}]}'
 ```
@@ -210,7 +210,7 @@ awslocal dsql put-cluster-policy \
 Retrieve the stored policy:
 
 ```bash
-awslocal dsql get-cluster-policy --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
+lstk aws dsql get-cluster-policy --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
 ```
 
 :::note
@@ -222,7 +222,7 @@ Cluster policies are stored and returned as-is but are not enforced by LocalStac
 You can manage stream metadata using the [`CreateStream`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_CreateStream.html), [`GetStream`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_GetStream.html), [`ListStreams`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_ListStreams.html), and [`DeleteStream`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_DeleteStream.html) APIs.
 
 ```bash
-awslocal dsql create-stream \
+lstk aws dsql create-stream \
     --cluster-identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6 \
     --target-definition '{"kinesis":{"streamArn":"arn:aws:kinesis:us-east-1:000000000000:stream/my-stream","roleArn":"arn:aws:iam::000000000000:role/dsql-stream-role"}}' \
     --ordering UNORDERED \
@@ -244,7 +244,7 @@ awslocal dsql create-stream \
 List the streams of a cluster:
 
 ```bash
-awslocal dsql list-streams --cluster-identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
+lstk aws dsql list-streams --cluster-identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
 ```
 
 :::note
@@ -256,7 +256,7 @@ Streams are backed as metadata only; no change-data-capture (CDC) records are em
 You can retrieve the synthesised VPC endpoint service name for a cluster using the [`GetVpcEndpointServiceName`](https://docs.aws.amazon.com/aurora-dsql/latest/APIReference/API_GetVpcEndpointServiceName.html) API:
 
 ```bash
-awslocal dsql get-vpc-endpoint-service-name --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
+lstk aws dsql get-vpc-endpoint-service-name --identifier 8a71d298-c086-4fb4-a698-d7b4eeb657e6
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/dynamodb.mdx
+++ b/src/content/docs/aws/services/dynamodb.mdx
@@ -18,7 +18,7 @@ DynamoDB emulation is powered by [DynamoDB Local](https://docs.aws.amazon.com/am
 
 ## Getting started
 
-This guide is designed for users new to DynamoDB and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to DynamoDB and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create DynamoDB table, along with its replicas, and put an item into the table using the AWS CLI.
@@ -29,7 +29,7 @@ You can create a DynamoDB table using the [`CreateTable`](https://docs.aws.amazo
 Execute the following command to create a table named `global01` with a primary key `id`:
 
 ```bash
-awslocal dynamodb create-table \
+lstk aws dynamodb create-table \
     --table-name global01 \
     --key-schema AttributeName=id,KeyType=HASH \
     --attribute-definitions AttributeName=id,AttributeType=S \
@@ -70,7 +70,7 @@ You can create replicas of a DynamoDB table using the [`UpdateTable`](https://do
 Execute the following command to create replicas in `ap-south-1` and `us-west-1` regions:
 
 ```bash
-awslocal dynamodb update-table \
+lstk aws dynamodb update-table \
     --table-name global01 \
     --replica-updates '[{"Create": {"RegionName": "eu-central-1"}}, {"Create": {"RegionName": "us-west-1"}}]' \
     --region ap-south-1
@@ -105,7 +105,7 @@ You can use the [`ListTables`](https://docs.aws.amazon.com/amazondynamodb/latest
 Run the following command to list the tables in the `eu-central-1` region:
 
 ```bash
-awslocal dynamodb list-tables \
+lstk aws dynamodb list-tables \
     --region eu-central-1
 ```
 
@@ -123,7 +123,7 @@ You can insert an item into a DynamoDB table using the [`PutItem`](https://docs.
 Execute the following command to insert an item into the `global01` table:
 
 ```bash
-awslocal dynamodb put-item \
+lstk aws dynamodb put-item \
     --table-name global01 \
     --item '{"id":{"S":"foo"}}' \
     --region eu-central-1
@@ -133,7 +133,7 @@ You can now query the number of items in the table using the [`DescribeTable`](h
 Run the following command to query the number of items in the `global01` table from a different region:
 
 ```bash
-awslocal dynamodb describe-table \
+lstk aws dynamodb describe-table \
     --table-name global01 \
     --query 'Table.ItemCount' \
     --region ap-south-1

--- a/src/content/docs/aws/services/dynamodbstreams.mdx
+++ b/src/content/docs/aws/services/dynamodbstreams.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to DynamoDB Streams and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to DynamoDB Streams and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate the following process using LocalStack:
@@ -34,7 +34,7 @@ You can create a DynamoDB table named `BarkTable` using the [`CreateTable`](http
 Run the following command to create the table:
 
 ```bash
-awslocal dynamodb create-table \
+lstk aws dynamodb create-table \
     --table-name BarkTable \
     --attribute-definitions AttributeName=Username,AttributeType=S AttributeName=Timestamp,AttributeType=S \
     --key-schema AttributeName=Username,KeyType=HASH  AttributeName=Timestamp,KeyType=RANGE \
@@ -84,7 +84,7 @@ Run the following command to create the Lambda function:
 
 ```bash
 zip index.zip index.js
-awslocal lambda create-function \
+lstk aws lambda create-function \
     --function-name publishNewBark \
     --zip-file fileb://index.zip \
     --role roleARN \
@@ -142,7 +142,7 @@ Create a new file named `payload.json` with the following content:
 Run the following command to invoke the Lambda function:
 
 ```bash
-awslocal lambda invoke \
+lstk aws lambda invoke \
     --function-name publishNewBark \
     --payload file://payload.json \
     --cli-binary-format raw-in-base64-out output.txt
@@ -161,14 +161,14 @@ You can get the stream ARN using the [`DescribeTable`](https://docs.aws.amazon.c
 Run the following command to get the stream ARN:
 
 ```bash
-awslocal dynamodb describe-table --table-name BarkTable
+lstk aws dynamodb describe-table --table-name BarkTable
 ```
 
 You can now create an event source mapping using the [`CreateEventSourceMapping`](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateEventSourceMapping.html) API.
 Run the following command to create the event source mapping:
 
 ```bash
-awslocal lambda create-event-source-mapping \
+lstk aws lambda create-event-source-mapping \
     --function-name publishNewBark \
     --event-source arn:aws:dynamodb:us-east-1:000000000000:table/BarkTable/stream/2024-07-12T06:18:37.101  \
     --batch-size 1 \
@@ -193,7 +193,7 @@ You can now test the event source mapping by adding an item to the `BarkTable` t
 Run the following command to add an item to the table:
 
 ```bash
-awslocal dynamodb put-item \
+lstk aws dynamodb put-item \
     --table-name BarkTable \
     --item Username={S="Jane Doe"},Timestamp={S="2016-11-18:14:32:17"},Message={S="Testing...1...2...3"}
 ```
@@ -206,7 +206,7 @@ You can list the streams using the [`ListStreams`](https://docs.aws.amazon.com/a
 Run the following command to list the streams:
 
 ```bash
-awslocal dynamodbstreams list-streams
+lstk aws dynamodbstreams list-streams
 ```
 
 The following output shows the list of streams:
@@ -227,7 +227,7 @@ You can also describe the stream using the [`DescribeStream`](https://docs.aws.a
 Run the following command to describe the stream:
 
 ```bash
-awslocal dynamodbstreams describe-stream \
+lstk aws dynamodbstreams describe-stream \
     --stream-arn arn:aws:dynamodb:us-east-1:000000000000:table/BarkTable/stream/2024-07-12T06:18:37.101
 ```
 

--- a/src/content/docs/aws/services/ec2.mdx
+++ b/src/content/docs/aws/services/ec2.mdx
@@ -19,7 +19,7 @@ The list of supported APIs can be found on the [API Coverage section](#api-cover
 
 ## Getting started
 
-This guide is designed for users new to EC2 and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to EC2 and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 We will demonstrate how to create an EC2 instance that runs a simple Python web server.
 LocalStack for AWS running on a Linux host is required as network access to containers is not possible on macOS.
 
@@ -33,7 +33,7 @@ To create a key pair, you can use the [`CreateKeyPair`](https://docs.aws.amazon.
 Run the following command to create the key pair and pipe the output to a file named `key.pem`:
 
 ```bash
-awslocal ec2 create-key-pair \
+lstk aws ec2 create-key-pair \
     --key-name my-key \
     --query 'KeyMaterial' \
     --output text | tee key.pem
@@ -69,7 +69,7 @@ icacls.exe key.pem /inheritance:r
 If you already have an SSH public key that you wish to use, such as the one located in your home directory at `~/.ssh/id_rsa.pub`, you can import it instead.
 
 ```bash
-awslocal ec2 import-key-pair --key-name my-key --public-key-material "$(cat ~/.ssh/id_rsa.pub)"
+lstk aws ec2 import-key-pair --key-name my-key --public-key-material "$(cat ~/.ssh/id_rsa.pub)"
 ```
 
 If you only have the SSH private key, a public key can be generated using the following command, and then imported:
@@ -85,7 +85,7 @@ You can add rules to the security group using the [`AuthorizeSecurityGroupIngres
 Run the following command to add a rule to allow inbound traffic on port 8000:
 
 ```bash
-awslocal ec2 authorize-security-group-ingress \
+lstk aws ec2 authorize-security-group-ingress \
     --group-id default \
     --protocol tcp \
     --port 8000 \
@@ -100,7 +100,7 @@ You can fetch the Security Group ID using the [`DescribeSecurityGroups`](https:/
 Run the following command to fetch the Security Group ID:
 
 ```bash
-awslocal ec2 describe-security-groups
+lstk aws ec2 describe-security-groups
 ```
 
 ```bash title="Output"
@@ -132,7 +132,7 @@ You can now run an EC2 instance using the [`RunInstances`](https://docs.aws.amaz
 Run the following command to run an EC2 instance by adding the appropriate Security Group ID that we fetched in the previous step:
 
 ```bash
-awslocal ec2 run-instances \
+lstk aws ec2 run-instances \
     --image-id ami-df5de72bdb3b \
     --count 1 \
     --instance-type t3.nano \
@@ -147,12 +147,12 @@ You can now open the LocalStack logs to find the IP address of the locally emula
 Run the following command to open the LocalStack logs:
 
 ```bash
-localstack logs
+lstk logs
 ```
 
 ```bash title="Output"
-2023-08-16T17:18:29.702  INFO --- [   asgi_gw_0] l.s.ec2.vmmanager.docker   : Instance i-b07acefd77a3c415f will be accessible via SSH at: 127.0.0.1:12862, 172.17.0.4:22
-2023-08-16T17:18:29.702  INFO --- [   asgi_gw_0] l.s.ec2.vmmanager.docker   : Instance i-b07acefd77a3c415f port mappings (container -> host): {'8000/tcp': 29043, '22/tcp': 12862}
+emulator | 2023-08-16T17:18:29.702  INFO --- [   asgi_gw_0] l.s.ec2.vmmanager.docker   : Instance i-b07acefd77a3c415f will be accessible via SSH at: 127.0.0.1:12862, 172.17.0.4:22
+emulator | 2023-08-16T17:18:29.702  INFO --- [   asgi_gw_0] l.s.ec2.vmmanager.docker   : Instance i-b07acefd77a3c415f port mappings (container -> host): {'8000/tcp': 29043, '22/tcp': 12862}
 ```
 
 You can now use the IP address to test the Python Web Server.
@@ -186,7 +186,7 @@ This section assumes that you have created or imported an SSH key pair named `my
 When running the EC2 instance, make sure to pass the `--key-name` parameter to the command:
 
 ```bash
-awslocal ec2 run-instances --key-name my-key ...
+lstk aws ec2 run-instances --key-name my-key ...
 ```
 
 Once the instance is up and running, we can use the `ssh` command to set up an SSH connection.
@@ -260,7 +260,7 @@ All LocalStack-managed Docker AMIs bear the resource tag `ec2_vm_manager:docker`
 These can be listed using:
 
 ```bash
-awslocal ec2 describe-images \
+lstk aws ec2 describe-images \
     --filters Name=tag:ec2_vm_manager,Values=docker
 ```
 
@@ -318,12 +318,12 @@ The system supports up to 32 ingress ports.
 This constraint is in place to prevent exhausting free ports on the host.
 
 ```bash
-awslocal ec2 authorize-security-group-ingress \
+lstk aws ec2 authorize-security-group-ingress \
   --group-id default \
   --protocol tcp \
   --port 8080
 
-awslocal ec2 describe-security-groups --group-names default
+lstk aws ec2 describe-security-groups --group-names default
 ```
 
 The port mapping details are provided in the logs when the instance starts up.
@@ -359,7 +359,7 @@ EOF
 We can then start an EC2 instance, specifying a block device mapping under the device name `/ebs-dev/sda1`, and pointing to our `init.sh` user data script:
 
 ```bash
-awslocal ec2 run-instances --image-id ami-ff0fea8310f3 --count 1 --instance-type t3.nano \
+lstk aws ec2 run-instances --image-id ami-ff0fea8310f3 --count 1 --instance-type t3.nano \
     --block-device-mapping '{"DeviceName":"/ebs-dev/sda1","Ebs":{"VolumeSize":10}}' \
     --user-data file://init.sh
 ```
@@ -570,7 +570,7 @@ Only the images that follow the above naming scheme will be recognised by LocalS
 These AMIs will also have the resource tag `ec2_vm_manager:libvirt`.
 
 ```bash
-awslocal ec2 describe-images --filters Name=tag:ec2_vm_manager,Values=libvirt
+lstk aws ec2 describe-images --filters Name=tag:ec2_vm_manager,Values=libvirt
 ```
 
 ### Instances

--- a/src/content/docs/aws/services/ecr.mdx
+++ b/src/content/docs/aws/services/ecr.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Elastic Container Registry and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Elastic Container Registry and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to build and push a Docker image to a local ECR repository.
@@ -77,7 +77,7 @@ You can create an ECR repository using the [`CreateRepository`](https://docs.aws
 Run the following command to create a repository named `localstack-ecr-repository`:
 
 ```bash
-awslocal ecr create-repository \
+lstk aws ecr create-repository \
     --repository-name localstack-ecr-repository \
     --image-scanning-configuration scanOnPush=true
 ```
@@ -122,7 +122,7 @@ The image will take a few seconds to push to the repository.
 You can run the following command to verify that the image was pushed successfully:
 
 ```bash
-awslocal ecr list-images --repository-name localstack-ecr-repository
+lstk aws ecr list-images --repository-name localstack-ecr-repository
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/ecs.mdx
+++ b/src/content/docs/aws/services/ecs.mdx
@@ -19,7 +19,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting Started
 
-This guide is designed for users new to ECS and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to ECS and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an ECS service using the AWS CLI
@@ -34,7 +34,7 @@ ECS tasks and services run on a cluster.
 Execute the following command to create an ECS cluster named `mycluster`:
 
 ```bash
-awslocal ecs create-cluster --cluster-name mycluster
+lstk aws ecs create-cluster --cluster-name mycluster
 ```
 
 ```bash title="Output"
@@ -90,7 +90,7 @@ To create a task definition that runs an `ubuntu` container forever (by running 
 and then run the following command:
 
 ```bash
-awslocal ecs register-task-definition --cli-input-json file://task_definition.json
+lstk aws ecs register-task-definition --cli-input-json file://task_definition.json
 ```
 
 ```bash title="Output"
@@ -150,7 +150,7 @@ This will create a number of containers in replica mode meaning they are distrib
 To create a service, execute the following command:
 
 ```bash
-awslocal ecs create-service --service-name myservice --cluster mycluster --task-definition myfamily --desired-count 1
+lstk aws ecs create-service --service-name myservice --cluster mycluster --task-definition myfamily --desired-count 1
 ```
 
 ```bash title="Output"
@@ -214,7 +214,7 @@ CONTAINER ID   IMAGE                       COMMAND                  CREATED     
 To access the generated logs from the container, run the following command:
 
 ```bash
-awslocal logs filter-log-events --log-group-name myloggroup --query 'events[].message'
+lstk aws logs filter-log-events --log-group-name myloggroup --query 'events[].message'
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/efs.mdx
+++ b/src/content/docs/aws/services/efs.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Elastic File System and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Elastic File System and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a file system, apply an IAM resource-based policy, and create a lifecycle configuration using the AWS CLI.
@@ -29,7 +29,7 @@ To create a new, empty file system you can use the [`CreateFileSystem`](https://
 Run the following command to create a new file system:
 
 ```bash
-awslocal efs create-file-system \
+lstk aws efs create-file-system \
     --performance-mode generalPurpose \
     --throughput-mode bursting \
     --encrypted \
@@ -59,7 +59,7 @@ You can also describe the locally available file systems using the [`DescribeFil
 Run the following command to describe the local file systems available:
 
 ```bash
-awslocal efs describe-file-systems
+lstk aws efs describe-file-systems
 ```
 
 You can alternatively pass the `--file-system-id` parameter to the `describe-file-system` command to retrieve information about a specific file system in AWS CLI.
@@ -70,7 +70,7 @@ You can apply an EFS `FileSystemPolicy` to an EFS file system using the [`PutFil
 Run the following command to apply a policy to the file system created in the previous step:
 
 ```bash
-awslocal efs put-file-system-policy \
+lstk aws efs put-file-system-policy \
     --file-system-id <FILE_SYSTEM_ID> \
     --policy "{\"Version\":\"2012-10-17\",\"Id\":\"ExamplePolicy01\",\"Statement\":[{\"Sid\":\"ExampleStatement01\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":[\"elasticfilesystem:ClientMount\",\"elasticfilesystem:ClientWrite\"],\"Resource\":\"arn:aws:elasticfilesystem:us-east-1:000000000000:file-system/fs-34feac549e66b814\"}]}"
 ```
@@ -79,7 +79,7 @@ You can list the file system policies using the [`DescribeFileSystemPolicy`](htt
 Run the following command to list the file system policies:
 
 ```bash
-awslocal efs describe-file-system-policy \
+lstk aws efs describe-file-system-policy \
     --file-system-id <FILE_SYSTEM_ID>
 ```
 
@@ -92,7 +92,7 @@ You can create a lifecycle configuration for an EFS file system using the [`PutL
 Run the following command to create a lifecycle configuration for the file system created in the previous step:
 
 ```bash
-awslocal efs put-lifecycle-configuration \
+lstk aws efs put-lifecycle-configuration \
     --file-system-id <FILE_SYSTEM_ID> \
     --lifecycle-policies "{\"TransitionToIA\":\"AFTER_30_DAYS\"}"
 ```

--- a/src/content/docs/aws/services/eks.mdx
+++ b/src/content/docs/aws/services/eks.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Elastic Kubernetes Service and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Elastic Kubernetes Service and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 To interact with the Kubernetes cluster, you should also install [`kubectl`](https://kubernetes.io/docs/tasks/tools/).
 
 Start your LocalStack container using your preferred method.
@@ -31,7 +31,7 @@ First we need to create a VPC for the EKS cluster. You can create a new VPC usin
 Run the following command:
 
 ```bash title="Create VPC"
-awslocal ec2 create-vpc --cidr-block 10.0.0.0/16
+lstk aws ec2 create-vpc --cidr-block 10.0.0.0/16
 ```
 
 ```bash title="Output"
@@ -50,7 +50,7 @@ Next, we need to create a subnet in the VPC. You can create a 2 subnets using th
 Run the following command:
 
 ```bash title="Create Subnet 1"
-awslocal ec2 create-subnet \
+lstk aws ec2 create-subnet \
   --vpc-id <vpc-id> \
   --cidr-block 10.0.1.0/24 \
   --availability-zone us-east-1a
@@ -69,7 +69,7 @@ awslocal ec2 create-subnet \
 ```
 
 ```bash title="Create Subnet 2"
-awslocal ec2 create-subnet \
+lstk aws ec2 create-subnet \
   --vpc-id <vpc-id> \
   --cidr-block 10.0.2.0/24 \
   --availability-zone us-east-1b
@@ -107,7 +107,7 @@ You can create a new cluster using the [`CreateCluster` API](https://docs.aws.am
 Run the following command:
 
 ```bash title="Create Cluster"
-awslocal eks create-cluster \
+lstk aws eks create-cluster \
   --name cluster1 \
   --role-arn "arn:aws:iam::000000000000:role/eks-role" \
   --resources-vpc-config '{"subnetIds":["<subnet-id-1>", "<subnet-id-2>"]}'
@@ -142,7 +142,7 @@ The cluster creation process may take a few moments as LocalStack sets up the ne
 Run the following command to wait for the cluster status to become `ACTIVE`:
 
 ```bash title="Wait for Cluster"
-awslocal eks wait cluster-active --name cluster1
+lstk aws eks wait cluster-active --name cluster1
 ```
 
 :::note
@@ -173,7 +173,7 @@ You can create a managed node group for your EKS cluster using the [`CreateNodeg
 Run the following command:
 
 ```bash title="Create Node Group"
-awslocal eks create-nodegroup \
+lstk aws eks create-nodegroup \
   --cluster-name cluster1 \
   --nodegroup-name nodegroup1 \
   --node-role arn:aws:iam::000000000000:role/eks-nodegroup-role \
@@ -216,7 +216,7 @@ The node group creation process may take a few moments as LocalStack sets up the
 You can wait for the node group status to become `ACTIVE` by running the following command:
 
 ```bash title="Wait for Node Group"
-awslocal eks wait nodegroup-active --cluster-name cluster1 --nodegroup-name nodegroup1
+lstk aws eks wait nodegroup-active --cluster-name cluster1 --nodegroup-name nodegroup1
 ```
 
 At this point, your EKS cluster is fully operational and ready to deploy workloads.
@@ -250,7 +250,7 @@ You can create a new ECR repository using the [`CreateRepository` API](https://d
 Run the following command:
 
 ```bash
-awslocal ecr create-repository --repository-name "fancier-nginx"
+lstk aws ecr create-repository --repository-name "fancier-nginx"
 ```
 
 ```bash title="Output"
@@ -296,7 +296,7 @@ Next, we can configure `kubectl` to use the EKS cluster, using the [`UpdateKubec
 Run the following command:
 
 ```bash
-awslocal eks update-kubeconfig --name cluster1 && \
+lstk aws eks update-kubeconfig --name cluster1 && \
     kubectl config use-context arn:aws:eks:us-east-1:000000000000:cluster/cluster1
 ```
 
@@ -476,7 +476,7 @@ LocalStack resolves the standard EKS AMI [SSM public parameters](https://docs.aw
 <Tabs>
   <TabItem label="AL2023">
 ```bash title="Resolve AL2023 AMI"
-awslocal ssm get-parameter \
+lstk aws ssm get-parameter \
   --name /aws/service/eks/optimized-ami/1.35/amazon-linux-2023/x86_64/standard/recommended/image_id \
   --query 'Parameter.Value' --output text
 ```
@@ -487,7 +487,7 @@ ami-eks-k3d-1.35-amd64-standard
   </TabItem>
   <TabItem label="Bottlerocket">
 ```bash title="Resolve Bottlerocket AMI"
-awslocal ssm get-parameter \
+lstk aws ssm get-parameter \
   --name /aws/service/bottlerocket/aws-k8s-1.35/x86_64/latest/image_id \
   --query 'Parameter.Value' --output text
 ```
@@ -535,7 +535,7 @@ The walkthrough below assumes a cluster named `cluster1` that is already `ACTIVE
     2. Launch an EC2 instance using the resolved AL2023 AMI and the user-data file:
 
        ```bash title="Launch AL2023 node"
-       awslocal ec2 run-instances \
+       lstk aws ec2 run-instances \
          --image-id ami-eks-k3d-1.35-amd64-standard \
          --count 1 \
          --instance-type t3.medium \
@@ -565,7 +565,7 @@ The walkthrough below assumes a cluster named `cluster1` that is already `ACTIVE
     2. Launch an EC2 instance using the resolved Bottlerocket AMI:
 
        ```bash title="Launch Bottlerocket node"
-       awslocal ec2 run-instances \
+       lstk aws ec2 run-instances \
          --image-id ami-eks-k3d-1.35-amd64 \
          --count 1 \
          --instance-type m5.large \
@@ -580,7 +580,7 @@ The walkthrough below assumes a cluster named `cluster1` that is already `ACTIVE
 Point `kubectl` at the cluster and list the nodes:
 
 ```bash
-awslocal eks update-kubeconfig --name cluster1 && \
+lstk aws eks update-kubeconfig --name cluster1 && \
   kubectl config use-context arn:aws:eks:us-east-1:000000000000:cluster/cluster1
 ```
 
@@ -667,7 +667,7 @@ By default, the Kubernetes API is assumed to run on the local TCP port `6443`.
 You can create an EKS Cluster configuration using the following command:
 
 ```bash
-awslocal eks create-cluster --name cluster1 --role-arn arn:aws:iam::000000000000:role/eks-role --resources-vpc-config '{}'
+lstk aws eks create-cluster --name cluster1 --role-arn arn:aws:iam::000000000000:role/eks-role --resources-vpc-config '{}'
 ```
 
 ```bash title="Output"
@@ -686,7 +686,7 @@ awslocal eks create-cluster --name cluster1 --role-arn arn:aws:iam::000000000000
 And check that it was created with:
 
 ```bash
-awslocal eks list-clusters
+lstk aws eks list-clusters
 ```
 
 ```bash title="Output"
@@ -713,7 +713,7 @@ If you need to customize the port or expose the load balancer on multiple ports,
 For instance, if you want to expose the load balancer on ports 8085 and 8086, you can use the following tag definition when creating the cluster:
 
 ```bash
-awslocal eks create-cluster \
+lstk aws eks create-cluster \
   --name cluster1 \
   --role-arn arn:aws:iam::000000000000:role/eks-role \
   --resources-vpc-config '{}' --tags '{"_lb_ports_":"8085,8086"}'
@@ -804,7 +804,7 @@ If you have specific directories that you want to mount from your local developm
 When creating your cluster, include the special tag `_volume_mount_`, which allows you to define the desired volume mounting configuration from your local development machine to the cluster nodes.
 
 ```bash
-awslocal eks create-cluster \
+lstk aws eks create-cluster \
   --name cluster1 \
   --role-arn arn:aws:iam::000000000000:role/eks-role \
   --resources-vpc-config '{}' \

--- a/src/content/docs/aws/services/eks.mdx
+++ b/src/content/docs/aws/services/eks.mdx
@@ -648,10 +648,18 @@ volumes:
   - "${HOME}/.kube/config:/root/.kube/config"
 ```
 
-When using the LocalStack CLI, please configure the `DOCKER_FLAGS` to mount the kubeconfig into the container:
+When using `lstk`, add the mount to your `config.toml`:
+
+```toml
+[[containers]]
+type = "aws"
+volumes = ["~/.kube/config:/root/.kube/config"]
+```
+
+Then set the environment variable and start LocalStack:
 
 ```bash
-DOCKER_FLAGS="-v ${HOME}/.kube/config:/root/.kube/config" localstack start
+LOCALSTACK_EKS_K8S_PROVIDER=local lstk start
 ```
 
 :::note
@@ -883,7 +891,7 @@ When LocalStack creates a k3d-backed EKS cluster, it starts the k3s server with 
 By default, LocalStack uses `localstack-k3d-cluster-token` as the cluster token. You can override this value using the `EKS_K3D_CLUSTER_TOKEN` configuration variable:
 
 ```bash
-EKS_K3D_CLUSTER_TOKEN=my-custom-token localstack start
+LOCALSTACK_EKS_K3D_CLUSTER_TOKEN=my-custom-token lstk start
 ```
 
 Any agent nodes added to the cluster — whether via k3d node create or k3s agent — will use the same token to authenticate with the k3s server.

--- a/src/content/docs/aws/services/elasticache.mdx
+++ b/src/content/docs/aws/services/elasticache.mdx
@@ -22,14 +22,14 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to ElastiCache and assumes basic knowledge of the AWS CLI and our `awslocal` wrapper script.
+This guide is designed for users new to ElastiCache and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 ### Single cache cluster
 
 After starting LocalStack for AWS, you can create a cluster with the following command.
 
 ```bash
-awslocal elasticache create-cache-cluster \
+lstk aws elasticache create-cache-cluster \
   --cache-cluster-id my-redis-cluster \
   --cache-node-type cache.t2.micro \
   --engine redis \
@@ -39,7 +39,7 @@ awslocal elasticache create-cache-cluster \
 Wait for it to be available, then you can use the cluster endpoint for Redis operations.
 
 ```bash
-awslocal elasticache describe-cache-clusters --show-cache-node-info --query "CacheClusters[0].CacheNodes[0].Endpoint"
+lstk aws elasticache describe-cache-clusters --show-cache-node-info --query "CacheClusters[0].CacheNodes[0].Endpoint"
 ```
 
 ```bash title="Output"
@@ -64,7 +64,7 @@ redis-cli -p 4510 get foo
 ### Replication groups in non-cluster mode
 
 ```bash
-awslocal elasticache create-replication-group \
+lstk aws elasticache create-replication-group \
   --replication-group-id my-redis-replication-group \
   --replication-group-description 'my replication group' \
   --engine redis \
@@ -76,13 +76,13 @@ Wait for it to be available.
 When running the following command, you should see one node group when running:
 
 ```bash
-awslocal elasticache describe-replication-groups --replication-group-id my-redis-replication-group
+lstk aws elasticache describe-replication-groups --replication-group-id my-redis-replication-group
 ```
 
 To retrieve the primary endpoint:
 
 ```bash
-awslocal elasticache describe-replication-groups --replication-group-id my-redis-replication-group \
+lstk aws elasticache describe-replication-groups --replication-group-id my-redis-replication-group \
   --query "ReplicationGroups[0].NodeGroups[0].PrimaryEndpoint"
 ```
 
@@ -91,7 +91,7 @@ awslocal elasticache describe-replication-groups --replication-group-id my-redis
 The cluster mode is enabled by using `--num-node-groups` and `--replicas-per-node-group`:
 
 ```bash
-awslocal elasticache create-replication-group \
+lstk aws elasticache create-replication-group \
   --engine redis \
   --replication-group-id my-clustered-redis-replication-group \
   --replication-group-description 'my clustered replication group' \
@@ -104,7 +104,7 @@ Note that the group nodes do not have a primary endpoint.
 Instead they have a `ConfigurationEndpoint`, which you can connect to using `redis-cli -c` where `-c` is for cluster mode.
 
 ```bash
-awslocal elasticache describe-replication-groups --replication-group-id my-clustered-redis-replication-group \
+lstk aws elasticache describe-replication-groups --replication-group-id my-clustered-redis-replication-group \
     --query "ReplicationGroups[0].ConfigurationEndpoint"
 ```
 
@@ -126,7 +126,7 @@ To enable full Valkey emulation:
 2. Create a cluster with the Valkey engine by including the `--engine valkey` flag in your API call:
 
 ```bash
-  awslocal elasticache create-replication-group \
+  lstk aws elasticache create-replication-group \
   --replication-group-id my-valkey-group \
   --replication-group-description "Valkey test group" \
   --engine valkey \

--- a/src/content/docs/aws/services/elasticbeanstalk.mdx
+++ b/src/content/docs/aws/services/elasticbeanstalk.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Elastic Beanstalk and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Elastic Beanstalk and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an Elastic Beanstalk application and environment with the AWS CLI.
@@ -28,7 +28,7 @@ To create an Elastic Beanstalk application, you can use the [`CreateApplication`
 Run the following command to create an application named `my-app`:
 
 ```bash
-awslocal elasticbeanstalk create-application \
+lstk aws elasticbeanstalk create-application \
     --application-name my-app
 ```
 
@@ -46,7 +46,7 @@ You can also use the [`DescribeApplications`](https://docs.aws.amazon.com/elasti
 Run the following command to retrieve information about the `my-app` application, we created earlier:
 
 ```bash
-awslocal elasticbeanstalk describe-applications \
+lstk aws elasticbeanstalk describe-applications \
     --application-names my-app
 ```
 
@@ -56,7 +56,7 @@ To create an Elastic Beanstalk environment, you can use the [`CreateEnvironment`
 Run the following command to create an environment named `my-environment`:
 
 ```bash
-awslocal elasticbeanstalk create-environment \
+lstk aws elasticbeanstalk create-environment \
     --application-name my-app \
     --environment-name my-environment
 ```
@@ -75,7 +75,7 @@ You can also use the [`DescribeEnvironments`](https://docs.aws.amazon.com/elasti
 Run the following command to retrieve information about the `my-environment` environment, we created earlier:
 
 ```bash
-awslocal elasticbeanstalk describe-environments \
+lstk aws elasticbeanstalk describe-environments \
     --environment-names my-environment
 ```
 
@@ -85,7 +85,7 @@ To create an Elastic Beanstalk application version, you can use the [`CreateAppl
 Run the following command to create an application version named `v1`:
 
 ```bash
-awslocal elasticbeanstalk create-application-version \
+lstk aws elasticbeanstalk create-application-version \
     --application-name my-app \
     --version-label v1
 ```
@@ -105,7 +105,7 @@ You can also use the [`DescribeApplicationVersions`](https://docs.aws.amazon.com
 Run the following command to retrieve information about the `v1` application version, we created earlier:
 
 ```bash
-awslocal elasticbeanstalk describe-application-versions \
+lstk aws elasticbeanstalk describe-application-versions \
     --application-name my-app
 ```
 

--- a/src/content/docs/aws/services/elb.mdx
+++ b/src/content/docs/aws/services/elb.mdx
@@ -180,7 +180,7 @@ In LocalStack, same-scheme listeners (for example, two HTTP listeners on ports 8
 To reach two same-scheme listeners on distinct ports, both ports must be published in [`GATEWAY_LISTEN`](/aws/configuration/config/configuration/#core) when starting LocalStack:
 
 ```bash
-GATEWAY_LISTEN=0.0.0.0:4566,0.0.0.0:80,0.0.0.0:8080 localstack start
+LOCALSTACK_GATEWAY_LISTEN=0.0.0.0:4566,0.0.0.0:80,0.0.0.0:8080 lstk start
 ```
 
 ### Creating multiple listeners

--- a/src/content/docs/aws/services/elb.mdx
+++ b/src/content/docs/aws/services/elb.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on the API coverage section for [ELBv1](#api-co
 
 ## Getting started
 
-This guide is designed for users new to Elastic Load Balancing and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Elastic Load Balancing and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an Application Load Balancer, along with its target group, listener, and rule, and forward requests to an IP target.
@@ -36,7 +36,7 @@ To specify the subnet and VPC in which the load balancer will be created, you ca
 In this example, we will use the subnet and VPC in the `us-east-1f` availability zone.
 
 ```bash
-subnet_info=$(awslocal ec2 describe-subnets --filters Name=availability-zone,Values=us-east-1f \
+subnet_info=$(lstk aws ec2 describe-subnets --filters Name=availability-zone,Values=us-east-1f \
     | jq -r '.Subnets[] | select(.AvailabilityZone == "us-east-1f") | {SubnetId: .SubnetId, VpcId: .VpcId}')
 
 subnet_id=$(echo $subnet_info | jq -r '.SubnetId')
@@ -48,7 +48,7 @@ To create a load balancer, you can use the [`CreateLoadBalancer`](https://docs.a
 The following command creates an Application Load Balancer named `example-lb`:
 
 ```bash
-loadBalancer=$(awslocal elbv2 create-load-balancer --name example-lb \
+loadBalancer=$(lstk aws elbv2 create-load-balancer --name example-lb \
     --subnets $subnet_id | jq -r '.LoadBalancers[]|.LoadBalancerArn')
 ```
 
@@ -58,7 +58,7 @@ To create a target group, you can use the [`CreateTargetGroup`](https://docs.aws
 The following command creates a target group named `example-target-group`:
 
 ```bash
-targetGroup=$(awslocal elbv2 create-target-group --name example-target-group \
+targetGroup=$(lstk aws elbv2 create-target-group --name example-target-group \
     --protocol HTTP --target-type ip --port 80 --vpc-id $vpc_id \
     | jq -r '.TargetGroups[].TargetGroupArn')
 ```
@@ -69,7 +69,7 @@ To register a target, you can use the [`RegisterTargets`](https://docs.aws.amazo
 The following command registers the target with the target group created in the previous step:
 
 ```bash
-awslocal elbv2 register-targets --targets Id=127.0.0.1,Port=5678,AvailabilityZone=all \
+lstk aws elbv2 register-targets --targets Id=127.0.0.1,Port=5678,AvailabilityZone=all \
     --target-group-arn $targetGroup
 ```
 
@@ -84,7 +84,7 @@ We create a listener for the load balancer using the [`CreateListener`](https://
 The following command creates a listener for the load balancer created in the previous step:
 
 ```bash
-listenerArn=$(awslocal elbv2 create-listener \
+listenerArn=$(lstk aws elbv2 create-listener \
         --protocol HTTP \
         --port 80 \
         --default-actions '{"Type":"forward","TargetGroupArn":"'$targetGroup'","ForwardConfig":{"TargetGroups":[{"TargetGroupArn":"'$targetGroup'","Weight":11}]}}' \
@@ -95,7 +95,7 @@ To create a rule for the listener, you can use the [`CreateRule`](https://docs.a
 The following command creates a rule for the listener created above:
 
 ```bash
-listenerRule=$(awslocal elbv2 create-rule \
+listenerRule=$(lstk aws elbv2 create-rule \
         --conditions Field=path-pattern,Values=/ \
         --priority 1 \
         --actions '{"Type":"forward","TargetGroupArn":"'$targetGroup'","ForwardConfig":{"TargetGroups":[{"TargetGroupArn":"'$targetGroup'","Weight":11}]}}' \
@@ -190,19 +190,19 @@ The following example uses the `subnet_id` variable set in the [Getting started]
 
 ```bash
 # Create the load balancer
-loadBalancer=$(awslocal elbv2 create-load-balancer \
+loadBalancer=$(lstk aws elbv2 create-load-balancer \
     --name multi-listener-lb \
     --subnets $subnet_id | jq -r '.LoadBalancers[].LoadBalancerArn')
 
 # Listener on port 80
-awslocal elbv2 create-listener \
+lstk aws elbv2 create-listener \
     --load-balancer-arn $loadBalancer \
     --protocol HTTP \
     --port 80 \
     --default-actions '{"Type":"fixed-response","FixedResponseConfig":{"StatusCode":"200","MessageBody":"Listener 80","ContentType":"text/plain"}}'
 
 # Listener on port 8080
-awslocal elbv2 create-listener \
+lstk aws elbv2 create-listener \
     --load-balancer-arn $loadBalancer \
     --protocol HTTP \
     --port 8080 \

--- a/src/content/docs/aws/services/emr.mdx
+++ b/src/content/docs/aws/services/emr.mdx
@@ -26,14 +26,14 @@ Alternatively, you can use one of our `*-bigdata` Docker image tags which alread
 
 ## Getting started
 
-This guide is designed for users new to EMR and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to EMR and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will create a virtual EMR cluster using the AWS CLI.
 To create an EMR cluster, run the following command:
 
 ```bash
-awslocal emr create-cluster \
+lstk aws emr create-cluster \
           --release-label emr-5.9.0 \
           --instance-groups InstanceGroupType=MASTER,InstanceCount=1,InstanceType=m4.large InstanceGroupType=CORE,InstanceCount=1,InstanceType=m4.large
 ```

--- a/src/content/docs/aws/services/es.mdx
+++ b/src/content/docs/aws/services/es.mdx
@@ -14,14 +14,14 @@ Any cluster created with the Elasticsearch Service will show up in the OpenSearc
 
 ## Creating an Elasticsearch cluster
 
-You can go ahead and use [`awslocal`](https://github.com/localstack/awscli-local) to create a new elasticsearch domain via the `aws es create-elasticsearch-domain` command.
+You can go ahead and use [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) to create a new elasticsearch domain via the `lstk aws es create-elasticsearch-domain` command.
 
 :::note
 Unless you use the Elasticsearch default version, the first time you create a cluster with a specific version, the Elasticsearch binary is downloaded, which may take a while to download.
 :::
 
 ```bash
-awslocal es create-elasticsearch-domain --domain-name my-domain
+lstk aws es create-elasticsearch-domain --domain-name my-domain
 ```
 
 ```bash title="Output"
@@ -74,7 +74,7 @@ In the LocalStack log you will see something like the following, where you can s
 and after some time, you should see that the `Processing` state of the domain is set to `false`:
 
 ```bash
-awslocal es describe-elasticsearch-domain --domain-name my-domain | jq ".DomainStatus.Processing"
+lstk aws es describe-elasticsearch-domain --domain-name my-domain | jq ".DomainStatus.Processing"
 ```
 
 ```bash title="Output"
@@ -162,7 +162,7 @@ This can be used to overwrite the behavior of the endpoint strategies described 
 You can also choose custom domains, however it is important to add the edge port (`80`/`443` or by default `4566`).
 
 ```bash
-awslocal es create-elasticsearch-domain --domain-name my-domain \
+lstk aws es create-elasticsearch-domain --domain-name my-domain \
     --elasticsearch-version 7.10 \
     --domain-endpoint-options '{ "CustomEndpoint": "http://localhost:4566/my-custom-endpoint", "CustomEndpointEnabled": true }'
 ```
@@ -265,7 +265,7 @@ volumes:
 
 2. Create the Elasticsearch domain:
     ```bash
-    awslocal es create-elasticsearch-domain \
+    lstk aws es create-elasticsearch-domain \
         --domain-name mylogs-2 \
         --elasticsearch-version 7.10 \
         --elasticsearch-cluster-config '{ "InstanceType": "m3.xlarge.elasticsearch", "InstanceCount": 4, "DedicatedMasterEnabled": true, "ZoneAwarenessEnabled": true, "DedicatedMasterType": "m3.xlarge.elasticsearch", "DedicatedMasterCount": 3}'
@@ -305,7 +305,7 @@ volumes:
 
 3. If the `Processing` status is true, it means that the cluster is not yet healthy. You can run `describe-elasticsearch-domain` to receive the status:
     ```bash
-    awslocal es describe-elasticsearch-domain --domain-name mylogs-2
+    lstk aws es describe-elasticsearch-domain --domain-name mylogs-2
     ```
 
 4. Check the cluster health endpoint and create indices:

--- a/src/content/docs/aws/services/events.mdx
+++ b/src/content/docs/aws/services/events.mdx
@@ -26,7 +26,7 @@ Any value for this variable now points to an invalid provider configuration and 
 
 ## Getting Started
 
-This guide is designed for users new to EventBridge and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to EventBridge and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate creating an EventBridge rule to run a Lambda function when a custom event is published to an event bus.
@@ -36,7 +36,7 @@ We will demonstrate creating an EventBridge rule to run a Lambda function when a
 First, create a custom EventBridge bus using the [`CreateEventBus`](https://docs.aws.amazon.com/cli/latest/reference/events/create-event-bus.html) API:
 
 ```bash
-awslocal events create-event-bus \
+lstk aws events create-event-bus \
     --name my-custom-bus
 ```
 
@@ -61,7 +61,7 @@ Run the following command to create a new Lambda function using the [`CreateFunc
 ```bash
 zip function.zip index.js
 
-awslocal lambda create-function \
+lstk aws lambda create-function \
     --function-name events-example \
     --runtime nodejs16.x \
     --zip-file fileb://function.zip \
@@ -76,7 +76,7 @@ The output will consist of the `FunctionArn`, which you will need to add the Lam
 Run the following command to create a new EventBridge rule using the [`PutRule`](https://docs.aws.amazon.com/cli/latest/reference/events/put-rule.html) API:
 
 ```bash
-awslocal events put-rule \
+lstk aws events put-rule \
     --name my-custom-rule \
     --event-bus-name my-custom-bus \
     --event-pattern '{"source":["my-source"],"detail-type":["my-detail-type"]}' \
@@ -92,7 +92,7 @@ This rule will trigger whenever an event matching this pattern is published to t
 Next, grant the EventBridge service principal (`events.amazonaws.com`) permission to run the rule, using the [`AddPermission`](https://docs.aws.amazon.com/cli/latest/reference/lambda/add-permission.html) API:
 
 ```bash
-awslocal lambda add-permission \
+lstk aws lambda add-permission \
     --function-name events-example \
     --statement-id my-custom-event \
     --action 'lambda:InvokeFunction' \
@@ -116,7 +116,7 @@ Create a file named `targets.json` with the following content:
 Finally, add the Lambda function as a target to the EventBridge rule using the [`PutTargets`](https://docs.aws.amazon.com/cli/latest/reference/events/put-targets.html) API:
 
 ```bash
-awslocal events put-targets \
+lstk aws events put-targets \
     --rule my-custom-rule \
     --event-bus-name my-custom-bus \
     --targets file://targets.json
@@ -127,7 +127,7 @@ awslocal events put-targets \
 Now, send an event that matches the rule pattern to trigger the Lambda function using the [`PutEvents`](https://docs.aws.amazon.com/cli/latest/reference/events/put-events.html) API:
 
 ```bash
-awslocal events put-events \
+lstk aws events put-events \
     --entries '[{"Source": "my-source", "DetailType": "my-detail-type", "Detail": "{\"key\": \"value\"}", "EventBusName": "my-custom-bus"}]'
 ```
 
@@ -140,24 +140,24 @@ You can verify the Lambda invocation by checking the CloudWatch logs.
 Run the following command to list the CloudWatch log groups:
 
 ```bash
-awslocal logs describe-log-groups
+lstk aws logs describe-log-groups
 ```
 
 The output will contain the log group name, which you can use to list the log streams:
 
 ```bash
-awslocal logs describe-log-streams \
+lstk aws logs describe-log-streams \
     --log-group-name /aws/lambda/events-example
 ```
 
 Alternatively, you can fetch LocalStack logs to verify the Lambda invocation:
 
 ```bash title="Output"
-localstack logs
+lstk logs
 ...
-2023-07-17T09:37:52.028  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS lambda.Invoke => 202
-2023-07-17T09:37:52.106  INFO --- [   asgi_gw_0] localstack.request.http    : POST /_localstack_lambda/97e08ac50c18930f131d9dd9744b8df4/invocations/ecb744d0-b3f2-400f-9e49-c85cf12b1e00/logs => 202
-2023-07-17T09:37:52.114  INFO --- [   asgi_gw_0] localstack.request.http    : POST /_localstack_lambda/97e08ac50c18930f131d9dd9744b8df4/invocations/ecb744d0-b3f2-400f-9e49-c85cf12b1e00/response => 202
+emulator | 2023-07-17T09:37:52.028  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS lambda.Invoke => 202
+emulator | 2023-07-17T09:37:52.106  INFO --- [   asgi_gw_0] localstack.request.http    : POST /_localstack_lambda/97e08ac50c18930f131d9dd9744b8df4/invocations/ecb744d0-b3f2-400f-9e49-c85cf12b1e00/logs => 202
+emulator | 2023-07-17T09:37:52.114  INFO --- [   asgi_gw_0] localstack.request.http    : POST /_localstack_lambda/97e08ac50c18930f131d9dd9744b8df4/invocations/ecb744d0-b3f2-400f-9e49-c85cf12b1e00/response => 202
 ...
 ```
 

--- a/src/content/docs/aws/services/firehose.mdx
+++ b/src/content/docs/aws/services/firehose.mdx
@@ -20,7 +20,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Data Firehose and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Data Firehose and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to use Firehose to load Kinesis data into Elasticsearch with S3 Backup with the AWS CLI.
@@ -31,7 +31,7 @@ You can create an Elasticsearch domain using the [`create-elasticsearch-domain`]
 Execute the following command to create a domain named `es-local`:
 
 ```bash
-awslocal es create-elasticsearch-domain --domain-name es-local
+lstk aws es create-elasticsearch-domain --domain-name es-local
 ```
 
 Save the value of the `Endpoint` field from the response, as it will be required further down to confirm the setup.
@@ -44,13 +44,13 @@ Before creating the stream, we need to create an S3 bucket to store our backup d
 You can do this using the [`mb`](https://docs.aws.amazon.com/cli/latest/reference/s3/mb.html) command:
 
 ```bash
-awslocal s3 mb s3://kinesis-activity-backup-local
+lstk aws s3 mb s3://kinesis-activity-backup-local
 ```
 
 You can now use the [`CreateStream`](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_CreateStream.html) API to create a Kinesis stream named `kinesis-es-local-stream` with two shards:
 
 ```bash
-awslocal kinesis create-stream \
+lstk aws kinesis create-stream \
   --stream-name kinesis-es-local-stream \
   --shard-count 2
 ```
@@ -72,7 +72,7 @@ However, when operating within the AWS environment, you need to check the access
 You can use the [`CreateDeliveryStream`](https://docs.aws.amazon.com/firehose/latest/APIReference/API_CreateDeliveryStream.html) API to create a Firehose delivery stream named `activity-to-elasticsearch-local`:
 
 ```bash
-awslocal firehose create-delivery-stream \
+lstk aws firehose create-delivery-stream \
   --delivery-stream-name activity-to-elasticsearch-local \
   --delivery-stream-type KinesisStreamAsSource \
   --kinesis-stream-source-configuration "KinesisStreamARN=arn:aws:kinesis:us-east-1:000000000000:stream/kinesis-es-local-stream,RoleARN=arn:aws:iam::000000000000:role/Firehose-Reader-Role" \
@@ -94,7 +94,7 @@ You can use the [`describe-elasticsearch-domain`](https://docs.aws.amazon.com/cl
 Run the following command:
 
 ```bash
-awslocal es describe-elasticsearch-domain \
+lstk aws es describe-elasticsearch-domain \
   --domain-name es-local | jq ".DomainStatus.Processing"
 ```
 
@@ -105,7 +105,7 @@ You can add data to the Kinesis stream using the [`PutRecord`](https://docs.aws.
 The following command adds a record to the stream:
 
 ```bash
-awslocal kinesis put-record \
+lstk aws kinesis put-record \
   --stream-name kinesis-es-local-stream \
   --data '{ "target": "barry" }' \
   --partition-key partition
@@ -119,7 +119,7 @@ You can use the [`PutRecord`](https://docs.aws.amazon.com/firehose/latest/APIRef
 The following command adds a record to the stream:
 
 ```bash
-awslocal firehose put-record \
+lstk aws firehose put-record \
   --delivery-stream-name activity-to-elasticsearch-local \
   --record '{ "Data": "eyJ0YXJnZXQiOiAiSGVsbG8gd29ybGQifQ==" }'
 ```

--- a/src/content/docs/aws/services/fis.mdx
+++ b/src/content/docs/aws/services/fis.mdx
@@ -43,7 +43,7 @@ Some of these events can automatically be undone after a defined time, such as s
 
 ## Getting started
 
-This guide is designed for users new to FIS and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to FIS and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an experiment that stops EC2 instances.
@@ -90,7 +90,7 @@ Nonetheless, they are obligatory fields according to AWS specifications and must
 Run the following command to create an FIS experiment template using the configuration file we just created:
 
 ```bash
-awslocal fis create-experiment-template --cli-input-json file://create-experiment.json
+lstk aws fis create-experiment-template --cli-input-json file://create-experiment.json
 ```
 
 The following output would be retrieved:
@@ -133,7 +133,7 @@ The following output would be retrieved:
 You can list all the templates you have created using the [`ListExperimentTemplates`](https://docs.aws.amazon.com/fis/latest/APIReference/API_ListExperimentTemplates.html):
 
 ```bash
-awslocal fis list-experiment-templates
+lstk aws fis list-experiment-templates
 ```
 
 ### Starting the experiment
@@ -141,7 +141,7 @@ awslocal fis list-experiment-templates
 Now let us start an EC2 instance that will match the criteria we specified in the experiment template.
 
 ```bash
-awslocal ec2 run-instances \
+lstk aws ec2 run-instances \
     --image-id ami-024f768332f0 \
     --count 1 \
     --tag-specifications '{"ResourceType": "instance", "Tags": [{"Key": "foo", "Value": "bar"}]}'
@@ -151,7 +151,7 @@ You can start the experiment using the [`StartExperiment`](https://docs.aws.amaz
 Run the following command and specify the ID of the experiment template you created earlier:
 
 ```bash
-awslocal fis start-experiment --experiment-template-id ad16589a-4a91-4aee-88df-c33446605882
+lstk aws fis start-experiment --experiment-template-id ad16589a-4a91-4aee-88df-c33446605882
 ```
 
 ```bash title="Output"
@@ -196,14 +196,14 @@ You can use the [`ListExperiments`](https://docs.aws.amazon.com/fis/latest/APIRe
 Run the following command:
 
 ```bash
-awslocal fis list-experiments
+lstk aws fis list-experiments
 ```
 
 You can fetch the details of your experiment using the [`GetExperiment`](https://docs.aws.amazon.com/fis/latest/APIReference/API_GetExperiment.html) API.
 Run the following command and specify the ID of the experiment you created earlier:
 
 ```bash
-awslocal fis get-experiment --id efee7c02-8733-4d7c-9628-1b60bbec9759
+lstk aws fis get-experiment --id efee7c02-8733-4d7c-9628-1b60bbec9759
 ```
 
 ### Verifying the outcome
@@ -212,7 +212,7 @@ You can now test that the experiment is working as expected by trying to obtain 
 Run the following command:
 
 ```bash
-awslocal ec2 describe-instance-status \
+lstk aws ec2 describe-instance-status \
     --instance-ids i-3c40b52ab72f99c63 \
     --output json \
     --query InstanceStatuses[0].InstanceState

--- a/src/content/docs/aws/services/glacier.mdx
+++ b/src/content/docs/aws/services/glacier.mdx
@@ -21,7 +21,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Glacier and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Glacier and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a vault, upload an archive, initiate a job to get an inventory details or download an archive, and delete the archive and vault with the AWS CLI.
@@ -32,14 +32,14 @@ You can create a vault using the [`CreateVault`](https://docs.aws.amazon.com/ama
 Run the follow command to create a Glacier Vault named `sample-vault`.
 
 ```bash
-awslocal glacier create-vault --vault-name sample-vault --account-id -
+lstk aws glacier create-vault --vault-name sample-vault --account-id -
 ```
 
 You can get the details from your vault using the [`DescribeVault`](https://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-get.html) API.
 Run the following command to describe your vault.
 
 ```bash
-awslocal glacier describe-vault --vault-name sample-vault --account-id -
+lstk aws glacier describe-vault --vault-name sample-vault --account-id -
 ```
 
 ```bash title="Output"
@@ -60,7 +60,7 @@ Download a random image from the internet and save it as `image.jpg`.
 Run the following command to upload the file to your Glacier vault:
 
 ```bash
-awslocal glacier upload-archive --vault-name sample-vault --account-id - --body image.jpg
+lstk aws glacier upload-archive --vault-name sample-vault --account-id - --body image.jpg
 ```
 
 ```bash title="Output"
@@ -78,7 +78,7 @@ You can initiate the retrieval of an archive from a vault using the [`InitiateJo
 To download an archive, you will need to initiate an `archive-retrieval` job first to make the Archive available for download.
 
 ```bash
-awslocal glacier initiate-job \
+lstk aws glacier initiate-job \
     --vault-name sample-vault  \
     --account-id - \
     --job-parameters '{"Type":"archive-retrieval","ArchiveId":"d41d8cd98f00b204e9800998ecf8427e"}'
@@ -96,7 +96,7 @@ awslocal glacier initiate-job \
 You can list the current and previous processes, called Jobs, to monitor the requests sent to the Glacier API using the [`ListJobs`](https://docs.aws.amazon.com/amazonglacier/latest/dev/api-jobs-get.html) API.
 
 ```bash
-awslocal glacier list-jobs --vault-name sample-vault --account-id -
+lstk aws glacier list-jobs --vault-name sample-vault --account-id -
 ```
 
 ```bash title="Output"
@@ -128,7 +128,7 @@ Once the `ArchiveRetrieval` Job is complete, the data can be downloaded.
 You can use the `JobId` of the Job to download your archive with the following command:
 
 ```bash
-awslocal glacier get-job-output \
+lstk aws glacier get-job-output \
     --vault-name sample-vault \
     --account-id - \
     --job-id 25CEOTJ7ZUR5Q7YY0B1O55AE4C3L1502EOHWMNY10IIYEBWEQB73D23S8BVYO9RTRTPLRK2LJLUCCRM52GDV87C9A4JW \
@@ -146,7 +146,7 @@ You can also initiate the retrieval of the inventory of a vault using the same [
 Initiate a job of the specified type to get the details of the individual inventory items inside a Vault using the `initiate-job` command:
 
 ```bash
-awslocal glacier initiate-job \
+lstk aws glacier initiate-job \
     --vault-name sample-vault  \
     --account-id - \
     --job-parameters '{"Type":"inventory-retrieval","ArchiveId":"d41d8cd98f00b204e9800998ecf8427e"}'
@@ -162,7 +162,7 @@ awslocal glacier initiate-job \
 In the same fashion as the archive retrieval, you can now download the result of the inventory retrieval job using `GetJobOutput` using the `JobId` from the result of the previous command:
 
 ```bash
-awslocal glacier get-job-output \
+lstk aws glacier get-job-output \
     --vault-name sample-vault \
     --account-id - \
     --job-id P5972CSWFR803BHX48OD1A7JWNBFJUMYVWCMZWY55ZJPIJMG1XWFV9ISZPZH1X3LBF0UV3UG6ORETM0EHE5R86Z47B1F \
@@ -194,7 +194,7 @@ You can delete a Glacier archive using the [`DeleteArchive`](https://docs.aws.am
 Run the following command to delete the previously created archive:
 
 ```bash
-awslocal glacier delete-archive \
+lstk aws glacier delete-archive \
     --vault-name sample-vault \
     --account-id - \
     --archive-id d41d8cd98f00b204e9800998ecf8427e
@@ -207,7 +207,7 @@ You can delete a Glacier vault with the [`DeleteVault`](https://docs.aws.amazon.
 Run the following command to delete the vault:
 
 ```bash
-awslocal glacier delete-vault \
+lstk aws glacier delete-vault \
     --vault-name sample-vault \
     --account-id -
 ```

--- a/src/content/docs/aws/services/glue.mdx
+++ b/src/content/docs/aws/services/glue.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Glue and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Glue and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create databases and table metadata in Glue, run Glue ETL jobs, import databases from Athena, and run Glue Crawlers with the AWS CLI.
@@ -32,9 +32,9 @@ These dependencies are automatically fetched when you start up the service, so p
 The commands below illustrate the creation of some very basic entries (databases, tables) in the Glue data catalog:
 
 ```bash
-awslocal glue create-database --database-input '{"Name":"db1"}'
-awslocal glue create-table --database db1 --table-input '{"Name":"table1"}'
-awslocal glue get-tables --database db1
+lstk aws glue create-database --database-input '{"Name":"db1"}'
+lstk aws glue create-table --database db1 --table-input '{"Name":"table1"}'
+lstk aws glue get-tables --database db1
 ```
 
 ```bash title="Output"
@@ -73,14 +73,14 @@ if __name__ == '__main__':
 You can now copy the script to an S3 bucket:
 
 ```bash
-awslocal s3 mb s3://glue-test
-awslocal s3 cp job.py s3://glue-test/job.py
+lstk aws s3 mb s3://glue-test
+lstk aws s3 cp job.py s3://glue-test/job.py
 ```
 
 Next, you can create a job definition:
 
 ```bash
-awslocal glue create-job \
+lstk aws glue create-job \
     --name job1 \
     --role arn:aws:iam::000000000000:role/glue-role \
     --command '{"Name": "pythonshell", "ScriptLocation": "s3://glue-test/job.py"}'
@@ -89,13 +89,13 @@ awslocal glue create-job \
 You can finally start the job execution:
 
 ```bash
-awslocal glue start-job-run --job-name job1
+lstk aws glue start-job-run --job-name job1
 ```
 
 The returned `JobRunId` can be used to query the status job the job execution, until it becomes `SUCCEEDED`:
 
 ```bash
-awslocal glue get-job-run --job-name job1 --run-id <JobRunId>
+lstk aws glue get-job-run --job-name job1 --run-id <JobRunId>
 ```
 
 ```bash title="Output"
@@ -125,14 +125,14 @@ CREATE EXTERNAL TABLE db2.table2 (a1 Date, a2 STRING, a3 INT) LOCATION 's3://tes
 Then this command will import these DB/table definitions into the Glue data catalog:
 
 ```bash
-awslocal glue import-catalog-to-glue
+lstk aws glue import-catalog-to-glue
 ```
 
 Afterwards, the databases and tables will be available in Glue.
 You can query the databases with the `get-databases` operation:
 
 ```bash
-awslocal glue get-databases
+lstk aws glue get-databases
 ```
 
 ```bash title="Output"
@@ -154,7 +154,7 @@ awslocal glue get-databases
 And you can query the databases with the `get-databases` operation:
 
 ```bash
-awslocal glue get-tables --database-name db2
+lstk aws glue get-tables --database-name db2
 ```
 
 ```bash title="Output"
@@ -190,30 +190,30 @@ The example below illustrates crawling tables and partition metadata from S3 buc
 You can first create an S3 bucket with a couple of items:
 
 ```bash
-awslocal s3 mb s3://test
+lstk aws s3 mb s3://test
 printf "1, 2, 3, 4\n5, 6, 7, 8" > /tmp/file.csv
-awslocal s3 cp /tmp/file.csv s3://test/table1/year=2021/month=Jan/day=1/file.csv
-awslocal s3 cp /tmp/file.csv s3://test/table1/year=2021/month=Jan/day=2/file.csv
-awslocal s3 cp /tmp/file.csv s3://test/table1/year=2021/month=Feb/day=1/file.csv
-awslocal s3 cp /tmp/file.csv s3://test/table1/year=2021/month=Feb/day=2/file.csv
+lstk aws s3 cp /tmp/file.csv s3://test/table1/year=2021/month=Jan/day=1/file.csv
+lstk aws s3 cp /tmp/file.csv s3://test/table1/year=2021/month=Jan/day=2/file.csv
+lstk aws s3 cp /tmp/file.csv s3://test/table1/year=2021/month=Feb/day=1/file.csv
+lstk aws s3 cp /tmp/file.csv s3://test/table1/year=2021/month=Feb/day=2/file.csv
 ```
 
 You can then create and trigger the crawler:
 
 ```bash
-awslocal glue create-database --database-input '{"Name":"db1"}'
-awslocal glue create-crawler \
+lstk aws glue create-database --database-input '{"Name":"db1"}'
+lstk aws glue create-crawler \
     --name c1 \
     --database-name db1 \
     --role arn:aws:iam::000000000000:role/glue-role \
     --targets '{"S3Targets": [{"Path": "s3://test/table1"}]}'
-awslocal glue start-crawler --name c1
+lstk aws glue start-crawler --name c1
 ```
 
 Finally, you can query the table metadata that has been created by the crawler:
 
 ```bash
-awslocal glue get-tables --database-name db1
+lstk aws glue get-tables --database-name db1
 ```
 
 ```bash title="Output"
@@ -228,7 +228,7 @@ awslocal glue get-tables --database-name db1
 You can also query the created table partitions:
 
 ```bash
-awslocal glue get-partitions --database-name db1 --table-name table1
+lstk aws glue get-partitions --database-name db1 --table-name table1
 ```
 
 ```bash title="Output"
@@ -248,7 +248,7 @@ Below is a rough outline of the steps required to get the integration for the JD
 You can first create the local Redshift cluster via:
 
 ```bash
-awslocal redshift create-cluster \
+lstk aws redshift create-cluster \
     --cluster-identifier c1 \
     --node-type dc1.large \
     --master-username test \
@@ -272,21 +272,21 @@ Then you can use any JDBC or Postgres client to create a table `mytable1` in the
 Next, you're creating the Glue database, the JDBC connection, as well as the crawler:
 
 ```bash
-awslocal glue create-database --database-input '{"Name":"gluedb1"}'
-awslocal glue create-connection --connection-input \
+lstk aws glue create-database --database-input '{"Name":"gluedb1"}'
+lstk aws glue create-connection --connection-input \
     {"Name":"conn1","ConnectionType":"JDBC","ConnectionProperties":{"USERNAME":"test","PASSWORD":"test","JDBC_CONNECTION_URL":"jdbc:redshift://localhost.localstack.cloud:4510/db1"}}'
-awslocal glue create-crawler \
+lstk aws glue create-crawler \
     --name c1 \
     --database-name gluedb1 \
     --role arn:aws:iam::000000000000:role/glue-role \
     --targets '{"JdbcTargets":[{"ConnectionName":"conn1","Path":"db1/%/mytable1"}]}'
-awslocal glue start-crawler --name c1
+lstk aws glue start-crawler --name c1
 ```
 
 Once the crawler has started, you have to wait until the `State` turns to `READY` when querying the current state:
 
 ```bash
-awslocal glue get-crawler --name c1
+lstk aws glue get-crawler --name c1
 ```
 
 Once the crawler has finished running and is back in `READY` state, the Glue table within the `gluedb1` DB should have been populated and can be queried via the API.
@@ -305,13 +305,13 @@ Support for other dataformats will be added in the future.
 You can create a schema registry with the following command:
 
 ```bash
-awslocal glue create-registry --registry-name demo-registry
+lstk aws glue create-registry --registry-name demo-registry
 ```
 
 You can create a schema in the newly created registry with the `create-schema` command:
 
 ```bash
-awslocal glue create-schema --schema-name demo-schema \
+lstk aws glue create-schema --schema-name demo-schema \
     --registry-id RegistryName=demo-registry \
     --data-format AVRO \
     --compatibility FORWARD \
@@ -338,7 +338,7 @@ awslocal glue create-schema --schema-name demo-schema \
 Once the schema has been created, you can create a new version:
 
 ```bash
-awslocal glue register-schema-version \
+lstk aws glue register-schema-version \
     --schema-id SchemaName=demo-schema,RegistryName=demo-registry \
     --schema-definition '{"type":"record","namespace":"Demo","name":"Person","fields":[{"name":"Name","type":"string"}, {"name":"Address","type":"string"}]}'
 ```
@@ -396,12 +396,12 @@ print("SQL result:", result.toJSON().collect())
 You can now run the following commands to create and start the Glue job:
 
 ```bash
-awslocal s3 mb s3://test
-awslocal s3 cp job.py s3://test/job.py
-awslocal glue create-job --name job1 --role arn:aws:iam::000000000000:role/test \
+lstk aws s3 mb s3://test
+lstk aws s3 cp job.py s3://test/job.py
+lstk aws glue create-job --name job1 --role arn:aws:iam::000000000000:role/test \
     --glue-version 4.0 \
     --command '{"Name": "pythonshell", "ScriptLocation": "s3://test/job.py"}'
-awslocal glue start-job-run --job-name job1
+lstk aws glue start-job-run --job-name job1
 ```
 
 Retrieve the job run ID from the output of the `start-job-run` command.
@@ -417,7 +417,7 @@ In order to see the logs above, make sure to enable `DEBUG=1` in the LocalStack 
 Alternatively, you can also retrieve the job logs programmatically via the CloudWatch Logs API - for example, using the job run ID from the above command.
 
 ```bash
-awslocal logs get-log-events \
+lstk aws logs get-log-events \
     --log-group-name /aws-glue/jobs/logs-v2 \
     --log-stream-name <JobRunId>
 ```

--- a/src/content/docs/aws/services/iam.mdx
+++ b/src/content/docs/aws/services/iam.mdx
@@ -19,7 +19,7 @@ The policy coverage is documented in the [IAM coverage documentation](/aws/devel
 
 ## Getting started
 
-This guide is designed for users new to IAM and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to IAM and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can create a new user named `test`, create an access key pair for the user, and assert that the user is recognized after the access keys are configured in the environment.
@@ -28,7 +28,7 @@ By default, in the absence of custom credentials configuration, all requests to 
 Run the following command to use the [`GetCallerIdentity`](https://docs.aws.amazon.com/cli/latest/reference/sts/get-caller-identity.html) API to confirm that the request is running under the root user:
 
 ```bash
-awslocal sts get-caller-identity
+lstk aws sts get-caller-identity
 ```
 
 ```bash title="Output"
@@ -43,14 +43,14 @@ You can now create a new user named `test` using the [`CreateUser`](https://docs
 Run the following command:
 
 ```bash
-awslocal iam create-user --user-name test
+lstk aws iam create-user --user-name test
 ```
 
 You can now create an access key pair for the user using the [`CreateAccessKey`](https://docs.aws.amazon.com/cli/latest/reference/iam/create-access-key.html) API.
 Run the following command:
 
 ```bash
-awslocal iam create-access-key --user-name test
+lstk aws iam create-access-key --user-name test
 ```
 
 ```bash title="Output"
@@ -71,7 +71,7 @@ Run the following command:
 
 ```bash
 export AWS_ACCESS_KEY_ID=LKIAQAAAAAAAGFWKCM5F AWS_SECRET_ACCESS_KEY=DUulXk2N2yD6rgoBBR9A/5iXa6dBcLyDknr925Q5
-awslocal sts get-caller-identity
+lstk aws sts get-caller-identity
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/identitystore.mdx
+++ b/src/content/docs/aws/services/identitystore.mdx
@@ -16,7 +16,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is aimed at users who are familiar with the AWS CLI and [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is aimed at users who are familiar with the AWS CLI and [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 It will walk you through the basics of setting up and managing groups within the AWS Identity Store using LocalStack.
 
 Start your LocalStack container using your preferred method.
@@ -28,7 +28,7 @@ You can create a new group in the Identity Store using the [`CreateGroup`](https
 Execute the following command to create a group with an identity store ID of `testls`:
 
 ```bash
-awslocal identitystore create-group --identity-store-id testls
+lstk aws identitystore create-group --identity-store-id testls
 ```
 
 ```bash title="Output"
@@ -46,7 +46,7 @@ After creating groups, you might want to list all groups within the Identity Sto
 Run the following command to list all groups using the [`ListGroups`](https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_ListGroups.html) API:
 
 ```bash
-awslocal identitystore list-groups --identity-store-id testls
+lstk aws identitystore list-groups --identity-store-id testls
 ```
 
 ```bash title="Output"
@@ -69,7 +69,7 @@ To view details about a specific group, use the [`DescribeGroup`](https://docs.a
 Run the following command to describe the group you created in the previous step:
 
 ```bash
-awslocal describe-group --identity-store-id testls --group-id 38cec731-de22-45bf-9af7-b74457bba884
+lstk aws describe-group --identity-store-id testls --group-id 38cec731-de22-45bf-9af7-b74457bba884
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/iot-data.mdx
+++ b/src/content/docs/aws/services/iot-data.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to IoT Data and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to IoT Data and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a thing, update its shadow, get its shadow, and delete its shadow using IoT Data.
@@ -28,7 +28,7 @@ You can update the shadow of a thing using the [`UpdateThingShadow`](https://doc
 Run the following command to update the shadow of a thing named `MyRPi`:
 
 ```bash
-awslocal iot-data update-thing-shadow \
+lstk aws iot-data update-thing-shadow \
     --thing-name "MyRPi" \
     --payload "{\"state\":{\"reported\":{\"moisture\":\"okay\"}}}" \
     output.txt --cli-binary-format raw-in-base64-out
@@ -61,7 +61,7 @@ You can get the shadow of a thing using the [`GetThingShadow`](https://docs.aws.
 Run the following command to get the shadow:
 
 ```bash
-awslocal iot-data get-thing-shadow \
+lstk aws iot-data get-thing-shadow \
     --thing-name "MyRPi" \
     output.txt
 ```
@@ -74,7 +74,7 @@ You can delete the shadow of a thing using the [`DeleteThingShadow`](https://doc
 Run the following command to delete the shadow:
 
 ```bash
-awslocal iot-data delete-thing-shadow \
+lstk aws iot-data delete-thing-shadow \
     --thing-name "MyRPi" \
     output.txt
 ```

--- a/src/content/docs/aws/services/iot.mdx
+++ b/src/content/docs/aws/services/iot.mdx
@@ -19,14 +19,14 @@ LocalStack ships a [Message Queuing Telemetry Transport (MQTT)](https://mqtt.org
 
 ## Getting Started
 
-This guide is for users that are new to IoT and assumes a basic knowledge of the AWS CLI and LocalStack [`awslocal`](https://github.com/localstack/awscli-local) wrapper.
+This guide is for users that are new to IoT and assumes a basic knowledge of the AWS CLI and LocalStack [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start LocalStack using your preferred method.
 
 To retrieve the MQTT endpoint, use the [`DescribeEndpoint`](https://docs.aws.amazon.com/iot/latest/apireference/API_DescribeEndpoint.html) operation.
 
 ```bash
-awslocal iot describe-endpoint
+lstk aws iot describe-endpoint
 ```
 
 ```bash title="Output"
@@ -171,7 +171,7 @@ Currently the `principalIdentifier` and `sessionIdentifier` fields in event payl
 LocalStack can publish the [registry events](https://docs.aws.amazon.com/iot/latest/developerguide/registry-events.html), if [you enable it](https://docs.aws.amazon.com/iot/latest/developerguide/iot-events.html#iot-events-enable).
 
 ```bash
-awslocal iot update-event-configurations \
+lstk aws iot update-event-configurations \
     --event-configurations '{"THING":{"Enabled": true}}'
 ```
 
@@ -221,7 +221,7 @@ const device = new iot.device({
 And configure the Lambda environment:
 
 ```bash
-awslocal lambda update-function-configuration \
+lstk aws lambda update-function-configuration \
   --function-name your-function-name \
   --environment "Variables={NODE_TLS_REJECT_UNAUTHORIZED=0}"
 ```

--- a/src/content/docs/aws/services/iotwireless.mdx
+++ b/src/content/docs/aws/services/iotwireless.mdx
@@ -16,7 +16,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to IoT Wireless and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to IoT Wireless and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to use IoT Wireless to create wireless devices and gateways with the AWS CLI.
@@ -27,7 +27,7 @@ You can create a wireless device using the [`CreateWirelessDevice`](https://docs
 Run the following command to create a wireless device:
 
 ```bash
-awslocal iotwireless create-device-profile
+lstk aws iotwireless create-device-profile
 ```
 
 The following output would be retrieved:
@@ -42,7 +42,7 @@ You can list the device profiles using the [`ListDeviceProfiles`](https://docs.a
 Run the following command to list the device profiles:
 
 ```bash
-awslocal iotwireless list-device-profiles
+lstk aws iotwireless list-device-profiles
 ```
 
 The following output would be retrieved:
@@ -63,7 +63,7 @@ You can create a wireless device using the [`CreateWirelessDevice`](https://docs
 Run the following command to create a wireless device:
 
 ```bash
-awslocal iotwireless create-wireless-device \
+lstk aws iotwireless create-wireless-device \
     --cli-input-json file://input.json
 ```
 
@@ -92,7 +92,7 @@ You can list the wireless devices using the [`ListWirelessDevices`](https://docs
 Run the following command to list the wireless devices:
 
 ```bash
-awslocal iotwireless list-wireless-devices
+lstk aws iotwireless list-wireless-devices
 ```
 
 The following output would be retrieved:
@@ -119,7 +119,7 @@ You can create a wireless gateway using the [`CreateWirelessGateway`](https://do
 Run the following command to create a wireless gateway:
 
 ```bash
-awslocal iotwireless create-wireless-gateway \
+lstk aws iotwireless create-wireless-gateway \
     --lorawan GatewayEui="a1b2c3d4567890ab",RfRegion="US915" \
     --name "myFirstLoRaWANGateway" \
     --description "Using my first LoRaWAN gateway"
@@ -137,7 +137,7 @@ You can list the wireless gateways using the [`ListWirelessGateways`](https://do
 Run the following command to list the wireless gateways:
 
 ```bash
-awslocal iotwireless list-wireless-gateways
+lstk aws iotwireless list-wireless-gateways
 ```
 
 The following output would be retrieved:

--- a/src/content/docs/aws/services/kafka.mdx
+++ b/src/content/docs/aws/services/kafka.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Managed Streaming for Kafka and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Managed Streaming for Kafka and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to configure an MSK Cluster locally, create a Kafka topic, and produce and consume messages.
@@ -45,7 +45,7 @@ Create the file and add the following content to it:
 Run the following command to create the cluster:
 
 ```bash
-awslocal kafka create-cluster \
+lstk aws kafka create-cluster \
     --cluster-name "EventsCluster" \
     --broker-node-group-info file://brokernodegroupinfo.json \
     --kafka-version "2.8.0" \
@@ -65,7 +65,7 @@ You can describe the cluster using the [`DescribeCluster`](https://docs.aws.amaz
 Run the following command, replacing `ClusterArn` with the Amazon Resource Name (ARN) you obtained above when you created cluster.
 
 ```bash
-awslocal kafka describe-cluster \
+lstk aws kafka describe-cluster \
     --cluster-arn "arn:aws:kafka:us-east-1:000000000000:cluster/EventsCluster/b154d18a-8ecb-4691-96b2-50348357fc2f-25"
 ```
 
@@ -147,7 +147,7 @@ ssl.truststore.location=/tmp/kafka.client.truststore.jks
 Run the following command, replacing `ClusterArn` with the Amazon Resource Name (ARN) you have.
 
 ```bash
-awslocal kafka get-bootstrap-brokers \
+lstk aws kafka get-bootstrap-brokers \
     --cluster-arn ClusterArn
 ```
 
@@ -197,7 +197,7 @@ The configuration for this mapping sets the starting position of the topic to `L
 Run the following command to use the [`CreateEventSourceMapping`](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateEventSourceMapping.html) API by specifying the Event Source ARN, the topic name, the starting position, and the Lambda function name.
 
 ```bash
-awslocal lambda create-event-source-mapping \
+lstk aws lambda create-event-source-mapping \
   --event-source-arn arn:aws:kafka:us-east-1:000000000000:cluster/EventsCluster \
   --topics LocalMSKTopic \
   --starting-position LATEST \
@@ -236,13 +236,13 @@ To do so, you must first obtain the ARN of the cluster you want to delete.
 Run the following command to list all the clusters in the region:
 
 ```bash
-awslocal kafka list-clusters --region us-east-1
+lstk aws kafka list-clusters --region us-east-1
 ```
 
 To initiate the deletion of a cluster, select the corresponding `ClusterARN` from the list of clusters, and then execute the following command:
 
 ```bash
-awslocal kafka delete-cluster --cluster-arn ClusterArn
+lstk aws kafka delete-cluster --cluster-arn ClusterArn
 ```
 
 ## Resource Browser

--- a/src/content/docs/aws/services/kinesis.mdx
+++ b/src/content/docs/aws/services/kinesis.mdx
@@ -19,7 +19,7 @@ Emulation for Kinesis is powered by [Kinesis Mock](https://github.com/etspaceman
 
 ## Getting started
 
-This guide is designed for users new to Kinesis Data Streams and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Kinesis Data Streams and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a Lambda function to consume events from a Kinesis stream with the AWS CLI.
@@ -45,7 +45,7 @@ Run the following command to create a Lambda function named `ProcessKinesisRecor
 
 ```bash
 zip function.zip index.mjs
-awslocal lambda create-function \
+lstk aws lambda create-function \
     --function-name ProcessKinesisRecords \
     --zip-file fileb://function.zip \
     --handler index.handler \
@@ -96,7 +96,7 @@ You can use the [`Invoke`](https://docs.aws.amazon.com/lambda/latest/dg/API_Invo
 Execute the following command:
 
 ```bash
-awslocal lambda invoke \
+lstk aws lambda invoke \
     --function-name ProcessKinesisRecords \
     --payload file://input.txt outputfile.txt
 ```
@@ -107,7 +107,7 @@ You can create a Kinesis Stream using the [`CreateStream`](https://docs.aws.amaz
 Run the following command to create a Kinesis Stream named `lambda-stream`:
 
 ```bash
-awslocal kinesis create-stream \
+lstk aws kinesis create-stream \
   --stream-name lambda-stream \
   --shard-count 1
 ```
@@ -116,7 +116,7 @@ You can retrieve the Stream ARN using the [`DescribeStream`](https://docs.aws.am
 Execute the following command:
 
 ```bash
-awslocal kinesis describe-stream \
+lstk aws kinesis describe-stream \
   --stream-name lambda-stream
 ```
 
@@ -147,7 +147,7 @@ You can add an Event Source to your Lambda function using the [`CreateEventSourc
 Run the following command to add the Kinesis Stream as an Event Source to your Lambda function:
 
 ```bash
-awslocal lambda create-event-source-mapping \
+lstk aws lambda create-event-source-mapping \
     --function-name ProcessKinesisRecords \
     --event-source arn:aws:kinesis:us-east-1:000000000000:stream/lambda-stream \
     --batch-size 100 \
@@ -160,7 +160,7 @@ You can test the event source mapping by adding a record to the Kinesis Stream u
 Run the following command to add a record to the Kinesis Stream:
 
 ```bash
-awslocal kinesis put-record \
+lstk aws kinesis put-record \
     --stream-name lambda-stream \
     --partition-key 1 \
     --data "Hello, this is a test."

--- a/src/content/docs/aws/services/kinesisanalyticsv2.mdx
+++ b/src/content/docs/aws/services/kinesisanalyticsv2.mdx
@@ -29,7 +29,7 @@ LocalStack creates Flink JobManager and TaskManager containers on the Docker net
 **Running LocalStack inside a Kubernetes cluster with the Docker executor is not supported.**
 Mounting the host Docker socket (`/var/run/docker.sock`) into a LocalStack pod is not sufficient — the Docker executor cannot create Flink containers in this topology and applications will remain stuck in `STARTING` indefinitely.
 
-If you are running LocalStack outside of Kubernetes (for example, with Docker Compose or the LocalStack CLI), no additional configuration is required and the Docker executor is used automatically.
+If you are running LocalStack outside of Kubernetes (for example, with Docker Compose or the `lstk` CLI), no additional configuration is required and the Docker executor is used automatically.
 
 ## Getting Started
 

--- a/src/content/docs/aws/services/kinesisanalyticsv2.mdx
+++ b/src/content/docs/aws/services/kinesisanalyticsv2.mdx
@@ -63,8 +63,8 @@ MSF requires that all application code resides in S3.
 Create an S3 bucket and upload the compiled Flink application jar.
 
 ```bash
-awslocal s3api create-bucket --bucket flink-bucket
-awslocal s3api put-object --bucket flink-bucket --key job.jar --body ./target/flink-kds-s3.jar
+lstk aws s3api create-bucket --bucket flink-bucket
+lstk aws s3api put-object --bucket flink-bucket --key job.jar --body ./target/flink-kds-s3.jar
 ```
 
 ### Output Sink
@@ -74,7 +74,7 @@ As mentioned earlier, this Flink application writes the output to an S3 bucket.
 Create the S3 bucket that will serve as the sink.
 
 ```bash
-awslocal s3api create-bucket --bucket sink-bucket
+lstk aws s3api create-bucket --bucket sink-bucket
 ```
 
 ### Permissions
@@ -99,7 +99,7 @@ Create an IAM role for the running MSF application to assume.
 ```
 
 ```bash
-awslocal iam create-role --role-name msaf-role --assume-role-policy-document file://role.json
+lstk aws iam create-role --role-name msaf-role --assume-role-policy-document file://role.json
 ```
 
 Next create add a permissions policy to this role that permits read and write access to S3.
@@ -119,7 +119,7 @@ Next create add a permissions policy to this role that permits read and write ac
 ```
 
 ```bash
-awslocal iam put-role-policy --role-name msaf-role --policy-name msaf-policy --policy-document file://policy.json
+lstk aws iam put-role-policy --role-name msaf-role --policy-name msaf-policy --policy-document file://policy.json
 ```
 
 Now, when the running MSF application assumes this role, it will have the necessary permissions to write to the S3 sink.
@@ -129,7 +129,7 @@ Now, when the running MSF application assumes this role, it will have the necess
 With all prerequisite resources in place, the Flink application can now be created and started.
 
 ```bash showshowLineNumbers
-awslocal kinesisanalyticsv2 create-application \
+lstk aws kinesisanalyticsv2 create-application \
     --application-name msaf-app \
     --runtime-environment FLINK-1_20 \
     --application-mode STREAMING \
@@ -151,14 +151,14 @@ awslocal kinesisanalyticsv2 create-application \
         }
     }'
 
-awslocal kinesisanalyticsv2 start-application --application-name msaf-app
+lstk aws kinesisanalyticsv2 start-application --application-name msaf-app
 ```
 
 Once the Flink cluster is up and running, the application will stream the results to the sink S3 bucket.
 You can verify this with:
 
 ```bash
-awslocal s3api list-objects --bucket sink-bucket
+lstk aws s3api list-objects --bucket sink-bucket
 ```
 
 ## CloudWatch Logging
@@ -176,7 +176,7 @@ There are following prerequisites for CloudWatch Logs integration:
 To add a logging option:
 
 ```bash showshowLineNumbers
-awslocal kinesisanalyticsv2 add-application-cloud-watch-logging-option \
+lstk aws kinesisanalyticsv2 add-application-cloud-watch-logging-option \
     --application-name msaf-app \
     --cloud-watch-logging-option '{"LogStreamARN": "arn:aws:logs:us-east-1:000000000000:log-group:msaf-log-group:log-stream:msaf-log-stream"}'
 ```
@@ -201,7 +201,7 @@ Enabling CloudWatch Logs integration has a significant performance hit.
 Configured logging options can be retrieved using [DescribeApplication](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_DescribeApplication.html):
 
 ```bash
-awslocal kinesisanalyticsv2 describe-application --application-name msaf-app | jq .ApplicationDetail.CloudWatchLoggingOptionDescriptions
+lstk aws kinesisanalyticsv2 describe-application --application-name msaf-app | jq .ApplicationDetail.CloudWatchLoggingOptionDescriptions
 ```
 
 ```bash title="Output"
@@ -221,7 +221,7 @@ Log events can be retrieved from CloudWatch Logs using the appropriate operation
 To retrieve all events:
 
 ```bash
-awslocal logs get-log-events --log-group-name msaf-log-group --log-stream-name msaf-log-stream
+lstk aws logs get-log-events --log-group-name msaf-log-group --log-stream-name msaf-log-stream
 ```
 
 LocalStack reports both Flink application and Flink framework logs to CloudWatch.
@@ -234,11 +234,11 @@ You can manage [resource tags](https://docs.aws.amazon.com/managed-flink/latest/
 Tags can also be specified when creating the Flink application using the [CreateApplication](https://docs.aws.amazon.com/managed-flink/latest/apiv2/API_CreateApplication.html) operation.
 
 ```bash
-awslocal kinesisanalyticsv2 tag-resource \
+lstk aws kinesisanalyticsv2 tag-resource \
     --resource-arn arn:aws:kinesisanalytics:us-east-1:000000000000:application/msaf-app \
     --tags Key=country,Value=SE
 
-awslocal kinesisanalyticsv2 list-tags-for-resource \
+lstk aws kinesisanalyticsv2 list-tags-for-resource \
     --resource-arn arn:aws:kinesisanalytics:us-east-1:000000000000:application/msaf-app
 ```
 
@@ -256,7 +256,7 @@ awslocal kinesisanalyticsv2 list-tags-for-resource \
 You can also untag the resource:
 
 ```bash
-awslocal kinesisanalyticsv2 untag-resource \
+lstk aws kinesisanalyticsv2 untag-resource \
     --resource-arn arn:aws:kinesisanalytics:us-east-1:000000000000:application/msaf-app \
     --tag-keys country
 ```

--- a/src/content/docs/aws/services/kms.mdx
+++ b/src/content/docs/aws/services/kms.mdx
@@ -19,7 +19,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to KMS and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to KMS and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a simple symmetric encryption key and use it to encrypt/decrypt data.
@@ -30,7 +30,7 @@ To generate a new key within the KMS, you can use the [`CreateKey`](https://docs
 Execute the following command to create a new key:
 
 ```bash
-awslocal kms create-key
+lstk aws kms create-key
 ```
 
 By default, this command generates a symmetric encryption key, eliminating the need for any additional arguments.
@@ -39,13 +39,13 @@ You can take a look at the `KeyId` of the freshly generated key in the output, a
 In case the key ID is misplaced, it is possible to retrieve a comprehensive list of IDs and [Amazon Resource Names](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) (ARNs) for all available keys through the following command:
 
 ```bash
-awslocal kms list-keys
+lstk aws kms list-keys
 ```
 
 Additionally, if needed, you can obtain extensive details about a specific key by providing its key ID or ARN using the subsequent command:
 
 ```bash
-awslocal kms describe-key --key-id <KEY_ID>
+lstk aws kms describe-key --key-id <KEY_ID>
 ```
 
 ### Encrypt the data
@@ -56,7 +56,7 @@ To do so, you can use the [`Encrypt`](https://docs.aws.amazon.com/kms/latest/API
 Execute the following command to encrypt the data:
 
 ```bash
-awslocal kms encrypt \
+lstk aws kms encrypt \
       --key-id 010a4301-4205-4df8-ae52-4c2895d47326 \
       --plaintext "some important stuff" \
       --output text \
@@ -76,7 +76,7 @@ However, with asymmetric keys the `KEY_ID` has to be specified.
 Execute the following command to decrypt the data:
 
 ```bash
-awslocal kms decrypt \
+lstk aws kms decrypt \
       --ciphertext-blob fileb://my_encrypted_data \
       --output text \
       --query Plaintext \
@@ -114,7 +114,7 @@ This can be useful to pre-seed a test environment and use a static `KeyId` for y
 Below is a simple example to create a key with a custom `KeyId` (note that the `KeyId` should have the format of a UUID):
 
 ```bash
-awslocal kms create-key --tags '[{"TagKey":"_custom_id_","TagValue":"00000000-0000-0000-0000-000000000001"}]'
+lstk aws kms create-key --tags '[{"TagKey":"_custom_id_","TagValue":"00000000-0000-0000-0000-000000000001"}]'
 ```
 
 The following output will be displayed:
@@ -148,7 +148,7 @@ thisisasecurekey
 You can create a key with custom key material using the following command:
 
 ```bash
-awslocal kms create-key --tags '[{"TagKey":"_custom_key_material_","TagValue":"dGhpc2lzYXNlY3VyZWtleQ=="}]'
+lstk aws kms create-key --tags '[{"TagKey":"_custom_key_material_","TagValue":"dGhpc2lzYXNlY3VyZWtleQ=="}]'
 ```
 
 The following output will be displayed:

--- a/src/content/docs/aws/services/lakeformation.mdx
+++ b/src/content/docs/aws/services/lakeformation.mdx
@@ -16,7 +16,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Lake Formation and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Lake Formation and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to register an S3 bucket as a resource in Lake Formation, grant permissions to a user, and list the resources and permissions.
@@ -26,7 +26,7 @@ We will demonstrate how to register an S3 bucket as a resource in Lake Formation
 Create a new S3 bucket named `test-bucket` using the `mb` command:
 
 ```bash
-awslocal s3 mb s3://test-bucket
+lstk aws s3 mb s3://test-bucket
 ```
 
 You can now register the S3 bucket as a resource in Lake Formation using the [`RegisterResource`](https://docs.aws.amazon.com/lake-formation/latest/dg/API_RegisterResource.html) API.
@@ -42,7 +42,7 @@ Create a file named `input.json` with the following content:
 Run the following command to register the resource:
 
 ```bash
-awslocal lakeformation register-resource \
+lstk aws lakeformation register-resource \
     --cli-input-json file://input.json
 ```
 
@@ -52,7 +52,7 @@ You can list the registered resources using the [`ListResources`](https://docs.a
 Execute the following command to list the resources:
 
 ```bash
-awslocal lakeformation list-resources
+lstk aws lakeformation list-resources
 ```
 
 ```bash title="Output"
@@ -94,7 +94,7 @@ Create a file named `permissions.json` with the following content:
 Run the following command to grant permissions:
 
 ```bash
-awslocal lakeformation grant-permissions \
+lstk aws lakeformation grant-permissions \
     --cli-input-json file://check.json
 ```
 
@@ -104,7 +104,7 @@ You can list the permissions granted to a user or group using the [`ListPermissi
 Execute the following command to list the permissions:
 
 ```bash
-awslocal lakeformation list-permissions
+lstk aws lakeformation list-permissions
 ```
 
 ## API Coverage

--- a/src/content/docs/aws/services/lambda.mdx
+++ b/src/content/docs/aws/services/lambda.mdx
@@ -20,7 +20,7 @@ The supported APIs are available on our [API coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Lambda and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Lambda and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a Lambda function with a Function URL.
@@ -46,7 +46,7 @@ Enter the following command to create a new Lambda function:
 
 ```bash
 zip function.zip index.js
-awslocal lambda create-function \
+lstk aws lambda create-function \
     --function-name localstack-lambda-url-example \
     --runtime nodejs22.x \
     --zip-file fileb://function.zip \
@@ -57,7 +57,7 @@ awslocal lambda create-function \
 :::note
 To create a predictable URL for the function, you can assign a custom ID by specifying the `_custom_id_` tag on the function itself.
 ```bash
-awslocal lambda create-function \
+lstk aws lambda create-function \
     --function-name localstack-lambda-url-example \
     --runtime nodejs22.x \
     --zip-file fileb://function.zip \
@@ -83,13 +83,13 @@ Run the following command to invoke the function:
 <Tabs>
 <TabItem label="AWS CLI v1">
 ```bash
-awslocal lambda invoke --function-name localstack-lambda-url-example \
+lstk aws lambda invoke --function-name localstack-lambda-url-example \
     --payload '{"body": "{\"num1\": \"10\", \"num2\": \"10\"}" }' output.txt
 ```
 </TabItem>
 <TabItem label="AWS CLI v2">
 ```bash
-awslocal lambda invoke --function-name localstack-lambda-url-example \
+lstk aws lambda invoke --function-name localstack-lambda-url-example \
     --cli-binary-format raw-in-base64-out \
     --payload '{"body": "{\"num1\": \"10\", \"num2\": \"10\"}" }' output.txt
 ```
@@ -106,7 +106,7 @@ With the Function URL property, there is now a new way to call a Lambda Function
 To create a URL for invoking the function, run the following command:
 
 ```bash
-awslocal lambda create-function-url-config \
+lstk aws lambda create-function-url-config \
     --function-name localstack-lambda-url-example \
     --auth-type NONE
 ```
@@ -118,7 +118,7 @@ The URL will be in the format `http://<XXXXXXXX>.lambda-url.us-east-1.localhost.
 As previously mentioned, when a Lambda Function has a `_custom_id_` tag, LocalStack sets this tag's value as the subdomain in the Function's URL.
 
 ```bash
-awslocal lambda create-function-url-config \
+lstk aws lambda create-function-url-config \
     --function-name localstack-lambda-url-example \
     --auth-type NONE
 ```
@@ -133,7 +133,7 @@ awslocal lambda create-function-url-config \
 In addition, if you pass an existing version alias as a `Qualifier` to the request, the created URL will combine the custom ID and the alias in the form `<custom-id>-<alias>`.
 
 ```bash
-awslocal lambda create-function-url-config \
+lstk aws lambda create-function-url-config \
     --function-name localstack-lambda-url-example \
     --auth-type NONE
     --qualifier test-alias
@@ -446,7 +446,7 @@ mkdir -p /tmp/python/
 echo 'def util():' > /tmp/python/testlayer.py
 echo '  print("Output from Lambda layer util function")' >> /tmp/python/testlayer.py
 (cd /tmp; zip -r testlayer.zip python)
-LAYER_ARN=$(awslocal lambda publish-layer-version --layer-name layer1 --zip-file fileb:///tmp/testlayer.zip | jq -r .LayerVersionArn)
+LAYER_ARN=$(lstk aws lambda publish-layer-version --layer-name layer1 --zip-file fileb:///tmp/testlayer.zip | jq -r .LayerVersionArn)
 ```
 
 Next, define a Lambda function that uses our layer:
@@ -456,7 +456,7 @@ echo 'def handler(*args, **kwargs):' > /tmp/testlambda.py
 echo '  import testlayer; testlayer.util()' >> /tmp/testlambda.py
 echo '  print("Debug output from Lambda function")' >> /tmp/testlambda.py
 (cd /tmp; zip testlambda.zip testlambda.py)
-awslocal lambda create-function \
+lstk aws lambda create-function \
   --function-name func1 \
   --runtime python3.8 \
   --role arn:aws:iam::000000000000:role/lambda-role \
@@ -694,7 +694,7 @@ Refer to our [sample `docker-compose.yml` file](https://github.com/localstack/lo
 If you receive a `ResourceConflictException` when trying to invoke a function, it is currently in a `Pending` state and cannot be executed yet.
 
 ```bash
-awslocal lambda get-function --function-name my-function
+lstk aws lambda get-function --function-name my-function
 ```
 
 ```bash title="Output"
@@ -706,13 +706,13 @@ The function is currently in the following state: Pending
 To wait until the function becomes `active`, you can use the following command:
 
 ```bash
-awslocal lambda wait function-active-v2 --function-name my-function
+lstk aws lambda wait function-active-v2 --function-name my-function
 ```
 
 Alternatively, you can check the function state using the [`GetFunction` API](https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html):
 
 ```bash
-awslocal lambda get-function --function-name my-function
+lstk aws lambda get-function --function-name my-function
 ```
 
 ```bash title="Output"
@@ -731,7 +731,7 @@ awslocal lambda get-function --function-name my-function
 When the function is active, the output will be similar to the following:
 
 ```bash
-awslocal lambda get-function --function-name my-function
+lstk aws lambda get-function --function-name my-function
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/logs.mdx
+++ b/src/content/docs/aws/services/logs.mdx
@@ -42,16 +42,16 @@ First, we setup the required resources.
 Therefore, we create a kinesis stream, a log group and log stream.
 Then we can configure the subscription filter.
 ```bash
-awslocal kinesis create-stream --stream-name "logtest" --shard-count 1
-kinesis_arn=$(awslocal kinesis describe-stream --stream-name "logtest" | jq -r .StreamDescription.StreamARN)
+lstk aws kinesis create-stream --stream-name "logtest" --shard-count 1
+kinesis_arn=$(lstk aws kinesis describe-stream --stream-name "logtest" | jq -r .StreamDescription.StreamARN)
 
-awslocal logs create-log-group --log-group-name test
+lstk aws logs create-log-group --log-group-name test
 
-awslocal logs create-log-stream \
+lstk aws logs create-log-stream \
     --log-group-name test \
     --log-stream-name test
 
-awslocal logs put-subscription-filter \
+lstk aws logs put-subscription-filter \
     --log-group-name "test" \
     --filter-name "kinesis_test" \
     --filter-pattern "" \
@@ -63,7 +63,7 @@ Next, we can add a log event, that will be forwarded to Kinesis.
 
 ```bash
 timestamp=$(($(date +'%s * 1000 + %-N / 1000000')))
-awslocal logs put-log-events --log-group-name test --log-stream-name test --log-events "[{\"timestamp\": ${timestamp} , \"message\": \"hello from cloudwatch\"}]"
+lstk aws logs put-log-events --log-group-name test --log-stream-name test --log-events "[{\"timestamp\": ${timestamp} , \"message\": \"hello from cloudwatch\"}]"
 ```
 
 Now we can retrieve the data.
@@ -71,8 +71,8 @@ In our example, there will only be one record.
 The data record is base64 encoded and compressed in gzip format:
 
 ```bash
-shard_iterator=$(awslocal kinesis get-shard-iterator --stream-name logtest --shard-id shardId-000000000000 --shard-iterator-type TRIM_HORIZON | jq -r .ShardIterator)
-record=$(awslocal kinesis get-records --limit 10 --shard-iterator $shard_iterator | jq -r '.Records[0].Data')
+shard_iterator=$(lstk aws kinesis get-shard-iterator --stream-name logtest --shard-id shardId-000000000000 --shard-iterator-type TRIM_HORIZON | jq -r .ShardIterator)
+record=$(lstk aws kinesis get-records --limit 10 --shard-iterator $shard_iterator | jq -r '.Records[0].Data')
 echo $record | base64 -d | zcat
 ```
 
@@ -89,13 +89,13 @@ Metric filters can be used to automatically create CloudWatch metrics.
 In the following example we are interested in logs that include a key-value pair `"foo": "bar"` and create a metric filter.
 
 ```bash
-awslocal logs create-log-group --log-group-name test-filter
+lstk aws logs create-log-group --log-group-name test-filter
 
-awslocal logs create-log-stream \
+lstk aws logs create-log-stream \
 --log-group-name test-filter \
 --log-stream-name test-filter-stream
 
-awslocal logs put-metric-filter \
+lstk aws logs put-metric-filter \
   --log-group-name test-filter \
   --filter-name my-filter \
   --filter-pattern "{$.foo = \"bar\"}" \
@@ -107,7 +107,7 @@ Next, we can insert some values:
 
 ```bash
 timestamp=$(($(date +'%s * 1000 + %-N / 1000000')))
-awslocal logs put-log-events --log-group-name test-filter \
+lstk aws logs put-log-events --log-group-name test-filter \
    --log-stream-name test-filter-stream \
    --log-events \
     timestamp=$timestamp,message='"{\"foo\":\"bar\", \"hello\": \"world\"}"' \
@@ -119,7 +119,7 @@ Now we can check that the metric was indeed created:
 
 ```bash
 end=$(date +%s)
-awslocal cloudwatch get-metric-statistics --namespace MyNamespace \
+lstk aws cloudwatch get-metric-statistics --namespace MyNamespace \
     --metric-name MyMetric --statistics Sum  --period 3600 \
     --start-time 1659621274 --end-time $end
 ```
@@ -134,7 +134,7 @@ For purely JSON structured log messages, you can use JSON filter patterns to tra
 Enclose your pattern in curly braces, like this:
 
 ```bash
-awslocal logs filter-log-events --log-group-name test-filter --filter-pattern "{$.foo = \"bar\"}"
+lstk aws logs filter-log-events --log-group-name test-filter --filter-pattern "{$.foo = \"bar\"}"
 ```
 
 This returns all events whose top level "foo" key has the "bar" value.
@@ -145,7 +145,7 @@ You can use a simplified regex syntax for regular expression matching.
 Enclose your pattern in percentage signs like this:
 
 ```bash
-awslocal logs filter-log-events --log-group-name test-filter --filter-pattern "\%[fF]oo\%"
+lstk aws logs filter-log-events --log-group-name test-filter --filter-pattern "\%[fF]oo\%"
 ```
 
 This returns all events containing "Foo" or "foo".
@@ -156,7 +156,7 @@ For a complete set of the supported syntax, check [the official AWS documentatio
 If not specified otherwise in the pattern, we look for a match in the whole event message:
 
 ```bash
-awslocal logs filter-log-events --log-group-name test-filter --filter-pattern "foo"
+lstk aws logs filter-log-events --log-group-name test-filter --filter-pattern "foo"
 ```
 
 ## Resource Browser

--- a/src/content/docs/aws/services/managedblockchain.mdx
+++ b/src/content/docs/aws/services/managedblockchain.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to AMB and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to AMB and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a blockchain network, a node, and a proposal.
@@ -28,7 +28,7 @@ You can create a blockchain network using the [`CreateNetwork`](https://docs.aws
 Run the following command to create a network named `OurBlockchainNet` which uses the Hyperledger Fabric with the following configuration:
 
 ```bash showshowLineNumbers
-awslocal managedblockchain create-network \
+lstk aws managedblockchain create-network \
     --cli-input-json '{
         "Name": "OurBlockchainNet",
         "Description": "OurBlockchainNetDesc",
@@ -83,7 +83,7 @@ You can create a node using the [`CreateNode`](https://docs.aws.amazon.com/manag
 Run the following command to create a node with the following configuration:
 
 ```bash showshowLineNumbers
-awslocal managedblockchain create-node \
+lstk aws managedblockchain create-node \
     --node-configuration '{
     "InstanceType": "bc.t3.small",
     "AvailabilityZone": "us-east-1a",
@@ -120,7 +120,7 @@ You can create a proposal using the [`CreateProposal`](https://docs.aws.amazon.c
 Run the following command to create a proposal with the following configuration:
 
 ```bash
-awslocal managedblockchain create-proposal \
+lstk aws managedblockchain create-proposal \
     --actions "Invitations=[{Principal=000000000000}]" \
     --network-id n-X24AF1AK2GC6MDW11HYW5I5DQC \
     --member-id m-6VWBWHP2Y15F7TQ2DS093RTCW2

--- a/src/content/docs/aws/services/mediaconvert.mdx
+++ b/src/content/docs/aws/services/mediaconvert.mdx
@@ -20,7 +20,7 @@ Elemental MediaConvert is in a preview state.
 
 ## Getting started
 
-This guide is designed for users new to Elemental MediaConvert and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Elemental MediaConvert and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a MediaConvert job, list jobs, create a queue, and list all queues using the AWS CLI.
@@ -100,7 +100,7 @@ You can create a MediaConvert job using the [`CreateJob`](https://docs.aws.amazo
 Execute the following command to create a job using a `job.json` file:
 
 ```bash
-awslocal mediaconvert create-job --cli-input-json file://job.json
+lstk aws mediaconvert create-job --cli-input-json file://job.json
 ```
 
 ```bash title="Output"
@@ -148,7 +148,7 @@ You can list all MediaConvert jobs using the [`ListJobs`](https://docs.aws.amazo
 Execute the following command to list all jobs:
 
 ```bash
-awslocal mediaconvert list-jobs
+lstk aws mediaconvert list-jobs
 ```
 
 ### Create a queue
@@ -157,7 +157,7 @@ You can create a MediaConvert queue using the [`CreateQueue`](https://docs.aws.a
 Execute the following command to create a queue named `MyQueue`:
 
 ```bash
-awslocal mediaconvert create-queue  
+lstk aws mediaconvert create-queue  
     --name MyQueue  
     --description "High priority queue for video encoding"
 ```
@@ -185,7 +185,7 @@ You can list all MediaConvert queues using the [`ListQueues`](https://docs.aws.a
 Execute the following command to list all queues:
 
 ```bash
-awslocal mediaconvert list-queues
+lstk aws mediaconvert list-queues
 ```
 
 ## Current Limitations

--- a/src/content/docs/aws/services/memorydb.mdx
+++ b/src/content/docs/aws/services/memorydb.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to MemoryDB and assumes basic knowledge of the AWS CLI and our `awslocal` wrapper script.
+This guide is designed for users new to MemoryDB and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can create a MemoryDB cluster and connect to it.
@@ -28,7 +28,7 @@ You can create a MemoryDB cluster using the [`CreateCluster`](https://docs.aws.a
 Run the following command to create a cluster:
 
 ```bash
-awslocal memorydb create-cluster \
+lstk aws memorydb create-cluster \
   --cluster-name my-redis-cluster \
   --node-type db.t4g.small \
   --acl-name open-access
@@ -38,7 +38,7 @@ Once it becomes available, you will be able to use the cluster endpoint for Redi
 Run the following command to retrieve the cluster endpoint using the [`DescribeClusters`](https://docs.aws.amazon.com/memorydb/latest/APIReference/API_DescribeClusters.html) API:
 
 ```bash
-awslocal memorydb describe-clusters --query "Clusters[0].ClusterEndpoint"
+lstk aws memorydb describe-clusters --query "Clusters[0].ClusterEndpoint"
 ```
 
 ```bash title="Output"
@@ -84,7 +84,7 @@ To enable full Valkey emulation:
 2. Create a cluster with the Valkey engine by including the `--engine valkey` flag in your API call:
 
 ```bash
-awslocal memorydb create-cluster \
+lstk aws memorydb create-cluster \
   --cluster-name my-valkey-cluster \
   --node-type db.t4g.small \
   --acl-name open-access \

--- a/src/content/docs/aws/services/mq.mdx
+++ b/src/content/docs/aws/services/mq.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to MQ and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local)  wrapper script.
+This guide is designed for users new to MQ and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an MQ broker and send a message to a sample queue.
@@ -28,7 +28,7 @@ You can create a broker using the [`CreateBroker`](https://docs.aws.amazon.com/a
 Run the following command to create a broker named `test-broker` with the following configuration:
 
 ```bash
-awslocal mq create-broker \
+lstk aws mq create-broker \
     --broker-name test-broker \
     --deployment-mode SINGLE_INSTANCE \
     --engine-type ACTIVEMQ \
@@ -52,7 +52,7 @@ You can use the [`DescribeBroker`](https://docs.aws.amazon.com/amazon-mq/latest/
 Run the following command to get information about the broker we created above:
 
 ```bash
-awslocal mq describe-broker --broker-id b-f503abb7-66bc-47fb-b1a9-8d8c51ef6545
+lstk aws mq describe-broker --broker-id b-f503abb7-66bc-47fb-b1a9-8d8c51ef6545
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/mwaa.mdx
+++ b/src/content/docs/aws/services/mwaa.mdx
@@ -16,7 +16,7 @@ The supported APIs are available on the [API Coverage section](#api-coverage).
 
 ## Getting started
 
-This guide is designed for users new to MWAA and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to MWAA and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an Airflow environment and access the Airflow UI.
@@ -27,7 +27,7 @@ Create a S3 bucket that will be used for Airflow resources.
 Run the following command to create a bucket using the [`mb`](https://docs.aws.amazon.com/cli/latest/reference/s3/mb.html) command.
 
 ```bash
-awslocal s3 mb s3://my-mwaa-bucket
+lstk aws s3 mb s3://my-mwaa-bucket
 ```
 
 ### Create an Airflow environment
@@ -36,7 +36,7 @@ You can now create an Airflow environment, using the [`CreateEnvironment`](https
 Run the following command, by specifying the bucket ARN we created earlier:
 
 ```bash
-awslocal mwaa create-environment --dag-s3-path /dags \
+lstk aws mwaa create-environment --dag-s3-path /dags \
         --execution-role-arn arn:aws:iam::000000000000:role/airflow-role \
         --network-configuration {} \
         --source-bucket-arn arn:aws:s3:::my-mwaa-bucket \
@@ -51,7 +51,7 @@ The Airflow UI can be accessed via the URL in the `WebserverUrl` attribute of th
 The username and password are always set to `localstack`.
 
 ```bash
-awslocal mwaa get-environment \
+lstk aws mwaa get-environment \
         --name my-mwaa-env \
         --query Environment.WebserverUrl \
         "http://localhost.localstack.cloud:4510"
@@ -97,7 +97,7 @@ Just upload your DAGs to the designated S3 bucket path, configured by the `DagS3
 For example, the command below uploads a sample DAG named `sample_dag.py` to your S3 bucket named `my-mwaa-bucket`:
 
 ```bash
-awslocal s3 cp sample_dag.py s3://my-mwaa-bucket/dags
+lstk aws s3 cp sample_dag.py s3://my-mwaa-bucket/dags
 ```
 
 LocalStack syncs new and changed objects in the S3 bucket to the Airflow container every 30 seconds.
@@ -111,7 +111,7 @@ LocalStack seamlessly supports plugins packaged according to [AWS specifications
 To integrate your custom plugins into the MWAA environment, upload the packaged `plugins.zip` file to the designated S3 bucket path:
 
 ```bash
-awslocal s3 cp plugins.zip s3://my-mwaa-bucket/plugins.zip
+lstk aws s3 cp plugins.zip s3://my-mwaa-bucket/plugins.zip
 ```
 
 ## Installing Python dependencies
@@ -130,7 +130,7 @@ Once you have your `requirements.txt` file ready, upload it to the designated S3
 Make sure to upload the file to `/requirements.txt` in the bucket:
 
 ```bash
-awslocal s3 cp requirements.txt s3://my-mwaa-bucket/requirements.txt
+lstk aws s3 cp requirements.txt s3://my-mwaa-bucket/requirements.txt
 ```
 
 After the upload, the environment will be automatically updated, and your Apache Airflow setup will be equipped with the new dependencies.

--- a/src/content/docs/aws/services/neptune.mdx
+++ b/src/content/docs/aws/services/neptune.mdx
@@ -38,7 +38,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Neptune and assumes basic knowledge of the AWS CLI and our `awslocal` wrapper script.
+This guide is designed for users new to Neptune and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate the following with AWS CLI & Python:
@@ -53,7 +53,7 @@ To create a Neptune cluster you can use the [`CreateDBCluster`](https://docs.aws
 Run the following command to create a Neptune cluster:
 
 ```bash
-awslocal neptune create-db-cluster \
+lstk aws neptune create-db-cluster \
     --engine neptune \
     --db-cluster-identifier my-neptune-db
 ```
@@ -76,7 +76,7 @@ To add an instance you can use the [`CreateDBInstance`](https://docs.aws.amazon.
 Run the following command to create a Neptune instance:
 
 ```bash
-awslocal neptune create-db-instance \
+lstk aws neptune create-db-instance \
     --db-cluster-identifier my-neptune-db \
     --db-instance-identifier my-neptune-instance \
     --engine neptune \
@@ -158,13 +158,13 @@ When LocalStack starts with [IAM enforcement enabled](/aws/developer-tools/secur
 Start LocalStack with `LOCALSTACK_ENFORCE_IAM=1` to create a Neptune cluster with IAM DB authentication enabled.
 
 ```bash
-LOCALSTACK_ENFORCE_IAM=1 localstack start
+LOCALSTACK_ENFORCE_IAM=1 lstk start
 ```
 
 You can then create a cluster.
 
 ```bash
-awslocal neptune create-db-cluster \
+lstk aws neptune create-db-cluster \
     --engine neptune \
     --db-cluster-identifier myneptune-db \
     --enable-iam-database-authentication

--- a/src/content/docs/aws/services/opensearch.mdx
+++ b/src/content/docs/aws/services/opensearch.mdx
@@ -39,7 +39,7 @@ You can select an Elasticsearch version with the `--engine-version` parameter wh
 
 ## Getting started
 
-This guide is designed for users new to OpenSearch Service and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to OpenSearch Service and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a new OpenSearch Service cluster and interact with it, using the AWS CLI.
@@ -51,7 +51,7 @@ OpenSearch Service domain is synonymous with an OpenSearch cluster.
 Execute the following command to create a new OpenSearch domain:
 
 ```bash
-awslocal opensearch create-domain --domain-name my-domain
+lstk aws opensearch create-domain --domain-name my-domain
 ```
 
 Each time you establish a cluster using a new version of OpenSearch, the corresponding OpenSearch binary must be downloaded, a process that might require some time to complete.
@@ -61,7 +61,7 @@ You can open the LocalStack logs, to see that the OpenSearch Service cluster is 
 You can use the [`DescribeDomain`](https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_DescribeDomain.html) API to check the status of the cluster:
 
 ```bash
-awslocal opensearch describe-domain \
+lstk aws opensearch describe-domain \
     --domain-name my-domain | jq ".DomainStatus.Processing"
 ```
 
@@ -128,7 +128,7 @@ Moreover, you can opt for custom domains, though it's important to incorporate t
 Run the following command to create a new OpenSearch domain with a custom endpoint:
 
 ```bash
-awslocal opensearch create-domain --domain-name my-domain \
+lstk aws opensearch create-domain --domain-name my-domain \
       --domain-endpoint-options '{ "CustomEndpoint": "http://localhost:4566/my-custom-endpoint", "CustomEndpointEnabled": true }'
 ```
 
@@ -214,10 +214,10 @@ Save it in a file named `opensearch_domain.json`.
 }
 ```
 
-To provision it, use the following `awslocal` CLI command, assuming the aforementioned CLI input has been stored in a file named `opensearch_domain.json`:
+To provision it, use the following `lstk aws` CLI command, assuming the aforementioned CLI input has been stored in a file named `opensearch_domain.json`:
 
 ```bash
-awslocal opensearch create-domain --cli-input-json file://./opensearch_domain.json
+lstk aws opensearch create-domain --cli-input-json file://./opensearch_domain.json
 ```
 
 Once the domain setup is complete (`Processing: false`), the cluster can only be accessed with the given master user credentials, via HTTP basic authentication:
@@ -253,7 +253,7 @@ Now you can provision a new OpenSearch domain.
 Make sure to enable the [advanced security options](#advanced-security-options):
 
 ```bash
-awslocal opensearch create-domain --cli-input-json file://./opensearch_domain.json
+lstk aws opensearch create-domain --cli-input-json file://./opensearch_domain.json
 ```
 
 Now you can start another container for OpenSearch Dashboards, which is configured such that:
@@ -341,17 +341,17 @@ You can start the Docker Compose environment using the following command:
 docker-compose up -d
 ```
 
-You can now create an OpenSearch cluster using the `awslocal` CLI:
+You can now create an OpenSearch cluster using the `lstk aws` CLI:
 
 ```bash
-awslocal opensearch create-domain --domain-name my-domain
+lstk aws opensearch create-domain --domain-name my-domain
 ```
 
 If the `Processing` status shows as `true`, the cluster isn't fully operational yet.
 You can use the `describe-domain` command to retrieve the current status:
 
 ```bash
-awslocal opensearch describe-domain --domain-name my-domain
+lstk aws opensearch describe-domain --domain-name my-domain
 ```
 
 You can now verify cluster health and set up indices:

--- a/src/content/docs/aws/services/organizations.mdx
+++ b/src/content/docs/aws/services/organizations.mdx
@@ -17,49 +17,49 @@ Organizations is available over LocalStack for AWS and the supported APIs are av
 ## Getting started
 
 In this getting started guide, you'll learn how to create your local AWS Organization and configure it with member accounts.
-This guide is intended for users who wish to get more acquainted with Organizations, and assumes you have basic knowledge of the AWS CLI (and our `awslocal` wrapper script).
+This guide is intended for users who wish to get more acquainted with Organizations, and assumes you have basic knowledge of the AWS CLI (and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command).
 To get started, start your LocalStack instance using your preferred method:
 
 1. Create a new local AWS Organization with the feature set flag set to `ALL`:
    ```bash
-   awslocal organizations create-organization --feature-set ALL
+   lstk aws organizations create-organization --feature-set ALL
    ```
 
 2. You can now run the `describe-organization` command to see the details of your organization:
    ```bash
-   awslocal organizations describe-organization
+   lstk aws organizations describe-organization
    ```
 
 3. You can now create an AWS account that would be a member of your organization:
    ```bash
-   awslocal organizations create-account \
+   lstk aws organizations create-account \
       --email example@example.com \
       --account-name "Test Account"
    ```
    Since LocalStack essentially mocks AWS, the account creation is instantaneous.
   You can now run the `list-accounts` command to see the details of your organization:
    ```bash
-   awslocal organizations list-accounts
+   lstk aws organizations list-accounts
    ```
 
 4. You can also remove a member account from your organization:
    ```bash
-   awslocal organizations remove-account-from-organization --account-id <ACCOUNT_ID>
+   lstk aws organizations remove-account-from-organization --account-id <ACCOUNT_ID>
    ```
 
 5. To close an account in your organization, you can run the `close-account` command:
    ```bash
-   awslocal organizations close-account --account-id 000000000000
+   lstk aws organizations close-account --account-id 000000000000
    ```
 
 6. You can use organizational units (OUs) to group accounts together to administer as a single unit.
   To create an OU, you can run:
    ```bash
-   awslocal organizations list-roots
-   awslocal organizations list-children \
+   lstk aws organizations list-roots
+   lstk aws organizations list-children \
         --parent-id <PARENT-ID> \
         --child-type ORGANIZATIONAL_UNIT
-   awslocal organizations create-organizational-unit \
+   lstk aws organizations create-organizational-unit \
         --parent-id <PARENT-ID> \
         --name New-Child-OU
    ```
@@ -67,25 +67,25 @@ To get started, start your LocalStack instance using your preferred method:
 7. Before you can create and attach a policy to your organization, you must enable a policy type.
   To enable a policy type, you can run:
    ```bash
-   awslocal organizations enable-policy-type \
+   lstk aws organizations enable-policy-type \
         --root-id <ROOT-ID> \
         --policy-type SERVICE_CONTROL_POLICY
    ```
    To disable a policy type, you can run:
    ```bash
-   awslocal organizations disable-policy-type \
+   lstk aws organizations disable-policy-type \
         --root-id <ROOT-ID> \
         --policy-type SERVICE_CONTROL_POLICY
    ```
 
 8. To view the policies that are attached to your organization, you can run:
    ```bash
-   awslocal organizations list-policies --filter SERVICE_CONTROL_POLICY
+   lstk aws organizations list-policies --filter SERVICE_CONTROL_POLICY
    ```
 
 9. To delete an organization, you can run:
    ```bash
-   awslocal organizations delete-organization
+   lstk aws organizations delete-organization
    ```
 
 ## Service Control Policy enforcement
@@ -116,7 +116,7 @@ Consider a member account that lists the objects of an S3 bucket in another acco
 
 ```bash
 # Run as the member (source) account
-awslocal s3api list-objects-v2 --bucket cross-account-bucket
+lstk aws s3api list-objects-v2 --bucket cross-account-bucket
 ```
 
 The default `FullAWSAccess` SCP lets the request succeed on the bucket policy.
@@ -140,7 +140,7 @@ You can use the [IAM Policy Simulator](https://docs.aws.amazon.com/IAM/latest/Us
 LocalStack evaluates SCPs during policy simulation, so you can validate SCP behavior with [`SimulatePrincipalPolicy`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_SimulatePrincipalPolicy.html) before making live requests.
 
 ```bash
-awslocal iam simulate-principal-policy \
+lstk aws iam simulate-principal-policy \
    --policy-source-arn arn:aws:iam::111111111111:user/test \
    --action-names s3:ListBucket \
    --resource-arns arn:aws:s3:::cross-account-bucket
@@ -178,7 +178,7 @@ LocalStack instead mirrors the behavior observed against real AWS: the enforced 
 For example, the following policy is rejected because it includes a `Principal` element, which is not permitted in an SCP:
 
 ```bash
-awslocal organizations create-policy \
+lstk aws organizations create-policy \
     --name "InvalidSCP" \
     --description "SCP with a Principal element" \
     --type SERVICE_CONTROL_POLICY \

--- a/src/content/docs/aws/services/pinpoint.mdx
+++ b/src/content/docs/aws/services/pinpoint.mdx
@@ -22,7 +22,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Pinpoint and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Pinpoint and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a Pinpoint application, retrieve all applications, and list tags for the resource.
@@ -33,7 +33,7 @@ Create a Pinpoint application using the [`CreateApp`](https://docs.aws.amazon.co
 Execute the following command:
 
 ```bash
-awslocal pinpoint create-app \
+lstk aws pinpoint create-app \
     --create-application-request Name=ExampleCorp,tags={"Stack"="Test"}
 ```
 
@@ -54,7 +54,7 @@ You can list all applications using the [`GetApps`](https://docs.aws.amazon.com/
 Execute the following command:
 
 ```bash
-awslocal pinpoint get-apps
+lstk aws pinpoint get-apps
 ```
 
 ```bash title="Output"
@@ -78,7 +78,7 @@ You can list all tags for the application using the [`GetApp`](https://docs.aws.
 Execute the following command:
 
 ```bash
-awslocal pinpoint list-tags-for-resource \
+lstk aws pinpoint list-tags-for-resource \
     --resource-arn arn:aws:mobiletargeting:us-east-1:000000000000:apps/4487a55ac6fb4a2699a1b90727c978e7
 ```
 
@@ -106,7 +106,7 @@ Instead it provides alternative ways to retrieve the actual OTP code as illustra
 Begin by making a OTP request:
 
 ```bash
-awslocal pinpoint send-otp-message \
+lstk aws pinpoint send-otp-message \
   --application-id fff5a801e01643c18a13a763e22a8fbf \
   --send-otp-message-request-parameters '{
       "BrandName": "LocalStack Pro",
@@ -159,7 +159,7 @@ The OTP code is also printed in an `INFO` level message in the LocalStack log ou
 Finally, the OTP code can be verified using:
 
 ```bash
-awslocal pinpoint verify-otp-message \
+lstk aws pinpoint verify-otp-message \
   --application-id fff5a801e01643c18a13a763e22a8fbf \
   --verify-otp-message-request-parameters '{
       "ReferenceId": "liftoffcampaign",

--- a/src/content/docs/aws/services/pipes.mdx
+++ b/src/content/docs/aws/services/pipes.mdx
@@ -26,7 +26,7 @@ If you would like support for more APIs or report bugs, please make a request on
 
 ## Getting started
 
-This guide is designed for users new to EventBridge Pipes and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to EventBridge Pipes and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a Pipe with SQS queues as source and target, and send events to the source queue which will be routed to the target queue.
@@ -37,15 +37,15 @@ Create two SQS queues that will be used as source and target for the Pipe.
 Run the following command to create a queue using the [`CreateQueue`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html) API:
 
 ```bash
-awslocal sqs create-queue --queue-name source-queue
-awslocal sqs create-queue --queue-name target-queue
+lstk aws sqs create-queue --queue-name source-queue
+lstk aws sqs create-queue --queue-name target-queue
 ```
 
 You can fetch their queue ARNs using the [`GetQueueAttributes`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html) API:
 
 ```bash
-SOURCE_QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/source-queue --attribute-names QueueArn --output text)
-TARGET_QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/target-queue --attribute-names QueueArn --output text)
+SOURCE_QUEUE_ARN=$(lstk aws sqs get-queue-attributes --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/source-queue --attribute-names QueueArn --output text)
+TARGET_QUEUE_ARN=$(lstk aws sqs get-queue-attributes --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/target-queue --attribute-names QueueArn --output text)
 ```
 
 ### Create a Pipe
@@ -54,7 +54,7 @@ You can now create a Pipe, using the [`CreatePipe`](https://docs.aws.amazon.com/
 Run the following command, by specifying the source and target queue ARNs we created earlier:
 
 ```bash
-awslocal pipes create-pipe --name sample-pipe \
+lstk aws pipes create-pipe --name sample-pipe \
         --source $SOURCE_QUEUE_ARN \
         --target $TARGET_QUEUE_ARN \
         --role-arn arn:aws:iam::000000000000:role/pipes-role
@@ -76,7 +76,7 @@ awslocal pipes create-pipe --name sample-pipe \
 You can use the [`DescribePipe`](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribePipe.html) API to get information about the Pipe:
 
 ```bash
-awslocal pipes describe-pipe --name sample-pipe
+lstk aws pipes describe-pipe --name sample-pipe
 ```
 
 ```bash title="Output"
@@ -108,7 +108,7 @@ You can now send events to the source queue, which will be routed to the target 
 Run the following command to send an event to the source queue:
 
 ```bash
-awslocal sqs send-message \
+lstk aws sqs send-message \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/source-queue \
     --message-body "message-1"
 ```
@@ -118,7 +118,7 @@ awslocal sqs send-message \
 You can fetch the message from the target queue using the [`ReceiveMessage`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html) API:
 
 ```bash
-awslocal sqs receive-message \
+lstk aws sqs receive-message \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/target-queue
 ```
 

--- a/src/content/docs/aws/services/ram.mdx
+++ b/src/content/docs/aws/services/ram.mdx
@@ -20,7 +20,7 @@ This section will illustrate how to create permissions and resource shares using
 ### Create a permission
 
 ```bash
-awslocal ram create-permission \
+lstk aws ram create-permission \
     --name example \
     --resource-type appsync:apis \
     --policy-template '{"Effect": "Allow", "Action": "appsync:SourceGraphQL"}'
@@ -29,7 +29,7 @@ awslocal ram create-permission \
 ### Create a resource share
 
 ```bash
-awslocal ram create-resource-share \
+lstk aws ram create-resource-share \
     --name example-resource-share \
     --principals arn:aws:organizations::000000000000:organization/o-truopwybwi \
     --resource-arn arn:aws:appsync:eu-central-1:000000000000:apis/wcgmjril5wuyvhmpildatuaat3

--- a/src/content/docs/aws/services/rds.mdx
+++ b/src/content/docs/aws/services/rds.mdx
@@ -26,7 +26,7 @@ Recreating the RDS state is recommended for compatibility.
 
 ## Getting started
 
-This guide is designed for users new to RDS and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to RDS and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate the following with the AWS CLI:
@@ -44,7 +44,7 @@ The following command creates a new cluster with the name `db1` and the engine `
 Instances for the cluster must be added manually.
 
 ```bash
-awslocal rds create-db-cluster \
+lstk aws rds create-db-cluster \
     --db-cluster-identifier db1 \
     --engine aurora-postgresql \
     --database-name test \
@@ -67,7 +67,7 @@ awslocal rds create-db-cluster \
 To add an instance you can run the following command:
 
 ```bash
-awslocal rds create-db-instance \
+lstk aws rds create-db-instance \
     --db-instance-identifier db1-instance \
     --db-cluster-identifier db1 \
     --engine aurora-postgresql \
@@ -96,7 +96,7 @@ EOF
 Run the following command to create the secret:
 
 ```bash
-awslocal secretsmanager create-secret \
+lstk aws secretsmanager create-secret \
     --name dbpass \
     --secret-string file://mycreds.json
 ```
@@ -119,7 +119,7 @@ The following command executes a query against the database.
 The query returns the value `123`.
 
 ```bash
-awslocal rds-data execute-statement \
+lstk aws rds-data execute-statement \
     --database test \
     --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:db1 \
     --secret-arn arn:aws:secretsmanager:us-east-1:000000000000:secret:dbpass-cfnAX \
@@ -260,7 +260,7 @@ The database will be created with a single instance, which will be used as the m
 MASTER_USER=hello
 MASTER_PW='MyPassw0rd!'
 DB_NAME=test
-awslocal rds create-db-instance \
+lstk aws rds create-db-instance \
     --master-username $MASTER_USER \
     --master-user-password $MASTER_PW \
     --db-instance-identifier mydb \
@@ -276,8 +276,8 @@ You can retrieve the hostname and port of your created instance either from the 
 Run the following command to retrieve the host and port of the instance:
 
 ```bash
-PORT=$(awslocal rds describe-db-instances --db-instance-identifier mydb | jq -r ".DBInstances[0].Endpoint.Port")
-HOST=$(awslocal rds describe-db-instances --db-instance-identifier mydb | jq -r ".DBInstances[0].Endpoint.Address")
+PORT=$(lstk aws rds describe-db-instances --db-instance-identifier mydb | jq -r ".DBInstances[0].Endpoint.Port")
+HOST=$(lstk aws rds describe-db-instances --db-instance-identifier mydb | jq -r ".DBInstances[0].Endpoint.Address")
 ```
 
 Next, you can connect to the database using the master username and password:
@@ -292,7 +292,7 @@ PGPASSWORD=$MASTER_PW psql -d $DB_NAME -U $MASTER_USER -p $PORT -h $HOST -w -c '
 You can create a token for the user you generated using the [`generate-db-auth-token`](https://docs.aws.amazon.com/cli/latest/reference/rds/generate-db-auth-token.html) command:
 
 ```bash
-TOKEN=$(awslocal rds generate-db-auth-token --username myiam --hostname $HOST --port $PORT)
+TOKEN=$(lstk aws rds generate-db-auth-token --username myiam --hostname $HOST --port $PORT)
 ```
 
 You can now connect to the database utilizing the user you generated and the token obtained in the previous step as the password:

--- a/src/content/docs/aws/services/redshift.mdx
+++ b/src/content/docs/aws/services/redshift.mdx
@@ -21,7 +21,7 @@ For advanced features like Redshift Data API and other emulation capabilities, p
 
 ## Getting started
 
-This guide is designed for users new to RedShift and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to RedShift and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a RedShift cluster and database while using a Glue Crawler to populate the metadata store with the schema of the RedShift database tables using the AWS CLI.
@@ -52,7 +52,7 @@ You can create a RedShift cluster using the [`CreateCluster`](https://docs.aws.a
 The following command will create a RedShift cluster with the variables defined above:
 
 ```bash
-awslocal redshift create-cluster \
+lstk aws redshift create-cluster \
       --cluster-identifier $REDSHIFT_CLUSTER_IDENTIFIER \
       --db-name $REDSHIFT_DATABASE_NAME \
       --master-username $REDSHIFT_USERNAME \
@@ -64,7 +64,7 @@ You can fetch the status of the cluster using the [`DescribeClusters`](https://d
 Run the following command to extract the URL of the cluster:
 
 ```bash
-REDSHIFT_URL=$(awslocal redshift describe-clusters \
+REDSHIFT_URL=$(lstk aws redshift describe-clusters \
       --cluster-identifier $REDSHIFT_CLUSTER_IDENTIFIER | jq -r '(.Clusters[0].Endpoint.Address) + ":" + (.Clusters[0].Endpoint.Port|tostring)')
 ```
 
@@ -74,7 +74,7 @@ You can create a Glue database using the [`CreateDatabase`](https://docs.aws.ama
 The following command will create a Glue database:
 
 ```bash
-awslocal glue create-database \
+lstk aws glue create-database \
       --database-input "{\"Name\": \"$GLUE_DATABASE_NAME\"}"
 ```
 
@@ -82,7 +82,7 @@ You can create a connection to the RedShift cluster using the [`CreateConnection
 The following command will create a Glue connection with the RedShift cluster:
 
 ```bash
-awslocal glue create-connection \
+lstk aws glue create-connection \
       --connection-input "{\"Name\":\"$GLUE_CONNECTION_NAME\", \"ConnectionType\": \"JDBC\", \"ConnectionProperties\": {\"USERNAME\": \"$REDSHIFT_USERNAME\", \"PASSWORD\": \"$REDSHIFT_PASSWORD\", \"JDBC_CONNECTION_URL\": \"jdbc:redshift://$REDSHIFT_URL/$REDSHIFT_DATABASE_NAME\"}}"
 ```
 
@@ -90,7 +90,7 @@ Finally, you can create a Glue crawler using the [`CreateCrawler`](https://docs.
 The following command will create a Glue crawler:
 
 ```bash
-awslocal glue create-crawler \
+lstk aws glue create-crawler \
       --name $GLUE_CRAWLER_NAME \
       --database-name $GLUE_DATABASE_NAME \
       --targets "{\"JdbcTargets\": [{\"ConnectionName\": \"$GLUE_CONNECTION_NAME\", \"Path\": \"$REDSHIFT_DATABASE_NAME/%/$REDSHIFT_TABLE_NAME\"}]}" \
@@ -103,7 +103,7 @@ You can create a table in RedShift using the [`CreateTable`](https://docs.aws.am
 The following command will create a table in RedShift:
 
 ```bash
-REDSHIFT_STATEMENT_ID=$(awslocal redshift-data execute-statement \
+REDSHIFT_STATEMENT_ID=$(lstk aws redshift-data execute-statement \
       --cluster-identifier $REDSHIFT_CLUSTER_IDENTIFIER \
       --database $REDSHIFT_DATABASE_NAME \
       --sql \
@@ -114,7 +114,7 @@ You can check the status of the statement using the [`DescribeStatement`](https:
 The following command will check the status of the statement:
 
 ```bash
-wait "awslocal redshift-data describe-statement \
+wait "lstk aws redshift-data describe-statement \
       --id $REDSHIFT_STATEMENT_ID" ".Status" "FINISHED"
 ```
 
@@ -124,7 +124,7 @@ You can run the crawler using the [`StartCrawler`](https://docs.aws.amazon.com/g
 The following command will run the crawler:
 
 ```bash
-awslocal glue start-crawler \
+lstk aws glue start-crawler \
       --name $GLUE_CRAWLER_NAME
 ```
 
@@ -132,7 +132,7 @@ You can wait for the crawler to finish using the [`GetCrawler`](https://docs.aws
 The following command will wait for the crawler to finish:
 
 ```bash
-wait "awslocal glue get-crawler \
+wait "lstk aws glue get-crawler \
       --name $GLUE_CRAWLER_NAME" ".Crawler.State" "READY"
 ```
 
@@ -140,7 +140,7 @@ You can finally retrieve the schema of the table using the [`GetTable`](https://
 The following command will retrieve the schema of the table:
 
 ```bash
-awslocal glue get-table \
+lstk aws glue get-table \
       --database-name $GLUE_DATABASE_NAME \
       --name "${REDSHIFT_DATABASE_NAME}_${REDSHIFT_SCHEMA_NAME}_${REDSHIFT_TABLE_NAME}"
 ```

--- a/src/content/docs/aws/services/resource-groups-tagging-api.mdx
+++ b/src/content/docs/aws/services/resource-groups-tagging-api.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Resource Groups Tagging API and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Resource Groups Tagging API and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create resources, tag them, and query them using the Resource Groups Tagging API.
@@ -30,15 +30,15 @@ Create an S3 bucket and an SQS queue:
 BUCKET_NAME="rg-tagging-bucket"
 QUEUE_NAME="rg-tagging-queue"
 
-awslocal s3api create-bucket --bucket "$BUCKET_NAME"
-QUEUE_URL=$(awslocal sqs create-queue --queue-name "$QUEUE_NAME" | jq -r '.QueueUrl')
+lstk aws s3api create-bucket --bucket "$BUCKET_NAME"
+QUEUE_URL=$(lstk aws sqs create-queue --queue-name "$QUEUE_NAME" | jq -r '.QueueUrl')
 ```
 
 Retrieve the resource ARNs:
 
 ```bash
 BUCKET_ARN="arn:aws:s3:::$BUCKET_NAME"
-QUEUE_ARN=$(awslocal sqs get-queue-attributes \
+QUEUE_ARN=$(lstk aws sqs get-queue-attributes \
   --queue-url "$QUEUE_URL" \
   --attribute-names QueueArn | jq -r '.Attributes.QueueArn')
 ```
@@ -48,7 +48,7 @@ QUEUE_ARN=$(awslocal sqs get-queue-attributes \
 Use the [`TagResources`](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_TagResources.html) API to apply tags:
 
 ```bash
-awslocal resourcegroupstaggingapi tag-resources \
+lstk aws resourcegroupstaggingapi tag-resources \
   --resource-arn-list "$BUCKET_ARN" "$QUEUE_ARN" \
   --tags '{"Environment":"dev","Team":"platform"}'
 ```
@@ -58,15 +58,15 @@ awslocal resourcegroupstaggingapi tag-resources \
 Use the [`GetResources`](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html) API to list resources with a specific tag:
 
 ```bash
-awslocal resourcegroupstaggingapi get-resources \
+lstk aws resourcegroupstaggingapi get-resources \
   --tag-filters Key=Environment,Values=dev
 ```
 
 You can also inspect available keys and values:
 
 ```bash
-awslocal resourcegroupstaggingapi get-tag-keys
-awslocal resourcegroupstaggingapi get-tag-values --key Environment
+lstk aws resourcegroupstaggingapi get-tag-keys
+lstk aws resourcegroupstaggingapi get-tag-values --key Environment
 ```
 
 ### Remove tags from resources
@@ -74,7 +74,7 @@ awslocal resourcegroupstaggingapi get-tag-values --key Environment
 Use the [`UntagResources`](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_UntagResources.html) API to remove one or more tag keys:
 
 ```bash
-awslocal resourcegroupstaggingapi untag-resources \
+lstk aws resourcegroupstaggingapi untag-resources \
   --resource-arn-list "$BUCKET_ARN" "$QUEUE_ARN" \
   --tag-keys Team
 ```

--- a/src/content/docs/aws/services/resource-groups.mdx
+++ b/src/content/docs/aws/services/resource-groups.mdx
@@ -20,7 +20,7 @@ For tag-centric operations across AWS resources, see the [Resource Groups Taggin
 
 ## Getting Started
 
-This guide is designed for users new to Resource Groups and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Resource Groups and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a Resource Group using the AWS CLI.
@@ -37,7 +37,7 @@ Use the [`CreateGroup`](https://docs.aws.amazon.com/resource-groups/latest/APIRe
 Run the following command to create a Resource Group named `my-resource-group`:
 
 ```bash
-awslocal resource-groups create-group \
+lstk aws resource-groups create-group \
     --name my-resource-group \
     --resource-query '{"Type":"TAG_FILTERS_1_0","Query":"{\"ResourceTypeFilters\":[\"AWS::EC2::Instance\"],\"TagFilters\":[{\"Key\":\"Stage\",\"Values\":[\"Test\"]}]}"}'
 ```
@@ -50,7 +50,7 @@ To update a Resource Group, use the [`UpdateGroup`](https://docs.aws.amazon.com/
 Execute the following command to update the Resource Group `my-resource-group`:
 
 ```bash
-awslocal resource-groups update-group \
+lstk aws resource-groups update-group \
     --group-name my-resource-group \
     --description "EC2 S3 buckets and RDS DBs that we are using for the test stage"
 ```
@@ -59,7 +59,7 @@ Furthermore, you can also update the query and tags associated with a Resource G
 Run the following command to update the query and tags of the Resource Group `my-resource-group`:
 
 ```bash
-awslocal resource-groups update-group-query \
+lstk aws resource-groups update-group-query \
     --group-name my-resource-group \
     --resource-query '{"Type":"TAG_FILTERS_1_0","Query":"{\"ResourceTypeFilters\":[\"AWS::EC2::Instance\",\"AWS::S3::Bucket\",\"AWS::RDS::DBInstance\"],\"TagFilters\":[{\"Key\":\"Stage\",\"Values\":[\"Test\"]}]}"}'
 ```
@@ -70,7 +70,7 @@ To delete a Resource Group, use the [`DeleteGroup`](https://docs.aws.amazon.com/
 Run the following command to delete the Resource Group `my-resource-group`:
 
 ```bash
-awslocal resource-groups delete-group \
+lstk aws resource-groups delete-group \
     --group-name my-resource-group
 ```
 

--- a/src/content/docs/aws/services/route53.mdx
+++ b/src/content/docs/aws/services/route53.mdx
@@ -27,7 +27,7 @@ This would be required if you want to reach out to Route53 domain names from you
 
 ## Getting started
 
-This guide is designed for users new to Route53 and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Route53 and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a hosted zone and query the DNS record with the AWS CLI.
@@ -38,7 +38,7 @@ You can created a hosted zone for `example.com` using the [`CreateHostedZone`](h
 Run the following command:
 
 ```bash
-zone_id=$(awslocal route53 create-hosted-zone \
+zone_id=$(lstk aws route53 create-hosted-zone \
     --name example.com \
     --caller-reference r1 | jq -r '.HostedZone.Id')
 echo $zone_id
@@ -54,7 +54,7 @@ You can now change the resource record sets for the hosted zone `example.com` us
 Run the following command:
 
 ```bash
-awslocal route53 change-resource-record-sets \
+lstk aws route53 change-resource-record-sets \
     --hosted-zone-id $zone_id \
     --change-batch 'Changes=[{Action=CREATE,ResourceRecordSet={Name=test.example.com,Type=A,ResourceRecords=[{Value=1.2.3.4}]}}]'
 ```
@@ -82,19 +82,19 @@ DOMAIN="example.com"
 BUCKET_NAME="$DOMAIN"
 
 # Create the bucket
-awslocal s3api create-bucket --bucket "$BUCKET_NAME"
+lstk aws s3api create-bucket --bucket "$BUCKET_NAME"
 
 # Upload your website files
-awslocal s3 cp index.html s3://$BUCKET_NAME/
-awslocal s3 cp error.html s3://$BUCKET_NAME/
+lstk aws s3 cp index.html s3://$BUCKET_NAME/
+lstk aws s3 cp error.html s3://$BUCKET_NAME/
 
 # Configure the bucket for website hosting
-awslocal s3 website s3://"$BUCKET_NAME"/ \
+lstk aws s3 website s3://"$BUCKET_NAME"/ \
     --index-document index.html \
     --error-document error.html
 
 # Set bucket policy to allow public read access
-awslocal s3api put-bucket-policy \
+lstk aws s3api put-bucket-policy \
     --bucket $BUCKET_NAME \
     --policy '{
         "Version": "2012-10-17",
@@ -114,7 +114,7 @@ Now create a hosted zone and an alias record that points to the S3 website endpo
 
 ```bash
 # Create the hosted zone
-HOSTED_ZONE_ID=$(awslocal route53 create-hosted-zone \
+HOSTED_ZONE_ID=$(lstk aws route53 create-hosted-zone \
     --name "$DOMAIN" \
     --caller-reference "$(date +%s)" \
     --output text \
@@ -123,7 +123,7 @@ HOSTED_ZONE_ID=$(awslocal route53 create-hosted-zone \
 echo "Hosted Zone created with ID: $HOSTED_ZONE_ID"
 
 # Create an alias record pointing to the S3 website endpoint
-awslocal route53 change-resource-record-sets \
+lstk aws route53 change-resource-record-sets \
     --hosted-zone-id "$HOSTED_ZONE_ID" \
     --change-batch '{
         "Comment": "Create alias record for S3 static website",
@@ -171,7 +171,7 @@ After creating your load balancer, you can create an alias record that points to
 ELB_DNS_NAME="my-load-balancer-123456.elb.localhost.localstack.cloud"
 
 # Create an alias record pointing to the ELB
-awslocal route53 change-resource-record-sets \
+lstk aws route53 change-resource-record-sets \
     --hosted-zone-id "$HOSTED_ZONE_ID" \
     --change-batch '{
         "Comment": "Create alias record for ELB",
@@ -239,7 +239,7 @@ Create a hosted zone for the domain `localhost.localstack.cloud` using the [`Cre
 Run the following command:
 
 ```bash
-zone_id=$(awslocal route53 create-hosted-zone \
+zone_id=$(lstk aws route53 create-hosted-zone \
     --name localhost.localstack.cloud \
     --caller-reference r1 | jq -r .HostedZone.Id)
 echo $zone_id
@@ -253,7 +253,7 @@ You can now use the [`ChangeResourceRecordSets`](https://docs.aws.amazon.com/Rou
 Run the following command to accomplish this:
 
 ```bash
-awslocal route53 change-resource-record-sets \
+lstk aws route53 change-resource-record-sets \
     --hosted-zone-id $zone_id \
     --change-batch '{"Changes":[{"Action":"CREATE","ResourceRecordSet":{"Name":"localhost.localstack.cloud","Type":"A","ResourceRecords":[{"Value":"5.6.7.8"}]}},{"Action":"CREATE","ResourceRecordSet":{"Name":"*.localhost.localstack.cloud","Type":"A","ResourceRecords":[{"Value":"5.6.7.8"}]}}]}'
 ```

--- a/src/content/docs/aws/services/route53resolver.mdx
+++ b/src/content/docs/aws/services/route53resolver.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Route53 Resolver and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Route53 Resolver and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a resolver endpoint, list the endpoints, and delete the endpoint with the AWS CLI.
@@ -28,13 +28,13 @@ We will demonstrate how to create a resolver endpoint, list the endpoints, and d
 Fetch the default VPC ID using the following command:
 
 ```bash
-VPC_ID=$(awslocal ec2 describe-vpcs --query 'Vpcs[?IsDefault==`true`].VpcId' --output text)
+VPC_ID=$(lstk aws ec2 describe-vpcs --query 'Vpcs[?IsDefault==`true`].VpcId' --output text)
 ```
 
 Fetch the default VPC's security group ID using the following command:
 
 ```bash
-awslocal ec2 describe-subnets --filters Name=vpc-id,Values=$VPC_ID --query 'Subnets[].SubnetId'
+lstk aws ec2 describe-subnets --filters Name=vpc-id,Values=$VPC_ID --query 'Subnets[].SubnetId'
 ```
 
 ```bash title="Output"
@@ -51,7 +51,7 @@ awslocal ec2 describe-subnets --filters Name=vpc-id,Values=$VPC_ID --query 'Subn
 Choose two subnets from the list above and fetch the CIDR block of the subnets which tells you the range of IP addresses within it. Let's fetch the CIDR block of the subnet `subnet-957d6ba6`:
 
 ```bash
-awslocal ec2 describe-subnets --subnet-ids subnet-957d6ba6 --query 'Subnets[*].CidrBlock'
+lstk aws ec2 describe-subnets --subnet-ids subnet-957d6ba6 --query 'Subnets[*].CidrBlock'
 ```
 
 ```bash title="Output"
@@ -63,7 +63,7 @@ awslocal ec2 describe-subnets --subnet-ids subnet-957d6ba6 --query 'Subnets[*].C
 Similarly, fetch the CIDR block of the subnet `subnet-bdd58a47`:
 
 ```bash
-awslocal ec2 describe-subnets --subnet-ids subnet-bdd58a47 --query 'Subnets[*].CidrBlock'
+lstk aws ec2 describe-subnets --subnet-ids subnet-bdd58a47 --query 'Subnets[*].CidrBlock'
 ```
 
 ```bash title="Output"
@@ -76,7 +76,7 @@ Save the CIDR blocks of the subnets as you will need them later.
 Lastly fetch the security group ID of the default VPC:
 
 ```bash
-awslocal ec2 describe-security-groups \
+lstk aws ec2 describe-security-groups \
     --filters Name=vpc-id,Values=$VPC_ID \
     --query 'SecurityGroups[0].GroupId'
 ```
@@ -122,7 +122,7 @@ You can now use the [`CreateResolverEndpoint`](https://docs.aws.amazon.com/Route
 Run the following command:
 
 ```bash
-awslocal route53resolver create-resolver-endpoint \
+lstk aws route53resolver create-resolver-endpoint \
     --cli-input-json file://create-outbound-resolver-endpoint.json
 ```
 
@@ -153,7 +153,7 @@ You can list the resolver endpoints using the [`ListResolverEndpoints`](https://
 Run the following command:
 
 ```bash
-awslocal route53resolver list-resolver-endpoints
+lstk aws route53resolver list-resolver-endpoints
 ```
 
 ```bash title="Output"
@@ -186,7 +186,7 @@ You can delete the resolver endpoint using the [`DeleteResolverEndpoint`](https:
 Run the following command:
 
 ```bash
-awslocal route53resolver delete-resolver-endpoint \
+lstk aws route53resolver delete-resolver-endpoint \
     --resolver-endpoint-id rslvr-out-5d61abaff9de06b99
 ```
 

--- a/src/content/docs/aws/services/s3.mdx
+++ b/src/content/docs/aws/services/s3.mdx
@@ -19,7 +19,7 @@ The supported APIs are available on the API coverage section for [S3](#api-cover
 
 ## Getting started
 
-This guide is designed for users new to S3 and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to S3 and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can create an S3 bucket, manage S3 objects, and generate pre-signed URLs for S3 objects.
@@ -30,14 +30,14 @@ You can create an S3 bucket using the [`CreateBucket`](https://docs.aws.amazon.c
 Run the following command to create an S3 bucket named `sample-bucket`:
 
 ```bash
-awslocal s3api create-bucket --bucket sample-bucket
+lstk aws s3api create-bucket --bucket sample-bucket
 ```
 
 You can list your S3 buckets using the [`ListBuckets`](https://docs.aws.amazon.com/cli/latest/reference/s3api/list-buckets.html) API.
 Run the following command to list your S3 buckets:
 
 ```bash
-awslocal s3api list-buckets
+lstk aws s3api list-buckets
 ```
 
 ```bash title="Output"
@@ -62,7 +62,7 @@ Download a random image from the internet and save it as `image.jpg`.
 Run the following command to upload the file to your S3 bucket:
 
 ```bash
-awslocal s3api put-object \
+lstk aws s3api put-object \
   --bucket sample-bucket \
   --key image.jpg \
   --body image.jpg
@@ -72,7 +72,7 @@ You can list the objects in your S3 bucket using the [`ListObjects`](https://doc
 Run the following command to list the objects in your S3 bucket:
 
 ```bash
-awslocal s3api list-objects \
+lstk aws s3api list-objects \
   --bucket sample-bucket
 ```
 
@@ -99,7 +99,7 @@ If your image has been uploaded successfully, you will see the following output:
 Run the following command to upload a file named `index.html` to your S3 bucket:
 
 ```bash
-awslocal s3api put-object --bucket sample-bucket --key index.html --body index.html
+lstk aws s3api put-object --bucket sample-bucket --key index.html --body index.html
 ```
 
 ```bash title="Output"
@@ -116,7 +116,7 @@ Pre-signed URL allows anyone to retrieve the S3 object with an HTTP GET request.
 Run the following command to generate a pre-signed URL for your S3 object:
 
 ```bash
-awslocal s3 presign s3://sample-bucket/image.jpg
+lstk aws s3 presign s3://sample-bucket/image.jpg
 ```
 
 You will see a generated pre-signed URL for your S3 object.
@@ -161,7 +161,7 @@ It would allow your local application to communicate directly with an S3 bucket 
 By default, LocalStack will apply specific CORS rules to all requests to allow you to display and access your resources through [LocalStack Web Application](https://app.localstack.cloud).
 If no CORS rules are configured for your S3 bucket, LocalStack will apply default rules unless specified otherwise.
 
-To configure CORS rules for your S3 bucket, you can use the `awslocal` wrapper.
+To configure CORS rules for your S3 bucket, you can use the `lstk aws` command.
 Optionally, you can run a local web application on [localhost:3000](http://localhost:3000).
 You can emulate the same behaviour with an AWS SDK or an integration you use.
 Follow this step-by-step guide to configure CORS rules on your S3 bucket.
@@ -169,7 +169,7 @@ Follow this step-by-step guide to configure CORS rules on your S3 bucket.
 Run the following command on your terminal to create your S3 bucket:
 
 ```bash
-awslocal s3api create-bucket --bucket cors-bucket
+lstk aws s3api create-bucket --bucket cors-bucket
 ```
 
 ```bash title="Output"
@@ -202,13 +202,13 @@ Save the file locally with a name of your choice, for example, `cors-config.json
 Run the following command to apply the CORS configuration to your S3 bucket:
 
 ```bash
-awslocal s3api put-bucket-cors --bucket cors-bucket --cors-configuration file://cors-config.json
+lstk aws s3api put-bucket-cors --bucket cors-bucket --cors-configuration file://cors-config.json
 ```
 
 You can further verify that the CORS configuration was applied successfully by running the following command:
 
 ```bash
-awslocal s3api get-bucket-cors --bucket cors-bucket
+lstk aws s3api get-bucket-cors --bucket cors-bucket
 ```
 
 On applying the configuration successfully, you should see the same JSON configuration file you created earlier.
@@ -237,8 +237,8 @@ We can edit the JSON file `cors-config.json` you created earlier with the follow
 You can now run the same steps as before to update the CORS configuration and verify if it is applied correctly:
 
 ```bash
-awslocal s3api put-bucket-cors --bucket cors-bucket --cors-configuration file://cors-config.json
-awslocal s3api get-bucket-cors --bucket cors-bucket
+lstk aws s3api put-bucket-cors --bucket cors-bucket --cors-configuration file://cors-config.json
+lstk aws s3api get-bucket-cors --bucket cors-bucket
 ```
 
 You can try again to upload files in your bucket from the [LocalStack Web Application](https://app.localstack.cloud) and it should work.

--- a/src/content/docs/aws/services/s3tables.mdx
+++ b/src/content/docs/aws/services/s3tables.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on the [API coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to S3 Tables and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to S3 Tables and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a table bucket, a namespace, a table, and how to retrieve table details and metadata location with the AWS CLI.
@@ -30,7 +30,7 @@ You can create a table bucket to store S3 Tables using the [`CreateTableBucket`]
 Run the following command to create a table bucket named `my-table-bucket`:
 
 ```bash
-awslocal s3tables create-table-bucket --name my-table-bucket
+lstk aws s3tables create-table-bucket --name my-table-bucket
 ```
 
 ```bash title="Output"
@@ -46,7 +46,7 @@ Namespaces help organize tables within a table bucket. You can create a namespac
 Run the following command to create a namespace named `my_namespace` within the table bucket `my-table-bucket`:
 
 ```bash
-awslocal s3tables create-namespace \
+lstk aws s3tables create-namespace \
     --table-bucket-arn arn:aws:s3tables:us-east-1:000000000000:bucket/my-table-bucket \
     --namespace my_namespace
 ```
@@ -67,7 +67,7 @@ You can also create a table within the namespace with the [`CreateTable`](https:
 Run the following command to create a table named `my_table` within the namespace `my_namespace`:
 
 ```bash
-awslocal s3tables create-table \
+lstk aws s3tables create-table \
     --table-bucket-arn arn:aws:s3tables:us-east-1:000000000000:bucket/my-table-bucket \
     --namespace my_namespace \
     --name my_table \
@@ -88,7 +88,7 @@ You can describe the table to view details such as ARN, namespace, format, and w
 Run the following command to describe the table `my_table`:
 
 ```bash
-awslocal s3tables get-table \
+lstk aws s3tables get-table \
     --table-bucket-arn arn:aws:s3tables:us-east-1:000000000000:bucket/my-table-bucket \
     --namespace my_namespace \
     --name my_table
@@ -121,7 +121,7 @@ You can fetch the warehouse location used for table metadata using the [`GetTabl
 Run the following command to fetch the warehouse location for the table `my_table`:
 
 ```bash
-awslocal s3tables get-table-metadata-location \
+lstk aws s3tables get-table-metadata-location \
     --table-bucket-arn arn:aws:s3tables:us-east-1:000000000000:bucket/my-table-bucket \
     --namespace my_namespace \
     --name my_table
@@ -142,7 +142,7 @@ You can list tables in the `my_namespace` namespace using the [`ListTables`](htt
 Run the following command to list tables in the namespace `my_namespace`:
 
 ```bash
-awslocal s3tables list-tables \
+lstk aws s3tables list-tables \
     --table-bucket-arn arn:aws:s3tables:us-east-1:000000000000:bucket/my-table-bucket \
     --namespace my_namespace
 ```

--- a/src/content/docs/aws/services/scheduler.mdx
+++ b/src/content/docs/aws/services/scheduler.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to EventBridge Scheduler and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to EventBridge Scheduler and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can create a new schedule, list all schedules, and tag a schedule using the EventBridge Scheduler APIs.
@@ -28,14 +28,14 @@ You can create a new SQS queue using the [`CreateQueue`](https://docs.aws.amazon
 Run the following command to create a new SQS queue:
 
 ```bash
-awslocal sqs create-queue --queue-name local-notifications
+lstk aws sqs create-queue --queue-name local-notifications
 ```
 
 You can fetch the Queue ARN using the [`GetQueueAttributes`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html) API.
 Run the following command to fetch the Queue ARN by specifying the Queue URL:
 
 ```bash
-awslocal sqs get-queue-attributes \
+lstk aws sqs get-queue-attributes \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/local-notifications \
     --attribute-names All
 ```
@@ -48,7 +48,7 @@ You can create a new schedule using the [`CreateSchedule`](https://docs.aws.amaz
 Run the following command to create a new schedule:
 
 ```bash
-awslocal scheduler create-schedule \
+lstk aws scheduler create-schedule \
     --name sqs-templated-schedule \
     --schedule-expression 'rate(5 minutes)' \
     --target '{"RoleArn": "arn:aws:iam::000000000000:role/schedule-role", "Arn":"arn:aws:sqs:us-east-1:000000000000:local-notifications", "Input": "test" }' \
@@ -67,7 +67,7 @@ You can list all schedules using the [`ListSchedules`](https://docs.aws.amazon.c
 Run the following command to list all schedules:
 
 ```bash
-awslocal scheduler list-schedules
+lstk aws scheduler list-schedules
 ```
 
 ```bash title="Output"
@@ -94,7 +94,7 @@ You can tag a schedule using the [`TagResource`](https://docs.aws.amazon.com/eve
 Run the following command to tag a schedule:
 
 ```bash
-awslocal scheduler tag-resource \
+lstk aws scheduler tag-resource \
     --resource-arn arn:aws:scheduler:us-east-1:000000000000:schedule/default/sqs-templated-schedule \
     --tags Key=Name,Value=Test
 ```
@@ -103,7 +103,7 @@ You can view the tags associated with a schedule using the [`ListTagsForResource
 Run the following command to list the tags associated with a schedule:
 
 ```bash
-awslocal scheduler list-tags-for-resource \
+lstk aws scheduler list-tags-for-resource \
     --resource-arn arn:aws:scheduler:us-east-1:00000000
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/secretsmanager.mdx
+++ b/src/content/docs/aws/services/secretsmanager.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Secrets Manager and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Secrets Manager and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a secret, get the secret value, and rotate the secret using the AWS CLI.
@@ -41,7 +41,7 @@ You can now create a secret using the [`CreateSecret`](https://docs.aws.amazon.c
 Execute the following command to create a secret named `test-secret`:
 
 ```bash
-awslocal secretsmanager create-secret \
+lstk aws secretsmanager create-secret \
     --name test-secret \
     --description "LocalStack Secret" \
     --secret-string file://secrets.json
@@ -64,7 +64,7 @@ To retrieve the details of the secret you created earlier, you can use the [`Des
 Execute the following command:
 
 ```bash
-awslocal secretsmanager describe-secret \
+lstk aws secretsmanager describe-secret \
     --secret-id test-secret
 ```
 
@@ -87,7 +87,7 @@ You can also get a list of the secrets available in your local environment that 
 Execute the following command:
 
 ```bash
-awslocal secretsmanager list-secrets \
+lstk aws secretsmanager list-secrets \
     --filters Key=name,Values=Secret
 ```
 
@@ -97,7 +97,7 @@ To retrieve the value of the secret you created earlier, you can use the [`GetSe
 Execute the following command:
 
 ```bash
-awslocal secretsmanager get-secret-value \
+lstk aws secretsmanager get-secret-value \
     --secret-id test-secret
 ```
 
@@ -118,7 +118,7 @@ You can tag your secret using the [`TagResource`](https://docs.aws.amazon.com/se
 Execute the following command:
 
 ```bash
-awslocal secretsmanager tag-resource \
+lstk aws secretsmanager tag-resource \
     --secret-id test-secret \
     --tags Key=Environment,Value=Development
 ```
@@ -133,7 +133,7 @@ Execute the following command:
 
 ```bash
 zip my-function.zip lambda_function.py
-awslocal lambda create-function \
+lstk aws lambda create-function \
     --function-name my-rotation-function \
     --runtime python3.9 \
     --zip-file fileb://my-function.zip \
@@ -148,7 +148,7 @@ Please note that this is not required with the default LocalStack settings, sinc
 Execute the following command:
 
 ```bash
-awslocal lambda add-permission \
+lstk aws lambda add-permission \
     --function-name my-rotation-function \
     --action lambda:InvokeFunction \
     --statement-id SecretsManager \
@@ -159,7 +159,7 @@ You can now create a rotation schedule for the secret using the [`RotateSecret`]
 Execute the following command:
 
 ```bash
-awslocal secretsmanager rotate-secret \
+lstk aws secretsmanager rotate-secret \
     --secret-id MySecret \
     --rotation-lambda-arn arn:aws:lambda:us-east-1:000000000000:function:my-rotation-function \
     --rotation-rules "{\"ScheduleExpression\": \"cron(0 16 1,15 *?*)\", \"Duration\": \"2h\"}"

--- a/src/content/docs/aws/services/serverlessrepo.mdx
+++ b/src/content/docs/aws/services/serverlessrepo.mdx
@@ -72,10 +72,10 @@ Resources:
 
 ### Retrieve the Application ID
 
-To retrieve the Application ID for your SAM application, you can utilize the [`awslocal`](https://github.com/localstack/awscli-local) CLI by running the following command:
+To retrieve the Application ID for your SAM application, you can utilize [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) by running the following command:
 
 ```bash
-awslocal serverlessrepo list-applications
+lstk aws serverlessrepo list-applications
 ```
 
 In the output, you will observe the `ApplicationId` property in the output, which is the Application ID for your SAM application, along with other properties such as the `Author`, `Description`, `Name`, `SpdxLicenseId`, and `Version` providing further details about your application.
@@ -95,7 +95,7 @@ samlocal publish \
 To remove a SAM application from the Serverless Application Repository, you can use the following command:
 
 ```bash
-awslocal serverlessrepo delete-application \
+lstk aws serverlessrepo delete-application \
     --application-id <application-id>
 ```
 

--- a/src/content/docs/aws/services/serverlessrepo.mdx
+++ b/src/content/docs/aws/services/serverlessrepo.mdx
@@ -17,17 +17,17 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Serverless Application Repository and assumes basic knowledge of the SAM CLI and our [`samlocal`](https://github.com/localstack/aws-sam-cli-local) wrapper script.
+This guide is designed for users new to Serverless Application Repository and assumes basic knowledge of the SAM CLI and our [`lstk sam`](/aws/developer-tools/running-localstack/lstk/) command.
 
 Start your LocalStack container using your preferred method, such as via docker-compose.
 We will demonstrate how to create a SAM application that comprises a Hello World serverless application with a simple API backend using the SAM CLI and then publish it to the Serverless Application Repository by defining it using a SAM template.
 
 ### Setup the SAM application
 
-To create a sample SAM application using the `samlocal` CLI, execute the following command:
+To create a sample SAM application using the `lstk sam` command, execute the following:
 
 ```bash
-samlocal init --runtime python3.9
+lstk sam init --runtime python3.9
 ```
 
 This command downloads a sample SAM application template and generates a `template.yml` file in the current directory.
@@ -35,10 +35,10 @@ The template includes a Lambda function and an API Gateway endpoint that support
 
 ### Package the SAM application
 
-Next, we can use the `samlocal` CLI to create a deployment package and a packaged SAM template.
+Next, we can use the `lstk sam` command to create a deployment package and a packaged SAM template.
 Add a Metadata section to your SAM template file (`template.yaml`), and specify the following properties:
 
-To create a deployment package and a packaged SAM template using the `samlocal` CLI, add a Metadata section to your SAM template file (`template.yaml`) and specify the desired properties:
+To create a deployment package and a packaged SAM template using the `lstk sam` command, add a Metadata section to your SAM template file (`template.yaml`) and specify the desired properties:
 
 ```yaml title="template.yaml"
 Metadata:
@@ -54,7 +54,7 @@ Metadata:
 Once the Metadata section is added, run the following command to create the Lambda function deployment package and the packaged SAM template:
 
 ```bash
-samlocal package \
+lstk sam package \
     --template-file template.yaml \
     --output-template-file packaged.yaml
 ```
@@ -85,7 +85,7 @@ In the output, you will observe the `ApplicationId` property in the output, whic
 To publish your application to the Serverless Application Repository, execute the following command:
 
 ```bash
-samlocal publish \
+lstk sam publish \
     --template packaged.yaml \
     --region us-east-1
 ```

--- a/src/content/docs/aws/services/servicediscovery.mdx
+++ b/src/content/docs/aws/services/servicediscovery.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting Started
 
-This guide is designed for users new to Service Discovery and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Service Discovery and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an ECS service containing a Fargate task that uses Service Discovery with the AWS CLI.
@@ -30,7 +30,7 @@ This API allows you to define a custom name for your namespace and specify the V
 To create the private Cloud Map service discovery namespace, execute the following command:
 
 ```bash
-awslocal servicediscovery create-private-dns-namespace \
+lstk aws servicediscovery create-private-dns-namespace \
       --name tutorial \
       --vpc <vpc-id>
 ```
@@ -42,7 +42,7 @@ This identifier can be used to check the status of the operation.
 To verify the status of the operation, execute the following command:
 
 ```bash
-awslocal servicediscovery get-operation \
+lstk aws servicediscovery get-operation \
       --operation-id <operation-id>
 ```
 
@@ -56,7 +56,7 @@ This service represents a specific component or resource in your application.
 To create a service within the namespace, execute the following command:
 
 ```bash
-awslocal servicediscovery create-service \
+lstk aws servicediscovery create-service \
       --name myapplication \
       --dns-config "NamespaceId="<Namespace-ID>",DnsRecords=[{Type="A",TTL="300"}]" \
       --health-check-custom-config FailureThreshold=1
@@ -73,7 +73,7 @@ Start by creating an ECS cluster using the [`CreateCluster`](https://docs.aws.am
 Execute the following command:
 
 ```bash
-awslocal ecs create-cluster \
+lstk aws ecs create-cluster \
       --cluster-name tutorial
 ```
 
@@ -121,7 +121,7 @@ Register the task definition using the [`RegisterTaskDefinition`](https://docs.a
 Execute the following command:
 
 ```bash
-awslocal ecs register-task-definition \
+lstk aws ecs register-task-definition \
       --cli-input-json file://fargate-task.json
 ```
 
@@ -132,7 +132,7 @@ You can obtain this information by using the [`DescribeVpcs`](https://docs.aws.a
 Execute the following command to retrieve the details of all VPCs:
 
 ```bash
-awslocal ec2 describe-vpcs
+lstk aws ec2 describe-vpcs
 ```
 
 The output will include a list of VPCs.
@@ -141,12 +141,12 @@ Locate the VPC that was used to create the Cloud Map namespace and make a note o
 Next, execute the following commands to retrieve the `securityGroups` and `subnets` associated with the VPC:
 
 ```bash
-awslocal ec2 describe-security-groups \
+lstk aws ec2 describe-security-groups \
     --filters Name=vpc-id,Values=vpc-<ID> \
     --query 'SecurityGroups[*].[GroupId, GroupName]' \
     --output text
 
-awslocal ec2 describe-subnets \
+lstk aws ec2 describe-subnets \
     --filters Name=vpc-id,Values=vpc-<ID> \
     --query 'Subnets[*].[SubnetId, CidrBlock]' \
     --output text
@@ -184,7 +184,7 @@ Create your ECS service using the [`CreateService`](https://docs.aws.amazon.com/
 Execute the following command:
 
 ```bash
-awslocal ecs create-service \
+lstk aws ecs create-service \
       --cli-input-json file://ecs-service-discovery.json
 ```
 
@@ -194,7 +194,7 @@ You can use the Service Discovery service ID to verify that the service was crea
 Execute the following command:
 
 ```bash
-awslocal servicediscovery list-instances \
+lstk aws servicediscovery list-instances \
        --service-id <service-id>
 ```
 
@@ -219,10 +219,10 @@ Both conditions and only support a single value to match by.
 The following examples demonstrate how to use filters with these operations:
 
 ```bash
-awslocal servicediscovery list-namespaces \
+lstk aws servicediscovery list-namespaces \
     --filters "Name=HTTP_NAME,Values=['example-namespace'],Condition=EQ"
 
-awslocal servicediscovery list-services \
+lstk aws servicediscovery list-services \
     --filters "Name=NAMESPACE_ID,Values=['id_to_match']"
 ```
 
@@ -232,7 +232,7 @@ Conditions in parameters must match return values, while if one ore more conditi
 This command will only return instances where the parameter `env` is equal to `fuu`:
 
 ```bash
-awslocal servicediscovery discover-instances \
+lstk aws servicediscovery discover-instances \
     --namespace-name example-namespace \
     --service-name example-service \
     --query-parameters "env"="fuu"
@@ -241,7 +241,7 @@ awslocal servicediscovery discover-instances \
 This command instead will return all instances where the optional parameter `env` is equal to `bar`, but if no instances match, all instances are returned:
 
 ```bash
-awslocal servicediscovery discover-instances \
+lstk aws servicediscovery discover-instances \
     --namespace-name example-namespace \
     --service-name example-service \
     --optional-parameters "env"="bar"

--- a/src/content/docs/aws/services/ses.mdx
+++ b/src/content/docs/aws/services/ses.mdx
@@ -21,7 +21,7 @@ For advanced features like SMTP integration and other emulation capabilities, pl
 ## Getting Started
 
 This is an introductory guide to get started with SES.
-Basic knowledge of the AWS CLI and LocalStack [`awslocal`](https://github.com/localstack/awscli-local) command is assumed.
+Basic knowledge of the AWS CLI and LocalStack [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command is assumed.
 
 Start LocalStack using your preferred method.
 
@@ -31,9 +31,9 @@ A verified identity appears as part of the 'From' field in the sent email.
 A singular email identity can be added using the `VerifyEmailIdentity` operation.
 
 ```bash
-awslocal ses verify-email-identity --email hello@example.com
+lstk aws ses verify-email-identity --email hello@example.com
 
-awslocal ses list-identities
+lstk aws ses list-identities
 ```
 
 ```bash title="Output"
@@ -52,7 +52,7 @@ In LocalStack, identities are automatically verified.
 Next, emails can be sent using the `SendEmail` operation.
 
 ```bash
-awslocal ses send-email \
+lstk aws ses send-email \
         --from "hello@example.com"   \
         --message 'Body={Text={Data="This is the email body"}},Subject={Data="This is the email subject"}'   \
         --destination 'ToAddresses=jeff@aws.com'

--- a/src/content/docs/aws/services/shield.mdx
+++ b/src/content/docs/aws/services/shield.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting Started
 
-This guide is designed for users new to Shield and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Shield and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a Shield protection, list all protections, and delete a protection with the AWS CLI.
@@ -28,7 +28,7 @@ To create a Shield protection, use the [`CreateProtection`](https://docs.aws.ama
 The following command creates a Shield protection for a resource:
 
 ```bash
-awslocal shield create-protection \
+lstk aws shield create-protection \
   --name "my-protection" \
   --resource-arn "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-alb/1234567890"
 ```
@@ -45,7 +45,7 @@ To list all Shield protections, use the [`ListProtections`](https://docs.aws.ama
 The following command lists all Shield protections:
 
 ```bash
-awslocal shield list-protections
+lstk aws shield list-protections
 ```
 
 ```bash title="Output"
@@ -67,7 +67,7 @@ To describe a Shield protection, use the [`DescribeProtection`](https://docs.aws
 The following command describes a Shield protection:
 
 ```bash
-awslocal shield describe-protection \
+lstk aws shield describe-protection \
   --protection-id "67908d33-16c0-443d-820a-31c02c4d5976"
 ```
 
@@ -90,7 +90,7 @@ To delete a Shield protection, use the [`DeleteProtection`](https://docs.aws.ama
 The following command deletes a Shield protection:
 
 ```bash
-awslocal shield delete-protection \
+lstk aws shield delete-protection \
   --protection-id "67908d33-16c0-443d-820a-31c02c4d5976"
 ```
 

--- a/src/content/docs/aws/services/sns.mdx
+++ b/src/content/docs/aws/services/sns.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 ## Getting started
 
 This guide is intended for users who wish to get more acquainted with SNS over LocalStack.
-It assumes you have basic knowledge of the AWS CLI (and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script).
+It assumes you have basic knowledge of the AWS CLI (and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command).
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an SNS topic, publish messages, and subscribe to the topic.
@@ -29,14 +29,14 @@ To create an SNS topic, use the [`CreateTopic`](https://docs.aws.amazon.com/sns/
 Run the following command to create a topic named `localstack-topic`:
 
 ```bash
-awslocal sns create-topic --name localstack-topic
+lstk aws sns create-topic --name localstack-topic
 ```
 
 You can set the SNS topic attribute using the SNS topic you created previously by using the [`SetTopicAttributes`](https://docs.aws.amazon.com/sns/latest/api/API_SetTopicAttributes.html) API.
 Run the following command to set the `DisplayName` attribute for the topic:
 
 ```bash
-awslocal sns set-topic-attributes \
+lstk aws sns set-topic-attributes \
    --topic-arn arn:aws:sns:us-east-1:000000000000:localstack-topic \
    --attribute-name DisplayName \
    --attribute-value MyTopicDisplayName
@@ -46,7 +46,7 @@ You can list all the SNS topics using the [`ListTopics`](https://docs.aws.amazon
 Run the following command to list all the SNS topics:
 
 ```bash
-awslocal sns list-topics
+lstk aws sns list-topics
 ```
 
 ### Get attributes and publish messages to SNS topic
@@ -55,7 +55,7 @@ You can get attributes for a single SNS topic using the [`GetTopicAttributes`](h
 Run the following command to get the attributes for the SNS topic:
 
 ```bash
-awslocal sns get-topic-attributes \
+lstk aws sns get-topic-attributes \
    --topic-arn arn:aws:sns:us-east-1:000000000000:localstack-topic
 ```
 
@@ -65,7 +65,7 @@ To publish messages to the SNS topic, create a new file named `messages.txt` in 
 Run the following command to publish messages to the SNS topic using the [`Publish`](https://docs.aws.amazon.com/sns/latest/api/API_Publish.html) API:
 
 ```bash
-awslocal sns publish \
+lstk aws sns publish \
    --topic-arn "arn:aws:sns:us-east-1:000000000000:localstack-topic" \
    --message file://message.txt
 ```
@@ -76,7 +76,7 @@ You can subscribe to the SNS topic using the [`Subscribe`](https://docs.aws.amaz
 Run the following command to subscribe to the SNS topic:
 
 ```bash
-awslocal sns subscribe \
+lstk aws sns subscribe \
    --topic-arn arn:aws:sns:us-east-1:000000000000:localstack-topic \
    --protocol email \
    --notification-endpoint test@gmail.com
@@ -86,7 +86,7 @@ You can configure the SNS Subscription attributes, using the `SubscriptionArn` r
 For example, run the following command to set the `RawMessageDelivery` attribute for the subscription:
 
 ```bash
-awslocal sns set-subscription-attributes \
+lstk aws sns set-subscription-attributes \
    --subscription-arn arn:aws:sns:us-east-1:000000000000:test-topic:b6f5e924-dbb3-41c9-aa3b-589dbae0cfff \
    --attribute-name RawMessageDelivery --attribute-value true
 ```
@@ -99,7 +99,7 @@ A Common technology to integrate with is SQS.
 First we need to ensure we create an SQS queue named `my-queue`:
 
 ```bash
-awslocal sqs create-queue --queue-name my-queue
+lstk aws sqs create-queue --queue-name my-queue
 ```
 
 ```bash title="Output"
@@ -111,7 +111,7 @@ awslocal sqs create-queue --queue-name my-queue
 Subscribe the SQS queue to the topic we created previously:
 
 ```bash
-awslocal sns subscribe \
+lstk aws sns subscribe \
     --topic-arn "arn:aws:sns:us-east-1:000000000000:localstack-topic" \
     --protocol sqs \
     --notification-endpoint "arn:aws:sqs:us-east-1:000000000000:my-queue"
@@ -126,7 +126,7 @@ awslocal sns subscribe \
 Sending a message to the queue, via the topic
 
 ```bash
-awslocal sns publish --topic-arn "arn:aws:sns:us-east-1:000000000000:localstack-topic" --message "hello"
+lstk aws sns publish --topic-arn "arn:aws:sns:us-east-1:000000000000:localstack-topic" --message "hello"
 {
     "MessageId": "5a1593ce-411b-44dc-861d-907daa05353b"
 }
@@ -135,7 +135,7 @@ awslocal sns publish --topic-arn "arn:aws:sns:us-east-1:000000000000:localstack-
 Check that our message has arrived:
 
 ```bash
-awslocal sqs receive-message \
+lstk aws sqs receive-message \
     --queue-url "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/my-queue"
 ```
 
@@ -157,7 +157,7 @@ You can list all the SNS subscriptions using the [`ListSubscriptions`](https://d
 Run the following command to list all the SNS subscriptions:
 
 ```bash
-awslocal sns list-subscriptions
+lstk aws sns list-subscriptions
 ```
 
 ```bash title="Output"
@@ -177,7 +177,7 @@ awslocal sns list-subscriptions
 Then, use the ARN to unsubscribe
 
 ```bash
-awslocal sns unsubscribe \
+lstk aws sns unsubscribe \
     --subscription-arn "arn:aws:sns:us-east-1:000000000000:localstack-topic:636e2a73-0dda-4e09-9fdf-77f113d0edd8"
 ```
 
@@ -245,7 +245,7 @@ In this example, we will create a platform endpoint in SNS and publish a message
 Run the following commands to create a platform endpoint:
 
 ```bash
-awslocal sns create-platform-application \
+lstk aws sns create-platform-application \
     --name app-test \
     --platform APNS \
     --attributes {}
@@ -260,7 +260,7 @@ awslocal sns create-platform-application \
 Using the `PlatformApplicationArn` from the previous call:
 
 ```bash
-awslocal sns create-platform-endpoint \
+lstk aws sns create-platform-endpoint \
     --platform-application-arn "arn:aws:sns:us-east-1:000000000000:app/APNS/app-test" \
     --token my-fake-token
 ```
@@ -276,7 +276,7 @@ awslocal sns create-platform-endpoint \
 Publish a message to the platform endpoint:
 
 ```bash
-awslocal sns publish \
+lstk aws sns publish \
     --target-arn "arn:aws:sns:us-east-1:000000000000:endpoint/APNS/app-test/c25f353e-856b-4b02-a725-6bde35e6e944" \
     --message '{"APNS_PLATFORM": "{\"aps\": {\"content-available\": 1}}"}' \
     --message-structure json
@@ -366,7 +366,7 @@ In this example, we will publish a message to a phone number and retrieve it:
 Publish a message to a phone number:
 
 ```bash
-awslocal sns publish \
+lstk aws sns publish \
     --phone-number "" \
     --message "Hello World!"
 ```
@@ -457,7 +457,7 @@ In this example, we will subscribe to an external SNS integration not confirming
 Create an SNS topic, and create a subscription to a external HTTP SNS integration:
 
 ```bash
-awslocal sns create-topic --name "test-external-integration"
+lstk aws sns create-topic --name "test-external-integration"
 ```
 
 ```bash title="Output"
@@ -469,7 +469,7 @@ awslocal sns create-topic --name "test-external-integration"
 We now create an HTTP SNS subscription to an external endpoint:
 
 ```bash
-awslocal sns subscribe \
+lstk aws sns subscribe \
     --topic-arn "arn:aws:sns:us-east-1:000000000000:test-external-integration" \
     --protocol https \
     --notification-endpoint "https://api.opsgenie.com/v1/json/amazonsns?apiKey=b13fd59a-9" \
@@ -486,7 +486,7 @@ Now, we can check the `PendingConfirmation` status of our subscription, showing 
 You will need to use the `SubscriptionArn` from the response of your subscribe call:
 
 ```bash
-awslocal sns get-subscription-attributes \
+lstk aws sns get-subscription-attributes \
     --subscription-arn "arn:aws:sns:us-east-1:000000000000:test-external-integration:c3ab47f3-b964-461d-84eb-903d8765b0c8"
 ```
 
@@ -523,7 +523,7 @@ curl "http://localhost:4566/_aws/sns/subscription-tokens/arn:aws:sns:us-east-1:0
 We can now use this token to manually confirm the subscription:
 
 ```bash
-awslocal sns confirm-subscription \
+lstk aws sns confirm-subscription \
     --topic-arn "arn:aws:sns:us-east-1:000000000000:test-external-integration" \
     --token 75732d656173742d312f3b875fb03b875fb03b875fb03b875fb03b875fb03b87
 ```
@@ -537,7 +537,7 @@ awslocal sns confirm-subscription \
 We can now finally verify the subscription has been confirmed:
 
 ```bash
-awslocal sns get-subscription-attributes \
+lstk aws sns get-subscription-attributes \
     --subscription-arn "arn:aws:sns:us-east-1:000000000000:test-external-integration:c3ab47f3-b964-461d-84eb-903d8765b0c8"
 ```
 

--- a/src/content/docs/aws/services/sqs.mdx
+++ b/src/content/docs/aws/services/sqs.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to SQS and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to SQS and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create an SQS queue, retrieve queue attributes and URLs, and receive and delete messages from the queue.
@@ -29,14 +29,14 @@ To create an SQS queue, use the [`CreateQueue`](https://docs.aws.amazon.com/AWSS
 Run the following command to create a queue named `localstack-queue`:
 
 ```bash
-awslocal sqs create-queue --queue-name localstack-queue
+lstk aws sqs create-queue --queue-name localstack-queue
 ```
 
 You can list all queues in your account using the [`ListQueues`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListQueues.html) API.
 Run the following command to list all queues in your account:
 
 ```bash
-awslocal sqs list-queues
+lstk aws sqs list-queues
 ```
 
 ```bash title="Output"
@@ -53,7 +53,7 @@ You need to pass the `queue-url` and `attribute-names` parameters.
 Run the following command to retrieve the queue attributes:
 
 ```bash
-awslocal sqs get-queue-attributes \
+lstk aws sqs get-queue-attributes \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/localstack-queue \
     --attribute-names All
 ```
@@ -61,7 +61,7 @@ awslocal sqs get-queue-attributes \
 To create a [FIFO queue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-fifo-queue-message-identifiers.html), the queue name must end with the `.fifo` suffix in addition to the `FifoQueue=true` attribute set:
 
 ```bash
-awslocal sqs create-queue --queue-name localstack-queue.fifo --attributes "FifoQueue=true"
+lstk aws sqs create-queue --queue-name localstack-queue.fifo --attributes "FifoQueue=true"
 {
     "QueueUrl": "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/localstack-queue.fifo"
 }
@@ -75,7 +75,7 @@ To send a message to a SQS queue, you can use the [`SendMessage`](https://docs.a
 Run the following command to send a message to the queue:
 
 ```bash
-awslocal sqs send-message \
+lstk aws sqs send-message \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/localstack-queue \
     --message-body "Hello World"
 ```
@@ -93,7 +93,7 @@ You can receive messages from the queue using the [`ReceiveMessage`](https://doc
 Run the following command to receive messages from the queue:
 
 ```bash
-awslocal sqs receive-message \
+lstk aws sqs receive-message \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/localstack-queue
 ```
 
@@ -107,7 +107,7 @@ You need to pass the `queue-url` and `receipt-handle` parameters.
 Run the following command to delete a message from the queue:
 
 ```bash
-awslocal sqs delete-message \
+lstk aws sqs delete-message \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/localstack-queue \
     --receipt-handle <receipt-handle>
 ```
@@ -118,7 +118,7 @@ If you have sent multiple messages to the queue, you can purge the queue using t
 Run the following command to purge the queue:
 
 ```bash
-awslocal sqs purge-queue \
+lstk aws sqs purge-queue \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/localstack-queue
 ```
 
@@ -131,9 +131,9 @@ First, create three queues.
 One will serve as original input queue, one as DLQ, and the third as target for DLQ redrive.
 
 ```bash
-awslocal sqs create-queue --queue-name input-queue
-awslocal sqs create-queue --queue-name dead-letter-queue
-awslocal sqs create-queue --queue-name recovery-queue
+lstk aws sqs create-queue --queue-name input-queue
+lstk aws sqs create-queue --queue-name dead-letter-queue
+lstk aws sqs create-queue --queue-name recovery-queue
 ```
 
 ```bash title="Output"
@@ -151,7 +151,7 @@ awslocal sqs create-queue --queue-name recovery-queue
 Configure `dead-letter-queue` to be a DLQ for `input-queue`:
 
 ```bash
-awslocal sqs set-queue-attributes \
+lstk aws sqs set-queue-attributes \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/input-queue \
     --attributes '{
     "RedrivePolicy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:000000000000:dead-letter-queue\",\"maxReceiveCount\":\"1\"}"
@@ -161,7 +161,7 @@ awslocal sqs set-queue-attributes \
 Send a message to the input queue:
 
 ```bash
-awslocal sqs send-message \
+lstk aws sqs send-message \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/input-queue \
     --message-body '{"hello": "world"}'
 ```
@@ -169,10 +169,10 @@ awslocal sqs send-message \
 Receive the message twice to provoke a move into the dead-letter queue:
 
 ```bash
-awslocal sqs receive-message \
+lstk aws sqs receive-message \
     --visibility-timeout 0 \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/input-queue
-awslocal sqs receive-message \
+lstk aws sqs receive-message \
     --visibility-timeout 0 \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/input-queue
 ```
@@ -186,7 +186,7 @@ In the localstack logs you should see something like the following line, indicat
 Now, start a message move task to asynchronously move the messages from the DLQ into the recovery queue:
 
 ```bash
-awslocal sqs start-message-move-task \
+lstk aws sqs start-message-move-task \
     --source-arn arn:aws:sqs:us-east-1:000000000000:dead-letter-queue \
     --destination-arn arn:aws:sqs:us-east-1:000000000000:recovery-queue
 ```
@@ -194,7 +194,7 @@ awslocal sqs start-message-move-task \
 Listing the message move tasks should yield something like
 
 ```bash
-awslocal sqs list-message-move-tasks \
+lstk aws sqs list-message-move-tasks \
     --source-arn arn:aws:sqs:us-east-1:000000000000:dead-letter-queue
 ```
 
@@ -216,7 +216,7 @@ awslocal sqs list-message-move-tasks \
 Receiving messages from the recovery queue should now show us the original message:
 
 ```bash
-awslocal sqs receive-message \
+lstk aws sqs receive-message \
     --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/recovery-queue
 ```
 

--- a/src/content/docs/aws/services/ssm.mdx
+++ b/src/content/docs/aws/services/ssm.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Systems Manager (SSM) and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Systems Manager (SSM) and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method with an additional `EC2_VM_MANAGER=docker` configuration variable.
 We will demonstrate how to use EC2 and SSM functionalities when using the Docker backend with LocalStack with the AWS CLI.
@@ -39,7 +39,7 @@ You can run an EC2 instance using the [`RunInstances`](https://docs.aws.amazon.c
 Execute the following command to create an EC2 instance using the `ami-00a001` AMI.
 
 ```bash
-awslocal ec2 run-instances \
+lstk aws ec2 run-instances \
     --image-id ami-00a001 --count 1
 ```
 
@@ -71,7 +71,7 @@ You can use the [`SendCommand`](https://docs.aws.amazon.com/systems-manager/late
 The following command sends a `cat lsb-release` command in the `/etc` directory to the EC2 instance.
 
 ```bash
-awslocal ssm send-command --document-name "AWS-RunShellScript" \
+lstk aws ssm send-command --document-name "AWS-RunShellScript" \
     --document-version "1" \
     --instance-ids i-abf6920789a06dd84 \
     --parameters "commands='cat lsb-release',workingDirectory=/etc"
@@ -99,7 +99,7 @@ You can use the [`GetCommandInvocation`](https://docs.aws.amazon.com/systems-man
 The following command retrieves the output of the command sent in the previous step.
 
 ```bash
-awslocal ssm get-command-invocation \
+lstk aws ssm get-command-invocation \
     --command-id 23547a9b-6993-4967-9446-f96b9b5dac70 \
     --instance-id i-abf6920789a06dd84
 ```

--- a/src/content/docs/aws/services/sso-admin.mdx
+++ b/src/content/docs/aws/services/sso-admin.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to SSO Admin and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to SSO Admin and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a permission set, add tags to a permission set, and list permission sets.
@@ -27,7 +27,7 @@ We will demonstrate how to create a permission set, add tags to a permission set
 You can create a permission set using the [`CreatePermissionSet`](https://docs.aws.amazon.com/sso-admin/latest/APIReference/API_CreatePermissionSet.html) API.
 
 ```bash
-awslocal sso-admin create-permission-set \
+lstk aws sso-admin create-permission-set \
     --name my-permission-set \
     --description "My permission set" \
     --instance-arn arn:aws:sso:::instance/d-1234567890 \
@@ -51,7 +51,7 @@ awslocal sso-admin create-permission-set \
 You can list permission sets using the [`ListPermissionSets`](https://docs.aws.amazon.com/sso-admin/latest/APIReference/API_ListPermissionSets.html) API.
 
 ```bash
-awslocal sso-admin list-permission-sets --instance-arn arn:aws:sso:::instance/d-1234567890
+lstk aws sso-admin list-permission-sets --instance-arn arn:aws:sso:::instance/d-1234567890
 ```
 
 ```bash title="Output"
@@ -67,7 +67,7 @@ awslocal sso-admin list-permission-sets --instance-arn arn:aws:sso:::instance/d-
 You can list tags for a permission set using the [`ListTagsForResource`](https://docs.aws.amazon.com/sso-admin/latest/APIReference/API_ListTagsForResource.html) API.
 
 ```bash
-awslocal sso-admin list-tags-for-resource --resource-arn arn:aws:sso:::instance/d-1234567890/ps-lm0rshcjz3tikab8 --instance-arn arn:aws:sso:::instance/d-1234567890
+lstk aws sso-admin list-tags-for-resource --resource-arn arn:aws:sso:::instance/d-1234567890/ps-lm0rshcjz3tikab8 --instance-arn arn:aws:sso:::instance/d-1234567890
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/stepfunctions.mdx
+++ b/src/content/docs/aws/services/stepfunctions.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Step Functions and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Step Functions and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can create a state machine, execute it, and check the status of the execution.
@@ -29,7 +29,7 @@ The API requires the name of the state machine, the state machine definition, an
 Run the following command to create a state machine:
 
 ```bash showLineNumbers
-awslocal stepfunctions create-state-machine \
+lstk aws stepfunctions create-state-machine \
     --name "CreateAndListBuckets" \
     --definition '{
         "Comment": "Create bucket and list buckets",
@@ -67,7 +67,7 @@ The API requires the state machine's ARN and the state machine's input.
 Run the following command to execute the state machine:
 
 ```bash
-awslocal stepfunctions start-execution \
+lstk aws stepfunctions start-execution \
     --state-machine-arn "arn:aws:states:us-east-1:000000000000:stateMachine:CreateAndListBuckets"
 ```
 
@@ -84,7 +84,7 @@ To check the status of the execution, you can use the [`DescribeExecution`](http
 Run the following command to describe the execution:
 
 ```bash
-awslocal stepfunctions describe-execution \
+lstk aws stepfunctions describe-execution \
         --execution-arn "arn:aws:states:us-east-1:000000000000:execution:CreateAndListBuckets:bf7d2138-e96f-42d1-b1f9-41f0c1c7bc3e"
 ```
 
@@ -421,7 +421,7 @@ Create the state machine to match the name defined in the mock configuration fil
 In this example, create the `LambdaSQSIntegration` state machine using:
 
 ```bash
-awslocal stepfunctions create-state-machine \
+lstk aws stepfunctions create-state-machine \
     --definition file://LambdaSQSIntegration.json \
     --name "LambdaSQSIntegration" \
     --role-arn "arn:aws:iam::000000000000:role/service-role/testrole"
@@ -436,7 +436,7 @@ This tells LocalStack to apply the corresponding mocked responses from the confi
 For example, to run the `BaseCase` test case:
 
 ```bash
-awslocal stepfunctions start-execution \
+lstk aws stepfunctions start-execution \
     --state-machine arn:aws:states:us-east-1:000000000000:stateMachine:LambdaSQSIntegration#BaseCase \
     --input '{"name": "John", "surname": "smith"}' \
     --name "MockExecutionBaseCase"
@@ -448,7 +448,7 @@ States without mock entries invoke the actual emulated service as usual.
 You can inspect the execution using the [`DescribeExecution`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_DescribeExecution.html) API:
 
 ```bash
-awslocal stepfunctions describe-execution \
+lstk aws stepfunctions describe-execution \
     --execution-arn "arn:aws:states:us-east-1:000000000000:execution:LambdaSQSIntegration:MockExecutionBaseCase"
 ```
 
@@ -474,7 +474,7 @@ awslocal stepfunctions describe-execution \
 You can also use the [`GetExecutionHistory`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_GetExecutionHistory.html) API to retrieve the execution history, including the events and their details.
 
 ```bash
-awslocal stepfunctions get-execution-history \
+lstk aws stepfunctions get-execution-history \
     --execution-arn "arn:aws:states:us-east-1:000000000000:execution:LambdaSQSIntegration:MockExecutionBaseCase"
 ```
 

--- a/src/content/docs/aws/services/stepfunctions.mdx
+++ b/src/content/docs/aws/services/stepfunctions.mdx
@@ -387,10 +387,19 @@ If you're running LocalStack in Docker, mount the file and pass the variable as 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 <Tabs>
-<TabItem label="LocalStack CLI">
+<TabItem label="lstk">
+Add the mount to your `config.toml`:
+
+```toml
+[[containers]]
+type = "aws"
+volumes = ["/path/to/MockConfigFile.json:/tmp/MockConfigFile.json"]
+```
+
+Then set the environment variable and start LocalStack:
+
 ```bash
-LOCALSTACK_SFN_MOCK_CONFIG=/tmp/MockConfigFile.json \
-localstack start --volume /path/to/MockConfigFile.json:/tmp/MockConfigFile.json
+LOCALSTACK_SFN_MOCK_CONFIG=/tmp/MockConfigFile.json lstk start
 ```
 </TabItem>
 <TabItem label="Docker Compose"> 

--- a/src/content/docs/aws/services/sts.mdx
+++ b/src/content/docs/aws/services/sts.mdx
@@ -18,7 +18,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to STS and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to STS and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to assume an IAM Role and assume the role as well as creating an IAM user and getting using the STS with the AWS CLI.
@@ -30,7 +30,7 @@ The IAM User will be used to assume the IAM Role.
 Run the following command to create an IAM User, named `localstack-user`:
 
 ```bash
-awslocal iam create-user \
+lstk aws iam create-user \
     --user-name localstack-user
 ```
 
@@ -38,7 +38,7 @@ You can generate long-term access keys for the IAM user using the [`CreateAccess
 Run the following command to create an access key for the IAM user:
 
 ```bash
-awslocal iam create-access-key \
+lstk aws iam create-access-key \
     --user-name localstack-user
 ```
 
@@ -58,7 +58,7 @@ Using STS, you can also fetch temporary credentials for this user using the [`Ge
 Run the following command using your long-term credentials to get your temporary credentials:
 
 ```bash
-awslocal sts get-session-token
+lstk aws sts get-session-token
 ```
 
 ```bash title="Output"
@@ -78,7 +78,7 @@ You can now create an IAM Role, named `localstack-role`, using the [`CreateRole`
 Run the following command to create the IAM Role:
 
 ```bash
-awslocal iam create-role \
+lstk aws iam create-role \
     --role-name localstack-role \
     --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::000000000000:root"},"Action":"sts:AssumeRole"}]}'
 ```
@@ -111,7 +111,7 @@ You can attach the policy to the IAM role using the [`AttachRolePolicy`](https:/
 Run the following command to attach the policy to the IAM role:
 
 ```bash
-awslocal iam attach-role-policy \
+lstk aws iam attach-role-policy \
     --role-name localstack-role \
     --policy-arn arn:aws:iam::aws:policy/AdministratorAccess
 ```
@@ -122,7 +122,7 @@ You can assume an IAM Role using the [`AssumeRole`](https://docs.aws.amazon.com/
 Run the following command to assume the IAM Role:
 
 ```bash
-awslocal sts assume-role \
+lstk aws sts assume-role \
     --role-arn arn:aws:iam::000000000000:role/localstack-role \
     --role-session-name localstack-session
 ```
@@ -151,7 +151,7 @@ You can get the caller identity to identify the principal your current credentia
 Run the following command to get the caller identity for the credentials set in your environment:
 
 ```bash
-awslocal sts get-caller-identity
+lstk aws sts get-caller-identity
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/support.mdx
+++ b/src/content/docs/aws/services/support.mdx
@@ -24,7 +24,7 @@ It's important to note that LocalStack doesn't offer a programmatic interface to
 
 ## Getting started
 
-This guide is designed for users new to Support and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Support and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can create a case in the mock Support Center using the AWS CLI.
@@ -35,7 +35,7 @@ To create a support case, you can use the [`CreateCase`](https://docs.aws.amazon
 The following example creates a case with the subject "Test case" and the description "This is a test case" in the category "General guidance".
 
 ```bash
-awslocal support create-case \
+lstk aws support create-case \
     --subject "Test case" \
     --service-code "general-guidance" \
     --category-code "general-guidance" \
@@ -54,7 +54,7 @@ To list all support cases, you can use the [`DescribeCases`](https://docs.aws.am
 The following example lists all cases in the category "General guidance".
 
 ```bash
-awslocal support describe-cases
+lstk aws support describe-cases
 ```
 
 ```bash title="Output"
@@ -87,7 +87,7 @@ To resolve a support case, you can use the [`ResolveCase`](https://docs.aws.amaz
 The following example resolves the case created in the previous step.
 
 ```bash
-awslocal support resolve-case \
+lstk aws support resolve-case \
     --case-id "case-12345678910-2020-kEa16f90bJE766J4"
 ```
 

--- a/src/content/docs/aws/services/swf.mdx
+++ b/src/content/docs/aws/services/swf.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Simple Workflow Service and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Simple Workflow Service and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to register an SWF domain and workflow using the AWS CLI.
@@ -28,7 +28,7 @@ You can register an SWF domain using the [`RegisterDomain`](https://docs.aws.ama
 Execute the following command to register a domain named `test-domain`:
 
 ```bash
-awslocal swf register-domain \
+lstk aws swf register-domain \
     --name test-domain \
     --workflow-execution-retention-period-in-days 1
 ```
@@ -37,7 +37,7 @@ You can use the [`DescribeDomain`](https://docs.aws.amazon.com/amazonswf/latest/
 Run the following command to describe the `test-domain` domain:
 
 ```bash
-awslocal swf describe-domain \
+lstk aws swf describe-domain \
     --name test-domain
 ```
 
@@ -60,21 +60,21 @@ You can list all registered domains using the [`ListDomains`](https://docs.aws.a
 Run the following command to list all registered domains:
 
 ```bash
-awslocal swf list-domains --registration-status REGISTERED
+lstk aws swf list-domains --registration-status REGISTERED
 ```
 
 To deprecate a domain, use the [`DeprecateDomain`](https://docs.aws.amazon.com/amazonswf/latest/apireference/API_DeprecateDomain.html) API.
 Run the following command to deprecate the `test-domain` domain:
 
 ```bash
-awslocal swf deprecate-domain \
+lstk aws swf deprecate-domain \
     --name test-domain
 ```
 
 You can now list the deprecated domains using the `--registration-status DEPRECATED` flag:
 
 ```bash
-awslocal swf list-domains --registration-status DEPRECATED
+lstk aws swf list-domains --registration-status DEPRECATED
 ```
 
 ### Registering a workflow
@@ -83,7 +83,7 @@ You can register a workflow using the [`RegisterWorkflowType`](https://docs.aws.
 Execute the following command to register a workflow named `test-workflow`:
 
 ```bash showLineNumbers
-awslocal swf register-workflow-type \
+lstk aws swf register-workflow-type \
     --domain test-domain \
     --name test-workflow \
     --default-task-list name=test-task-list \
@@ -97,7 +97,7 @@ You can use the [`DescribeWorkflowType`](https://docs.aws.amazon.com/amazonswf/l
 Run the following command to describe the `test-workflow` workflow:
 
 ```bash
-awslocal swf describe-workflow-type \
+lstk aws swf describe-workflow-type \
     --domain test-domain \
     --workflow-type name=test-workflow,version=1.0
 ```
@@ -131,7 +131,7 @@ You can register an activity using the [`RegisterActivityType`](https://docs.aws
 Execute the following command to register an activity named `test-activity`:
 
 ```bash showLineNumbers
-awslocal swf register-activity-type \
+lstk aws swf register-activity-type \
     --domain test-domain \
     --name test-activity \
     --default-task-list name=test-task-list \
@@ -146,7 +146,7 @@ You can use the [`DescribeActivityType`](https://docs.aws.amazon.com/amazonswf/l
 Run the following command to describe the `test-activity` activity:
 
 ```bash showLineNumbers
-awslocal swf describe-activity-type \
+lstk aws swf describe-activity-type \
     --domain test-domain \
     --activity-type name=test-activity,version=1.0
 ```
@@ -181,7 +181,7 @@ You can start a workflow execution using the [`StartWorkflowExecution`](https://
 Execute the following command to start a workflow execution for the `test-workflow` workflow:
 
 ```bash showLineNumbers
-awslocal swf start-workflow-execution \
+lstk aws swf start-workflow-execution \
     --domain test-domain \
     --workflow-type name=test-workflow,version=1.0 \
     --workflow-id test-workflow-id \

--- a/src/content/docs/aws/services/textract.mdx
+++ b/src/content/docs/aws/services/textract.mdx
@@ -15,7 +15,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), p
 
 ## Getting started
 
-This guide is tailored for users new to Textract and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is tailored for users new to Textract and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to perform basic Textract operations, such as mocking text detection in a document.
@@ -26,7 +26,7 @@ You can use the [`DetectDocumentText`](https://docs.aws.amazon.com/textract/late
 Execute the following command:
 
 ```bash
-awslocal textract detect-document-text \
+lstk aws textract detect-document-text \
     --document '{"S3Object":{"Bucket":"your-bucket","Name":"your-document"}}'
 ```
 
@@ -48,7 +48,7 @@ You can use the [`StartDocumentTextDetection`](https://docs.aws.amazon.com/textr
 Execute the following command:
 
 ```bash
-awslocal textract start-document-text-detection \
+lstk aws textract start-document-text-detection \
         --document-location '{"S3Object":{"Bucket":"bucket","Name":"document"}}'
 ```
 
@@ -66,7 +66,7 @@ You can use the [`GetDocumentTextDetection`](https://docs.aws.amazon.com/textrac
 Execute the following command:
 
 ```bash
-awslocal textract get-document-text-detection \
+lstk aws textract get-document-text-detection \
     --job-id "501d7251-1249-41e0-a0b3-898064bfc506"
 ```
 

--- a/src/content/docs/aws/services/timestream-query.mdx
+++ b/src/content/docs/aws/services/timestream-query.mdx
@@ -20,27 +20,27 @@ The supported APIs are available on our API Coverage Page ([Timestream Query](#a
 
 ## Getting Started
 
-The following example illustrates the basic operations, using the [`awslocal`](https://github.com/localstack/awscli-local) command line.
+The following example illustrates the basic operations, using the [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command line.
 
 First, we create a test database and table:
 
 ```bash
-awslocal timestream-write create-database --database-name testDB
-awslocal timestream-write create-table --database-name testDB --table-name testTable
+lstk aws timestream-write create-database --database-name testDB
+lstk aws timestream-write create-table --database-name testDB --table-name testTable
 ```
 
 We can then add a few records with a timestamp, measure name, and value to the table:
 
 ```bash
-awslocal timestream-write write-records --database-name testDB --table-name testTable --records '[{"MeasureName":"cpu","MeasureValue":"60","TimeUnit":"SECONDS","Time":"1636986409"}]'
-awslocal timestream-write write-records --database-name testDB --table-name testTable --records '[{"MeasureName":"cpu","MeasureValue":"80","TimeUnit":"SECONDS","Time":"1636986412"}]'
-awslocal timestream-write write-records --database-name testDB --table-name testTable --records '[{"MeasureName":"cpu","MeasureValue":"70","TimeUnit":"SECONDS","Time":"1636986414"}]'
+lstk aws timestream-write write-records --database-name testDB --table-name testTable --records '[{"MeasureName":"cpu","MeasureValue":"60","TimeUnit":"SECONDS","Time":"1636986409"}]'
+lstk aws timestream-write write-records --database-name testDB --table-name testTable --records '[{"MeasureName":"cpu","MeasureValue":"80","TimeUnit":"SECONDS","Time":"1636986412"}]'
+lstk aws timestream-write write-records --database-name testDB --table-name testTable --records '[{"MeasureName":"cpu","MeasureValue":"70","TimeUnit":"SECONDS","Time":"1636986414"}]'
 ```
 
 Finally, we can run a query to retrieve the timeseries data (or aggregate values) from the table:
 
 ```bash
-awslocal timestream-query query --query-string "SELECT CREATE_TIME_SERIES(time, measure_value::double) as cpu FROM testDB.timeStreamTable WHERE measure_name='cpu'"
+lstk aws timestream-query query --query-string "SELECT CREATE_TIME_SERIES(time, measure_value::double) as cpu FROM testDB.timeStreamTable WHERE measure_name='cpu'"
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/services/transcribe.mdx
+++ b/src/content/docs/aws/services/transcribe.mdx
@@ -22,7 +22,7 @@ Language models typically have a size of around 50 MiB and are saved in the cach
 
 ## Getting Started
 
-This guide is designed for users new to Transcribe and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local)  wrapper script.
+This guide is designed for users new to Transcribe and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a transcription job and view the transcript in an S3 bucket using the AWS CLI.
@@ -33,8 +33,8 @@ You can create an S3 bucket using the [`mb`](https://docs.aws.amazon.com/cli/lat
 Run the following command to create a bucket named `foo` to upload a sample audio file named `example.wav`:
 
 ```bash
-awslocal s3 mb s3://foo
-awslocal s3 cp ~/example.wav s3://foo/example.wav
+lstk aws s3 mb s3://foo
+lstk aws s3 cp ~/example.wav s3://foo/example.wav
 ```
 
 ### Create a transcription job
@@ -43,7 +43,7 @@ You can create a transcription job using the [`StartTranscriptionJob`](https://d
 Run the following command to create a transcription job named `example` for the audio file `example.wav`:
 
 ```bash
-awslocal transcribe start-transcription-job \
+lstk aws transcribe start-transcription-job \
     --transcription-job-name example \
     --media MediaFileUri=s3://foo/example.wav \
     --language-code en-IN
@@ -53,7 +53,7 @@ You can list the transcription jobs using the [`ListTranscriptionJobs`](https://
 Run the following command to list the transcription jobs:
 
 ```bash
-awslocal transcribe list-transcription-jobs
+lstk aws transcribe list-transcription-jobs
 ```
 
 The following output would be retrieved:
@@ -78,7 +78,7 @@ After the job is complete, the transcript can be retrieved from the S3 bucket us
 Run the following command to get the transcript:
 
 ```bash
-awslocal transcribe get-transcription-job --transcription-job example
+lstk aws transcribe get-transcription-job --transcription-job example
 ```
 
 ```bash title="Output"
@@ -104,7 +104,7 @@ awslocal transcribe get-transcription-job --transcription-job example
 You can then view the transcript by running the following command:
 
 ```bash
-awslocal s3 cp s3://foo/7844aaa5.json .
+lstk aws s3 cp s3://foo/7844aaa5.json .
 jq .results.transcripts[0].transcript 7844aaa5.json
 ```
 

--- a/src/content/docs/aws/services/verifiedpermissions.mdx
+++ b/src/content/docs/aws/services/verifiedpermissions.mdx
@@ -17,7 +17,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Verified Permissions and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Verified Permissions and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how to create a Verified Permissions Policy Store, add a policy to it, and authorize a request with the AWS CLI.
@@ -28,7 +28,7 @@ To create a Verified Permissions Policy Store, use the [`CreatePolicyStore`](htt
 Run the following command to create a Policy Store with Schema validation settings set to `OFF`:
 
 ```bash
-awslocal verifiedpermissions create-policy-store \
+lstk aws verifiedpermissions create-policy-store \
   --validation-settings mode=OFF \
   --description "A local Policy Store"
 ```
@@ -46,7 +46,7 @@ You can list all the Verified Permissions policy stores using the [`ListPolicySt
 Run the following command to list all the Verified Permissions policy stores:
 
 ```bash
-awslocal verifiedpermissions list-policy-stores
+lstk aws verifiedpermissions list-policy-stores
 ```
 
 ### Create a Policy
@@ -67,7 +67,7 @@ Create a JSON file named `static_policy.json` with the following content:
 You can then run this command to create the policy:
 
 ```bash
-awslocal verifiedpermissions create-policy \
+lstk aws verifiedpermissions create-policy \
     --definition file://static_policy.json \
     --policy-store-id q5PCScu9qo4aswMVc0owNN
 ```
@@ -107,7 +107,7 @@ We can now make use of the Policy Store and the Policy to start authorizing requ
 To authorize a request using Verified Permissions, use the [`IsAuthorized`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorized.html) API.
 
 ```bash title="Output"
-awslocal verifiedpermissions is-authorized \
+lstk aws verifiedpermissions is-authorized \
   --policy-store-id q5PCScu9qo4aswMVc0owNN \
   --principal entityType=User,entityId=alice \
   --action actionType=Action,actionId=view \

--- a/src/content/docs/aws/services/waf.mdx
+++ b/src/content/docs/aws/services/waf.mdx
@@ -16,7 +16,7 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is for users who are familiar with the AWS CLI and [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is for users who are familiar with the AWS CLI and [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will walk you through creating, listing, tagging, and viewing tags for Web Access Control Lists (WebACLs) using the Web Application Firewall (WAF) service in a LocalStack environment using the AWS CLI.
@@ -27,7 +27,7 @@ Start by creating a Web Access Control List (WebACL) using the [`CreateWebACL`](
 Run the following command to create a WebACL named `TestWebAcl`:
 
 ```bash showLineNumbers
-awslocal wafv2 create-web-acl \
+lstk aws wafv2 create-web-acl \
     --name TestWebAcl \
     --scope REGIONAL \
     --default-action Allow={} \
@@ -53,7 +53,7 @@ To view all the WebACLs you have created, use the [`ListWebACLs`](https://docs.a
 Run the following command to list the WebACLs:
 
 ```bash
-awslocal wafv2 list-web-acls --scope REGIONAL
+lstk aws wafv2 list-web-acls --scope REGIONAL
 ```
 
 ```bash title="Output"
@@ -77,7 +77,7 @@ Use the [`TagResource`](https://docs.aws.amazon.com/waf/latest/APIReference/API_
 Run the following command to add a tag to the WebACL created in the previous step:
 
 ```bash
-awslocal wafv2 tag-resource \
+lstk aws wafv2 tag-resource \
     --resource-arn arn:aws:wafv2:us-east-1:000000000000:regional/webacl/TestWebAcl/f94fd5bc-e4d4-4280-9f53-51e9441ad51d \
     --tags Key=Name,Value=AWSWAF
 ```
@@ -87,7 +87,7 @@ Use the [`ListTagsForResource`](https://docs.aws.amazon.com/waf/latest/APIRefere
 Run the following command to list the tags for the WebACL created in the previous step:
 
 ```bash
-awslocal wafv2 list-tags-for-resource \
+lstk aws wafv2 list-tags-for-resource \
     --resource-arn arn:aws:wafv2:us-east-1:000000000000:regional/webacl/TestWebAcl/f94fd5bc-e4d4-4280-9f53-51e9441ad51d
 ```
 

--- a/src/content/docs/aws/services/xray.mdx
+++ b/src/content/docs/aws/services/xray.mdx
@@ -28,7 +28,7 @@ which provides information on the extent of X-Ray integration with LocalStack.
 ## Getting started
 
 This guide is designed for users new to X-Ray and assumes basic
-knowledge of the AWS CLI and our `awslocal` wrapper script.
+knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can create a minimal [trace segment](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields)
@@ -54,7 +54,7 @@ DOC=$(cat <<EOF
 EOF
 )
 echo "Sending trace segment to X-Ray API: $DOC"
-awslocal xray put-trace-segments --trace-segment-documents "$DOC"
+lstk aws xray put-trace-segments --trace-segment-documents "$DOC"
 ```
 
 ```bash title="Output"
@@ -71,7 +71,7 @@ Run the following commands in your terminal:
 
 ```bash showLineNumbers
 EPOCH=$(date +%s)
-awslocal xray get-trace-summaries --start-time $(($EPOCH-600)) --end-time $(($EPOCH))
+lstk aws xray get-trace-summaries --start-time $(($EPOCH-600)) --end-time $(($EPOCH))
 {
     "TraceSummaries": [
         {
@@ -98,7 +98,7 @@ You can retrieve the full trace by providing the `TRACE_ID` using the [BatchGetT
 Run the following commands in your terminal (use the same terminal as for the first command):
 
 ```bash
-awslocal xray batch-get-traces --trace-ids $TRACE_ID
+lstk aws xray batch-get-traces --trace-ids $TRACE_ID
 ```
 
 ```bash title="Output"


### PR DESCRIPTION
## Summary

This the first of many PRs to migrate the docs from the "LocalStack CLI" to the new `lstk`. The changes will be accumulated into the `docs-312-aws-docs-to-use-lstk` (the target branch of this PR), so it can later be merged into the monthly release branch without a detailed review (probably `aws-docs-release-august`).

This PR addresses the `/aws/services` section:

- Mechanically replace `awslocal` references across all AWS service docs with `lstk aws`
- Switch `samlocal` references to `lstk sam`
- Resolve remaining lstk migration gaps for env vars (`LOCALSTACK_*` passthrough) and volume mounts
- Fix a leftover `localstack start` invocation and a generic "LocalStack CLI" prose mention caught in a follow-up audit of `aws/services`

Note: there are still two places in `/aws/services` that have not migrated, simply because the necessary `lstk` options don't yet exist. The Linear issues are:
* [DEVX-949: Allow configuring the emulator container's Docker network mode (`--network`) in `lstk`](https://linear.app/localstack/issue/DEVX-949/allow-configuring-the-emulator-containers-docker-network-mode-network)
* [DEVX-994: Allow the `--dns-host` (or similar) option to export network ports](https://linear.app/localstack/issue/DEVX-994/allow-the-dns-host-or-similar-option-to-export-network-ports)

Part of [DEVX-988](https://linear.app/localstack/issue/DEVX-988/migrate-local-aws-services-docs-section-to-use-lstk).