### PR TITLE
docs(aws): migrate /aws/connecting section to use `lstk`

### DIFF
--- a/src/content/docs/aws/connecting/aws-cli.md
+++ b/src/content/docs/aws/connecting/aws-cli.md
@@ -8,31 +8,27 @@ sidebar:
 
 ## Introduction
 
-The [AWS Command Line Interface (CLI)](https://aws.amazon.com/cli/) is a unified tool for creating and managing AWS services via a command line interface.
-All CLI commands applicable to services implemented within [LocalStack](/aws/connecting/aws-cli/) can be executed when operating against LocalStack.
+The [AWS Command Line Interface (CLI)](https://aws.amazon.com/cli/) is the standard tool from Amazon for creating and managing AWS services via a command line interface.
+Due to LocalStack's compatibility with the AWS APIs, this tool can also access LocalStack's emulated services.
 
-You can use the AWS CLI with LocalStack using either of the following approaches:
+You can use the AWS CLI with LocalStack using one or more of the following approaches:
 
-[AWS CLI](#aws-cli)
-
-[LocalStack AWS CLI](#localstack-aws-cli-awslocal)
+- [AWS CLI](#aws-cli) - Use the standard `aws` command with hand-crafted configuration options necessary to communicate with LocalStack.
+- [LocalStack AWS CLI](#localstack-aws-cli-lstk-aws) - Use the `lstk aws` command to set the configuration options for you.
+- [Using AWS CLI from a pre-built container](#using-aws-cli-from-a-pre-built-container) - Use Amazon's pre-built AWS CLI container image instead of installing `aws` locally.
 
 ## AWS CLI
 
-You can install `aws` by using the following command if it's not already installed.
+If you don't already have `aws` (version 2) installed, follow the [official AWS CLI installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 
-```bash
-pip install awscli
-```
-
-You can configure the AWS CLI to redirect AWS API requests to LocalStack using two approaches:
+Once installed, you can configure the AWS CLI to redirect AWS API requests to LocalStack using two approaches:
 
 - [Configuring an endpoint URL](#configuring-an-endpoint-url)
 - [Configuring a custom profile](#configuring-a-custom-profile)
 
 ### Configuring an endpoint URL
 
-You can use AWS CLI with an endpoint URL by configuring test environment variables and include the `--endpoint-url=<localstack-url>` flag in your `aws` CLI commands.
+You can use AWS CLI with an endpoint URL by configuring environment variables and including the `--endpoint-url=<localstack-url>` flag in your `aws` CLI commands.
 For example:
 
 ```bash
@@ -80,86 +76,32 @@ aws s3 ls --profile localstack
 Alternatively, you can also set the `AWS_PROFILE=localstack` environment variable, in which case the `--profile localstack` parameter can be omitted in the commands above.
 :::
 
-## LocalStack AWS CLI (`awslocal`)
+## LocalStack AWS CLI (`lstk aws`)
 
-`awslocal` serves as a thin wrapper and a substitute for the standard `aws` command, enabling you to run AWS CLI commands within the LocalStack environment without specifying the `--endpoint-url` parameter or a profile.
+`lstk aws` serves as a thin wrapper and a substitute for the standard `aws` command, enabling you to run AWS CLI commands within the LocalStack environment without specifying the `--endpoint-url` parameter or a profile.
 
 ### Installation
 
-Install the `awslocal` command using the following command:
+To make use of `lstk aws`, you must install both the `lstk` CLI and the standard `aws` command from Amazon .
 
-```bash
-pip install awscli-local[ver1]
-```
-
-:::tip
-
-The above command installs the most recent version of the underlying AWS CLI version 1 (`awscli`) package.
-If you would rather manage your own `awscli` version (e.g., `v1` or `v2`) and only install the wrapper script, you can use the following command:
-
-```bash
-pip install awscli-local
-```
-
-:::
-
-:::note
-
-Automatic installation of AWS CLI version 2 is currently not supported yet (at the time of writing there is no official pypi package for `v2` available), but the `awslocal` technically also works with AWS CLI v2 (see [this section](#current-limitations) for more details).
-:::
+1. To install `lstk`, follow the [`lstk` installation instructions](/aws/developer-tools/running-localstack/lstk/#installation).
+2. To install `aws`, follow the [official AWS CLI installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 
 ### Usage
 
-The `awslocal` command shares identical usage with the standard `aws` command.
-For comprehensive usage instructions, refer to the manual pages by running `awslocal help`.
+The `lstk aws` command shares identical usage with the standard `aws` command.
+For comprehensive usage instructions, refer to the manual pages by running `lstk aws help`.
 
 ```bash
-awslocal kinesis list-streams
+lstk aws kinesis list-streams
 ```
 
-### Configuration
 
-| Variable Name    | Description                                                                         |
-| ---------------- | ----------------------------------------------------------------------------------- |
-| AWS_ENDPOINT_URL | The endpoint URL to connect to (takes precedence over USE_SSL/LOCALSTACK_HOST)      |
-| LOCALSTACK_HOST  | (deprecated) A variable defining where to find LocalStack (default: localhost:4566) |
-| USE_SSL          | (deprecated) Whether to use SSL when connecting to LocalStack (default: False)      |
+## Using AWS CLI from a pre-built container
 
-### Current Limitations
+As an alternative to installing the `aws` command directly on your local machine, Amazon provides a [pre-built container image with the AWS CLI pre-installed](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-docker.html). This approach is most suitable when working in multi-container environments, rather than single-machine installations. If you take this approach, an extra step is required for communication with LocalStack, also running inside a container.
 
-Please note that there is a known limitation for using the `cloudformation package ...` command with the AWS CLI v2.
-The problem is that the AWS CLI v2 is [not available as a package on pypi.org](https://github.com/aws/aws-cli/issues/4947), but is instead shipped as a binary package that cannot be easily patched from `awslocal`.
-To work around this issue, you have 2 options:
-
-- Downgrade to the v1 AWS CLI (this is the recommended approach)
-- There is an unofficial way to install AWS CLI v2 from sources.
-  We do not recommend this, but it is technically possible.
-  Also, you should install these libraries in a Python virtualenv, to avoid version clashes with other libraries on your system:
-
-```bash
-virtualenv .venv
-. .venv/bin/activate
-pip install https://github.com/boto/botocore/archive/v2.zip https://github.com/aws/aws-cli/archive/v2.zip
-```
-
-Please also note there is a known limitation for issuing requests using
-`--no-sign-request` with the AWS CLI.
-LocalStack's routing mechanism depends on
-the signature of each request to identify the correct service for the request.
-Thus, adding the flag `--no-sign-requests` provokes your request to reach the
-wrong service.
-One possible way to address this is to use the `awslocal` CLI
-instead of AWS CLI.
-
-## AWS CLI v2
-
-Automatic installation of AWS CLI version 2 is currently not supported (at the time of writing there is no official pypi package for v2 available), but the awslocal technically also works with AWS CLI v2 (see this section for more details).
-
-### AWS CLI v2 with Docker and LocalStack
-
-By default, the container running [amazon/aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-docker.html) is isolated from `0.0.0.0:4566` on the host machine, that means that aws-cli cannot reach localstack through your shell.
-
-To ensure that the two docker containers can communicate create a network on the docker engine:
+By default, the AWS CLI container is isolated from `0.0.0.0:4566` on the host machine, which means the AWS CLI cannot reach LocalStack. To ensure the two docker containers can communicate create a network on the docker engine:
 
 ```bash
 docker network create localstack
@@ -175,7 +117,7 @@ networks:
       name: 'localstack'
 ```
 
-Run AWS Cli v2 docker container using this network (example):
+Run the AWS CLI v2 docker container using this network (example):
 
 ```bash
 docker run --network localstack --rm -it amazon/aws-cli --endpoint-url=http://localstack:4566 lambda list-functions

--- a/src/content/docs/aws/connecting/aws-cli.md
+++ b/src/content/docs/aws/connecting/aws-cli.md
@@ -86,7 +86,7 @@ Alternatively, you can also set the `AWS_PROFILE=localstack` environment variabl
 
 ### Installation
 
-To make use of `lstk aws`, you must install both the `lstk` CLI and the standard `aws` command from Amazon .
+To make use of `lstk aws`, you must install both the `lstk` CLI and the standard `aws` command from Amazon.
 
 1. To install `lstk`, follow the [`lstk` installation instructions](/aws/developer-tools/running-localstack/lstk/#installation).
 2. To install `aws`, follow the [official AWS CLI installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).

--- a/src/content/docs/aws/connecting/aws-cli.md
+++ b/src/content/docs/aws/connecting/aws-cli.md
@@ -17,6 +17,10 @@ You can use the AWS CLI with LocalStack using one or more of the following appro
 - [LocalStack AWS CLI](#localstack-aws-cli-lstk-aws) - Use the `lstk aws` command to set the configuration options for you.
 - [Using AWS CLI from a pre-built container](#using-aws-cli-from-a-pre-built-container) - Use Amazon's pre-built AWS CLI container image instead of installing `aws` locally.
 
+:::note
+`lstk aws` supersedes the older [`awslocal` wrapper script](/aws/connecting/infrastructure-as-code/deprecated-wrapper-scripts#awslocal), which is deprecated but still available if you need it.
+:::
+
 ## AWS CLI
 
 If you don't already have `aws` (version 2) installed, follow the [official AWS CLI installation instructions](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).

--- a/src/content/docs/aws/connecting/infrastructure-as-code/aws-cdk.md
+++ b/src/content/docs/aws/connecting/infrastructure-as-code/aws-cdk.md
@@ -14,40 +14,43 @@ The AWS Cloud Development Kit (CDK) is an Infrastructure-as-Code (IaC) tool usin
 
 ## AWS CDK CLI for LocalStack
 
-`cdklocal` is a thin wrapper script for using the [AWS CDK](https://github.com/aws/aws-cdk) library against local APIs provided by LocalStack.
+[`lstk cdk`](/aws/developer-tools/running-localstack/lstk/#cdk) proxies the [AWS CDK](https://github.com/aws/aws-cdk) library against local APIs provided by LocalStack. It requires the AWS CDK CLI version `2.177.0` or newer on your `PATH`.
+
+:::note
+`lstk cdk` supersedes the older [`cdklocal` wrapper script](/aws/connecting/infrastructure-as-code/deprecated-wrapper-scripts#cdklocal), which is deprecated but still available if you need it.
+:::
 
 ### Installation
 
-The `cdklocal` command line is published as an [npm library](https://www.npmjs.com/package/aws-cdk-local):
+Install `lstk` by following the [`lstk` installation instructions](/aws/developer-tools/running-localstack/lstk/#installation).
+You'll also need the AWS CDK CLI installed separately:
 
 ```bash
 # Install globally
-npm install -g aws-cdk-local aws-cdk
+npm install -g aws-cdk
 
 # Verify it installed correctly
-cdklocal --version
-# e.g. 1.65.5
+cdk --version
 ```
-
-:::note
-
-Using `cdklocal` locally (e.g. within the `node_modules` of your repo instead of globally installed) does not work at the moment for some setups, so make sure you install both `aws-cdk` and `aws-cdk-local` with the `-G` flag.
-:::
 
 ### Usage
 
-`cdklocal` can be used as a drop-in replacement of where you would otherwise use `cdk` when targeting the AWS Cloud.
+`lstk cdk` can be used as a drop-in replacement of where you would otherwise use `cdk` when targeting the AWS Cloud.
 
 ```bash
-cdklocal --help
+lstk cdk --help
 ```
 
 ### Configuration
 
+`lstk cdk`'s only lstk-specific flag (before the CDK action) is `--region <region>` (default `us-east-1`); CDK always targets the default LocalStack account `000000000000`, so there is no `--account` flag.
+
 The following environment variables can be configured:
 
 - `AWS_ENDPOINT_URL`: The endpoint URL (i.e., protocol, host, and port) to connect to LocalStack (default: `http://localhost.localstack.cloud:4566`)
-- `LAMBDA_MOUNT_CODE`: Whether to use local Lambda code mounting (via setting `hot-reload` S3 bucket name)
+- `AWS_ENDPOINT_URL_S3`: The S3-specific endpoint URL, required alongside `AWS_ENDPOINT_URL` and must include `.s3.` to correctly identify S3 API calls
+- `LSTK_CDK_CMD`: Binary to invoke (default `cdk`)
+- `AWS_REGION`: Fallback for `--region`
 
 ### Example
 
@@ -62,20 +65,20 @@ The CDK command line ships with a sample app generator to run a quick test for g
 ```bash
 # create sample app
 mkdir /tmp/test; cd /tmp/test
-cdklocal init sample-app --language=javascript
+lstk cdk init sample-app --language=javascript
 
 # bootstrap localstack environment
-cdklocal bootstrap
+lstk cdk bootstrap
 
 # deploy the sample app
-cdklocal deploy
+lstk cdk deploy
 > Do you wish to deploy these changes (y/n)? y
 ```
 
-Once the deployment is done, you can inspect the created resources via the [`awslocal`](https://github.com/localstack/awscli-local) command line
+Once the deployment is done, you can inspect the created resources via the [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command line
 
 ```bash
-awslocal sns list-topics
+lstk aws sns list-topics
  {
      "Topics": [
          {
@@ -107,21 +110,5 @@ When this lambda is executed locally from the `/tmp` folder, the package can not
 
 ## CDK Version Compatibility
 
-`cdklocal` works with all installed versions of the Node.js `aws-cdk` package.
-However, issues exist for `aws-cdk >= 2.177.0`.
-
-For these versions:
-
-- We unset AWS-related environment variables like `AWS_PROFILE` before calling `cdk`.
-- We explicitly set `AWS_ENDPOINT_URL` and `AWS_ENDPOINT_URL_S3` to point to LocalStack.
-
-Some environment variables may cause conflicting config, such as wrong region or accidental deploys to real AWS.
-To allow specific variables (e.g., `AWS_REGION`), use `AWS_ENVAR_ALLOWLIST`:
-
-```bash
-AWS_ENVAR_ALLOWLIST=AWS_REGION,AWS_DEFAULT_REGION AWS_DEFAULT_REGION=eu-central-1 AWS_REGION=eu-central-1 cdklocal ...
-```
-
-If you manually set `AWS_ENDPOINT_URL`, it will be used.
-You must also set `AWS_ENDPOINT_URL_S3`, and it must include `.s3.` to correctly identify S3 API calls.
-See full configuration details [on our configuration docs](https://github.com/localstack/aws-cdk-local?tab=readme-ov-file#configurations).
+`lstk cdk` requires AWS CDK CLI `2.177.0` or newer, as noted in [Installation](#installation).
+If you're using an older `aws-cdk` version, or the legacy `cdklocal` wrapper script, see [CDK Version Compatibility](/aws/connecting/infrastructure-as-code/deprecated-wrapper-scripts#cdklocal) on the deprecated wrapper scripts page for the relevant environment-variable workarounds.

--- a/src/content/docs/aws/connecting/infrastructure-as-code/aws-chalice.mdx
+++ b/src/content/docs/aws/connecting/infrastructure-as-code/aws-chalice.mdx
@@ -20,7 +20,7 @@ Using LocalStack, you can kick-start your development process, create a new Chal
 Start LocalStack inside a Docker container by running:
 
 ```bash
-localstack start -d
+lstk start
 ```
 
 Install the `chalice-local` package by running:

--- a/src/content/docs/aws/connecting/infrastructure-as-code/aws-sam.md
+++ b/src/content/docs/aws/connecting/infrastructure-as-code/aws-sam.md
@@ -12,29 +12,29 @@ The AWS Serverless Application Model (SAM) is an open-source framework for devel
 It uses a simplified syntax to define functions, APIs, databases, and event source mappings.
 When you deploy, SAM converts its syntax into AWS CloudFormation syntax, helping you create serverless applications more quickly.
 
-LocalStack can work with SAM using the AWS SAM CLI for LocalStack.
-This CLI comes in the form of a `samlocal` wrapper script, which lets you deploy SAM applications on LocalStack.
-This guide explains how to set up local AWS resources using the `samlocal` wrapper script.
+LocalStack can work with SAM using [`lstk sam`](/aws/developer-tools/running-localstack/lstk/#sam), which lets you deploy SAM applications on LocalStack.
+This guide explains how to set up local AWS resources using `lstk sam`.
 
-## `samlocal` wrapper script
+## `lstk sam`
 
-`samlocal` is a wrapper for the `sam` command line interface, facilitating the use of SAM framework with LocalStack.
-When executing deployment commands like `samlocal ["build", "deploy", "validate", "package"]`, the script configures the SAM settings for LocalStack and runs the specified SAM command.
+`lstk sam` proxies the `sam` command line interface, facilitating the use of the SAM framework with LocalStack.
+When executing deployment commands like `lstk sam [ build | deploy | validate | package ]`, it configures the SAM settings for LocalStack and runs the specified SAM command.
 
-### Install the `samlocal` wrapper script
+:::note
+`lstk sam` supersedes the older [`samlocal` wrapper script](/aws/connecting/infrastructure-as-code/deprecated-wrapper-scripts#samlocal), which is deprecated but still available if you need it.
+:::
 
-You can install the `samlocal` wrapper script by running the following command:
+### Install lstk
 
-```bash
-pip install aws-sam-cli-local
-```
+To use `lstk sam`, install `lstk` by following the [`lstk` installation instructions](/aws/developer-tools/running-localstack/lstk/#installation).
+You'll also need the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) (version `1.95.0` or newer) installed and on your `PATH`.
 
 ### Create a new SAM project
 
 You can initialize a new SAM project using the following command:
 
 ```bash
-samlocal init
+lstk sam init
 ```
 
 Select `1` to create a new SAM application using an AWS Quick Start template.
@@ -50,19 +50,29 @@ Then, enter the project name and press `Enter`.
 After initializing the SAM project, enter the project directory and deploy the application using the following command:
 
 ```bash
-samlocal deploy --guided
+lstk sam deploy --guided
 ```
 
 Enter the default values for the deployment, such as the stack name, region, and confirm the changes.
-The `samlocal` wrapper will package and deploy the application to LocalStack.
+`lstk sam` will package and deploy the application to LocalStack.
 
 ### Configuration
 
-| Environment Variable   | Default value                                    | Description                                                             |
-|------------------------|--------------------------------------------------|-------------------------------------------------------------------------|
-| AWS_ENDPOINT_URL       | `http://localhost.localstack.cloud:4566`        | URL at which the `boto3` client can reach LocalStack                   |
-| EDGE_PORT (Deprecated)              | `4566`                              | Port number under which the LocalStack edge service is available        |
-| LOCALSTACK_HOSTNAME (Deprecated)     | `localhost`                         | Host under which the LocalStack edge service is available
+The `lstk sam` command supports several options and environment variables beyond what is available with the standard `sam` command. 
+| Option              | Default         | Description |
+|----------------------|-----------------|--------------|
+| `--region <region>`  | `us-east-1`     | Deployment region |
+| `--account <id>`     | `000000000000`  | Target AWS account id (12 digits) |
+
+`lstk sam`-specific flags must appear **before** the SAM action (for example, `lstk sam --region us-west-2 build`)
+
+| Environment Variable   | Default value | Description |
+|-------------------------|----------------|--------------|
+| `AWS_ENDPOINT_URL`      | -              | Override the auto-resolved LocalStack endpoint |
+| `AWS_ENDPOINT_URL_S3`   | -              | Override the auto-resolved LocalStack S3 endpoint |
+| `LSTK_SAM_CMD`          | `sam`          | Binary to invoke |
+| `AWS_REGION`            | -              | Fallback for `--region` |
+| `AWS_ACCESS_KEY_ID`     | -              | Fallback for `--account` |
 
 ## Debugging on VS Code
 

--- a/src/content/docs/aws/connecting/infrastructure-as-code/cloud-custodian.md
+++ b/src/content/docs/aws/connecting/infrastructure-as-code/cloud-custodian.md
@@ -16,7 +16,7 @@ You can use Cloud Custodian with LocalStack by just specifying the Cloud Custodi
 
 ## Getting started
 
-This guide is designed for users who are new to Cloud Custodian and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users who are new to Cloud Custodian and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 
 Start your LocalStack container using your preferred method.
 We will demonstrate how you can spin up an EC2 instance and tag it with the key `Custodian`, and then use Cloud Custodian to stop the instance.
@@ -33,12 +33,12 @@ After installing Cloud Custodian, you can configure a [custom LocalStack profile
 
 ### Create an EC2 instance
 
-You can create an EC2 instance using the `awslocal` wrapper script.
+You can create an EC2 instance using `lstk aws`.
 You can use the [`RunInstances`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html) API to create an EC2 instance.
 The following example creates an EC2 instance with the tag `Custodian` (any value):
 
 ```bash
-awslocal ec2 run-instances \
+lstk aws ec2 run-instances \
     --image-id ami-ff0fea8310f3 \
     --count 1 \
     --instance-type t3.nano \

--- a/src/content/docs/aws/connecting/infrastructure-as-code/crossplane.md
+++ b/src/content/docs/aws/connecting/infrastructure-as-code/crossplane.md
@@ -194,10 +194,10 @@ crossplane-test-bucket   True    True     crossplane-test-bucket   30s
 ```
 
 ...
-and the bucket it should also be visible when querying the local S3 buckets in LocalStack via [`awslocal`](https://github.com/localstack/awscli-local):
+and the bucket it should also be visible when querying the local S3 buckets in LocalStack via [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws):
 
 ```bash
-awslocal s3 ls
+lstk aws s3 ls
 ```
 
 ```bash title="Output"
@@ -233,7 +233,7 @@ crossplane-test-queue   True    True     http://host.docker.internal:4566/000000
 ...and the queue should be visible when listing the SQS queues in LocalStack:
 
 ```bash
-awslocal sqs list-queues
+lstk aws sqs list-queues
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/connecting/infrastructure-as-code/deprecated-wrapper-scripts.md
+++ b/src/content/docs/aws/connecting/infrastructure-as-code/deprecated-wrapper-scripts.md
@@ -1,0 +1,251 @@
+---
+title: Deprecated Wrapper Scripts
+description: Reference for the legacy awslocal, tflocal, samlocal, and cdklocal wrapper scripts, superseded by lstk.
+template: doc
+sidebar:
+  order: 12
+---
+
+## Introduction
+
+The following (now deprecated) wrapper scripts were used in conjunction with LocalStack, to direct the `aws`, `terraform`, `sam`, and `cdk` commands to LocalStack endpoints.
+
+- [`awslocal`](#awslocal) - Runs AWS CLI commands against LocalStack.
+- [`tflocal`](#tflocal) - Runs Terraform against LocalStack.
+- [`samlocal`](#samlocal) - Runs AWS SAM CLI commands against LocalStack.
+- [`cdklocal`](#cdklocal) - Runs AWS CDK commands against LocalStack.
+
+:::caution
+`awslocal`, `tflocal`, `samlocal`, and `cdklocal` are **deprecated** in favor of [`lstk`](/aws/developer-tools/running-localstack/lstk/), which provides equivalent functionality via `lstk aws`, `lstk terraform` (alias `lstk tf`), `lstk sam`, and `lstk cdk`.
+These wrapper scripts remain available and continue to work. This page documents them for anyone still relying on them.
+:::
+
+See the [AWS CLI](/aws/connecting/aws-cli), [Terraform](/aws/connecting/infrastructure-as-code/terraform), [AWS SAM](/aws/connecting/infrastructure-as-code/aws-sam), and [AWS CDK](/aws/connecting/infrastructure-as-code/aws-cdk) pages for the current `lstk`-based workflow.
+
+
+## awslocal
+
+`awslocal` serves as a thin wrapper and a substitute for the standard `aws` command, enabling you to run AWS CLI commands within the LocalStack environment without specifying the `--endpoint-url` parameter or a profile.
+
+### Installation
+
+Install the `awslocal` command using the following command:
+
+```bash
+pip install awscli-local[ver1]
+```
+
+:::tip
+The above command installs the most recent version of the underlying AWS CLI version 1 (`awscli`) package.
+If you would rather manage your own `awscli` version (e.g., `v1` or `v2`) and only install the wrapper script, you can use the following command:
+
+```bash
+pip install awscli-local
+```
+
+:::
+
+:::note
+Automatic installation of AWS CLI version 2 is not supported (at the time of writing there is no official pypi package for `v2` available), but the `awslocal` technically also works with AWS CLI v2 (see [Current Limitations](#current-limitations) for more details).
+:::
+
+### Usage
+
+The `awslocal` command shares identical usage with the standard `aws` command.
+For comprehensive usage instructions, refer to the manual pages by running `awslocal help`.
+
+```bash
+awslocal kinesis list-streams
+```
+
+### Configuration
+
+| Variable Name    | Description                                                                         |
+| ---------------- | ----------------------------------------------------------------------------------- |
+| AWS_ENDPOINT_URL | The endpoint URL to connect to (takes precedence over USE_SSL/LOCALSTACK_HOST)      |
+| LOCALSTACK_HOST  | A variable defining where to find LocalStack (default: `localhost:4566`) |
+| USE_SSL          | Whether to use SSL when connecting to LocalStack (default: False)      |
+
+### Current Limitations
+
+Please note that there is a known limitation for using the `cloudformation package ...` command with the AWS CLI v2.
+The problem is that the AWS CLI v2 is [not available as a package on pypi.org](https://github.com/aws/aws-cli/issues/4947), but is instead shipped as a binary package that cannot be easily patched from `awslocal`.
+To work around this issue, you have 2 options:
+
+- Downgrade to the v1 AWS CLI (this is the recommended approach)
+- There is an unofficial way to install AWS CLI v2 from sources.
+  We do not recommend this, but it is technically possible.
+  Also, you should install these libraries in a Python virtualenv, to avoid version clashes with other libraries on your system:
+
+```bash
+virtualenv .venv
+. .venv/bin/activate
+pip install https://github.com/boto/botocore/archive/v2.zip https://github.com/aws/aws-cli/archive/v2.zip
+```
+
+Please also note there is a known limitation for issuing requests using
+`--no-sign-request` with the AWS CLI.
+LocalStack's routing mechanism depends on
+the signature of each request to identify the correct service for the request.
+Thus, adding the flag `--no-sign-requests` provokes your request to reach the
+wrong service.
+One possible way to address this is to use the `awslocal` CLI
+instead of AWS CLI.
+
+## tflocal
+
+`tflocal` is a small wrapper script to run Terraform against LocalStack. It uses the [Terraform Override mechanism](https://www.terraform.io/language/files/override) and creates a temporary file `localstack_providers_override.tf` to configure the endpoints for the AWS `provider` section.
+The endpoints for all services are configured to point to the LocalStack API (`http://localhost:4566` by default).
+
+### Installation
+
+To install the `tflocal` command, you can use `pip` (assuming you have a local Python installation):
+
+```bash
+pip install terraform-local
+```
+
+After installation, you can use the `tflocal` command, which has the same interface as the `terraform` command line.
+
+```bash
+tflocal --help
+```
+
+### Usage
+
+```bash
+tflocal init
+tflocal apply
+```
+
+### Configuration
+
+| Environment Variable     | Default value                    | Description |
+| ------------------------ | -------------------------------- | ----------- |
+| `TF_CMD`                 | `terraform`                        | Terraform command to call |
+| `AWS_ENDPOINT_URL`       | -                                | Hostname and port of the target LocalStack instance |
+| `LOCALSTACK_HOSTNAME`    | `localhost`                        | Host name of the target LocalStack instance |
+| `EDGE_PORT`              | `4566`                             | Port number of the target LocalStack instance |
+| `S3_HOSTNAME`            | `s3.localhost.localstack.cloud`    | Special hostname to be used to connect to LocalStack S3 |
+| `USE_EXEC`               | -                                | Whether to use `os.exec` instead of `subprocess.Popen` (try using this in case of I/O issues) |
+| `<SERVICE>_ENDPOINT`     | -                                | Setting a custom service endpoint, e.g., `COGNITO_IDP_ENDPOINT=http://example.com` |
+| `AWS_DEFAULT_REGION`     | `us-east-1`                        | The AWS region to use (determined from local credentials if `boto3` is installed) |
+| `CUSTOMIZE_ACCESS_KEY`   | -                                | Enables you to override the static AWS Access Key ID |
+| `AWS_ACCESS_KEY_ID`      | `test` (`accountId`: 000000000000)   | AWS Access Key ID to use for multi-account setups |
+
+:::note
+While using `CUSTOMIZE_ACCESS_KEY`, following cases are taking precedence over each other from top to bottom:
+1. If the `AWS_ACCESS_KEY_ID` environment variable is set.
+2. If `access_key` is configured in the Terraform AWS provider.
+3. If the `AWS_PROFILE` environment variable is set and properly configured.
+4. If the `AWS_DEFAULT_PROFILE` environment variable is set and configured.
+5. If credentials for the `default` profile are configured.
+6. If none of the above settings are present, it falls back to using the default `AWS_ACCESS_KEY_ID` mock value.
+:::
+
+### OpenTofu
+
+You can use the `TF_CMD` environment variable with `tflocal` to specify the `tofu` binary to call:
+
+```bash
+TF_CMD=tofu tflocal --help
+```
+
+## samlocal
+
+`samlocal` is a wrapper for the `sam` command line interface, facilitating the use of the SAM framework with LocalStack.
+When executing deployment commands like `samlocal [ build | deploy | validate | package ]`, the script configures the SAM settings for LocalStack and runs the specified SAM command.
+
+:::note
+`samlocal` supports image/container-based Lambda (ECR) deploys and nested CloudFormation stacks, which `lstk sam` does not (yet) support - this is the main reason to keep using `samlocal` today.
+:::
+
+### Installation
+
+You can install the `samlocal` wrapper script by running the following command:
+
+```bash
+pip install aws-sam-cli-local
+```
+
+### Usage
+
+```bash
+samlocal init
+samlocal deploy --guided
+```
+
+### Configuration
+
+| Environment Variable   | Default value                                    | Description                                                             |
+|------------------------|--------------------------------------------------|-------------------------------------------------------------------------|
+| AWS_ENDPOINT_URL       | `http://localhost.localstack.cloud:4566`        | URL at which the `boto3` client can reach LocalStack                   |
+| EDGE_PORT              | `4566`                              | Port number under which the LocalStack edge service is available        |
+| LOCALSTACK_HOSTNAME    | `localhost`                         | Host under which the LocalStack edge service is available
+
+## cdklocal
+
+`cdklocal` is a thin wrapper script for using the [AWS CDK](https://github.com/aws/aws-cdk) library against local APIs provided by LocalStack.
+
+### Installation
+
+The `cdklocal` command line is published as an [npm library](https://www.npmjs.com/package/aws-cdk-local):
+
+```bash
+# Install globally
+npm install -g aws-cdk-local aws-cdk
+
+# Verify it installed correctly
+cdklocal --version
+# e.g. 1.65.5
+```
+
+:::note
+Using `cdklocal` locally (e.g. within the `node_modules` of your repo instead of globally installed) does not work at the moment for some setups, so make sure you install both `aws-cdk` and `aws-cdk-local` with the `-G` flag.
+:::
+
+### Usage
+
+`cdklocal` can be used as a drop-in replacement of where you would otherwise use `cdk` when targeting the AWS Cloud.
+
+```bash
+cdklocal --help
+
+# create sample app
+mkdir /tmp/test; cd /tmp/test
+cdklocal init sample-app --language=javascript
+
+# bootstrap localstack environment
+cdklocal bootstrap
+
+# deploy the sample app
+cdklocal deploy
+```
+
+### Configuration
+
+The following environment variables can be configured:
+
+- `AWS_ENDPOINT_URL`: The endpoint URL (i.e., protocol, host, and port) to connect to LocalStack (default: `http://localhost.localstack.cloud:4566`)
+- `LAMBDA_MOUNT_CODE`: Whether to use local Lambda code mounting (via setting `hot-reload` S3 bucket name)
+
+### CDK Version Compatibility
+
+`cdklocal` works with all installed versions of the Node.js `aws-cdk` package.
+However, issues exist for `aws-cdk >= 2.177.0`.
+
+For these versions:
+
+- We unset AWS-related environment variables like `AWS_PROFILE` before calling `cdk`.
+- We explicitly set `AWS_ENDPOINT_URL` and `AWS_ENDPOINT_URL_S3` to point to LocalStack.
+
+Some environment variables may cause conflicting config, such as wrong region or accidental deploys to real AWS.
+To allow specific variables (e.g., `AWS_REGION`), use `AWS_ENVAR_ALLOWLIST`:
+
+```bash
+AWS_ENVAR_ALLOWLIST=AWS_REGION,AWS_DEFAULT_REGION AWS_DEFAULT_REGION=eu-central-1 AWS_REGION=eu-central-1 cdklocal ...
+```
+
+If you manually set `AWS_ENDPOINT_URL`, it will be used.
+You must also set `AWS_ENDPOINT_URL_S3`, and it must include `.s3.` to correctly identify S3 API calls.
+See full configuration details [on our configuration docs](https://github.com/localstack/aws-cdk-local?tab=readme-ov-file#configurations).

--- a/src/content/docs/aws/connecting/infrastructure-as-code/former2.md
+++ b/src/content/docs/aws/connecting/infrastructure-as-code/former2.md
@@ -26,7 +26,7 @@ These outputs enable you to redeploy your resources while spinning a new LocalSt
 
 ## Getting started
 
-This guide is designed for users new to Former2 and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Former2 and assumes basic knowledge of the AWS CLI and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk/#aws) command.
 We will demonstrate how you can create local AWS resources using LocalStack, and import a CloudFormation output via Former2.
 
 ### Install Former2
@@ -49,13 +49,13 @@ Start your LocalStack container using your preferred method with the following e
 - **Mozilla Firefox**: `EXTRA_CORS_ALLOWED_ORIGINS=moz-extension://853c673f-1bd8-4226-a5ff-f1473f7b3d90`
 - **Microsoft Edge**: `EXTRA_CORS_ALLOWED_ORIGINS=extension://okkjnfohglnomdbpimkcdkiojbeiedof`
 
-You can create local AWS resources using the AWS CLI and the `awslocal` wrapper script.
+You can create local AWS resources using the AWS CLI and `lstk aws`.
 For example, you can create a new S3 bucket, SQS queue, and DynamoDB table using the following commands:
 
 ```bash
-awslocal s3 mb s3://my-bucket
-awslocal sqs create-queue --queue-name my-queue
-awslocal dynamodb create-table \
+lstk aws s3 mb s3://my-bucket
+lstk aws sqs create-queue --queue-name my-queue
+lstk aws dynamodb create-table \
     --table-name my-table \
     --attribute-definitions AttributeName=id,AttributeType=S \
     --key-schema AttributeName=id,KeyType=HASH \
@@ -65,19 +65,19 @@ awslocal dynamodb create-table \
 You can verify that the resources were created successfully by running the following command:
 
 ```bash
-localstack logs
+lstk logs
 ```
 
 ```bash title="Output"
-2023-10-14T15:31:08.852  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS s3.CreateBucket => 200
-2023-10-14T15:31:09.356  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS sqs.CreateQueue => 200
-2023-10-14T15:31:12.920  INFO --- [   asgi_gw_0] botocore.credentials       : Found credentials in environment variables.
-2023-10-14T15:31:13.332  INFO --- [   asgi_gw_0] localstack.utils.bootstrap : Execution of "require" took 2028.25ms
-2023-10-14T15:31:13.712  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS dynamodb.CreateTable => 200
+emulator | 2023-10-14T15:31:08.852  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS s3.CreateBucket => 200
+emulator | 2023-10-14T15:31:09.356  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS sqs.CreateQueue => 200
+emulator | 2023-10-14T15:31:12.920  INFO --- [   asgi_gw_0] botocore.credentials       : Found credentials in environment variables.
+emulator | 2023-10-14T15:31:13.332  INFO --- [   asgi_gw_0] localstack.utils.bootstrap : Execution of "require" took 2028.25ms
+emulator | 2023-10-14T15:31:13.712  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS dynamodb.CreateTable => 200
 ```
 
 ```bash
-awslocal s3 ls
+lstk aws s3 ls
 ```
 
 ```bash title="Output"
@@ -85,7 +85,7 @@ awslocal s3 ls
 ```
 
 ```bash
-awslocal sqs list-queues
+lstk aws sqs list-queues
 ```
 
 ```bash title="Output"
@@ -97,7 +97,7 @@ awslocal sqs list-queues
 ```
 
 ```bash
-awslocal dynamodb list-tables
+lstk aws dynamodb list-tables
 ```
 
 ```bash title="Output"

--- a/src/content/docs/aws/connecting/infrastructure-as-code/pulumi.mdx
+++ b/src/content/docs/aws/connecting/infrastructure-as-code/pulumi.mdx
@@ -444,7 +444,7 @@ pulumi up
 After the update, check the S3 buckets with:
 
 ```bash
-awslocal s3 ls
+lstk aws s3 ls
 ```
 
 You should see output similar to:

--- a/src/content/docs/aws/connecting/infrastructure-as-code/serverless-framework.md
+++ b/src/content/docs/aws/connecting/infrastructure-as-code/serverless-framework.md
@@ -20,7 +20,7 @@ In particular, the setup consists of the following two steps.
 
 This guide assumes that you have the following tools installed.
 
-- LocalStack ([Install](/aws/getting-started/installation))
+- The `lstk` CLI ([Install](/aws/developer-tools/running-localstack/lstk/#installation))
 - Serverless ([Install](https://www.serverless.com/framework/docs/getting-started/))
 
 It also assumes that you already have a Serverless app set up consisting of a couple of Lambda functions and a `serverless.yml` file similar to the following.
@@ -134,7 +134,7 @@ You can now deploy your Serverless service to LocalStack.
 First, start LocalStack by running
 
 ```bash
-localstack start
+lstk start
 ```
 
 Then deploy the endpoint by running

--- a/src/content/docs/aws/connecting/infrastructure-as-code/terraform.mdx
+++ b/src/content/docs/aws/connecting/infrastructure-as-code/terraform.mdx
@@ -17,16 +17,20 @@ HCL is a domain-specific language designed for writing configurations that defin
 LocalStack supports Terraform via the [AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) through [custom service endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/custom-service-endpoints#localstack).
 You can configure Terraform to use LocalStack in two ways:
 
-- Using the [`tflocal` wrapper script](https://github.com/localstack/terraform-local) to automatically configure the service endpoints for you.
+- Using [`lstk terraform`](/aws/developer-tools/running-localstack/lstk/#terraform) (alias `lstk tf`) to automatically configure the service endpoints for you.
 - Manually configuring the service endpoints in your Terraform configuration with additional maintenance.
 
-In this guide, we will demonstrate how you can create local AWS resources using Terraform and LocalStack, by using the `tflocal` wrapper script and a manual configuration example.
+In this guide, we will demonstrate how you can create local AWS resources using Terraform and LocalStack, by using `lstk terraform` and a manual configuration example.
 
-## `tflocal` wrapper script
+## `lstk terraform`
 
-`tflocal` is a small wrapper script to run Terraform against LocalStack. `tflocal` script uses the [Terraform Override mechanism](https://www.terraform.io/language/files/override) and creates a temporary file `localstack_providers_override.tf` to configure the endpoints for the AWS `provider` section.
+`lstk terraform` (alias `lstk tf`) runs Terraform against LocalStack. It uses the [Terraform Override mechanism](https://www.terraform.io/language/files/override) and creates a temporary file `localstack_providers_override.tf` to configure the endpoints for the AWS `provider` section, then forwards your arguments to the real `terraform` binary.
 The endpoints for all services are configured to point to the LocalStack API (`http://localhost:4566` by default).
 It allows you to easily deploy your unmodified Terraform scripts against LocalStack.
+
+:::note
+`lstk terraform` supersedes the older [`tflocal` wrapper script](/aws/connecting/infrastructure-as-code/deprecated-wrapper-scripts#tflocal), which is deprecated but still available if you need it.
+:::
 
 ### Create a Terraform configuration
 
@@ -39,18 +43,15 @@ resource "aws_s3_bucket" "test-bucket" {
 }
 ```
 
-### Install the `tflocal` wrapper script
+### Install lstk
 
-To install the `tflocal` command, you can use `pip` (assuming you have a local Python installation):
+To use `lstk terraform`, install `lstk` by following the [`lstk` installation instructions](/aws/developer-tools/running-localstack/lstk/#installation).
+You'll also need the [`terraform` CLI](https://developer.hashicorp.com/terraform/install) itself installed and on your `PATH`.
 
-```bash
-pip install terraform-local
-```
-
-After installation, you can use the `tflocal` command, which has the same interface as the `terraform` command line.
+Once installed, you can use `lstk terraform`, which has the same interface as the `terraform` command line.
 
 ```bash
-tflocal --help
+lstk terraform --help
 ```
 
 ```bash title="Output"
@@ -64,43 +65,36 @@ Start your LocalStack container using your preferred method.
 Initialize Terraform using the following command:
 
 ```bash
-tflocal init
+lstk terraform init
 ```
 
 You can now provision the S3 bucket specified in the configuration:
 
 ```bash
-tflocal apply
+lstk terraform apply
 ```
 
 ### Configuration
 
-| Environment Variable     | Default value                    | Description |
-| ------------------------ | -------------------------------- | ----------- |
-| `TF_CMD`                 | `terraform`                        | Terraform command to call |
-| `AWS_ENDPOINT_URL`       | -                                | Hostname and port of the target LocalStack instance |
-| `LOCALSTACK_HOSTNAME`    | `localhost`                        | **(Deprecated)** Host name of the target LocalStack instance |
-| `EDGE_PORT`              | `4566`                             | **(Deprecated)** Port number of the target LocalStack instance |
-| `S3_HOSTNAME`            | `s3.localhost.localstack.cloud`    | Special hostname to be used to connect to LocalStack S3 |
-| `USE_EXEC`               | -                                | Whether to use `os.exec` instead of `subprocess.Popen` (try using this in case of I/O issues) |
-| `<SERVICE>_ENDPOINT`     | -                                | Setting a custom service endpoint, e.g., `COGNITO_IDP_ENDPOINT=http://example.com` |
-| `AWS_DEFAULT_REGION`     | `us-east-1`                        | The AWS region to use (determined from local credentials if `boto3` is installed) |
-| `CUSTOMIZE_ACCESS_KEY`   | -                                | Enables you to override the static AWS Access Key ID |
-| `AWS_ACCESS_KEY_ID`      | `test` (`accountId`: 000000000000)   | AWS Access Key ID to use for multi-account setups |
+The `lstk terraform` command supports several options and environment variables beyond what is available with standard `terraform`. Flags that are specific to `lstk terraform` must appear **before** the Terraform action:
 
-:::note
-While using `CUSTOMIZE_ACCESS_KEY`, following cases are taking precedence over each other from top to bottom:
-1. If the `AWS_ACCESS_KEY_ID` environment variable is set.
-2. If `access_key` is configured in the Terraform AWS provider.
-3. If the `AWS_PROFILE` environment variable is set and properly configured.
-4. If the `AWS_DEFAULT_PROFILE` environment variable is set and configured.
-5. If credentials for the `default` profile are configured.
-6. If none of the above settings are present, it falls back to using the default `AWS_ACCESS_KEY_ID` mock value.
-:::
+| Option                | Description |
+| ---------------------- | ----------- |
+| `--region <region>`    | Deployment region |
+| `--account <id>`       | Target AWS account id (12 digits) |
+
+| Environment Variable          | Default value                        | Description |
+| ------------------------------ | ------------------------------------- | ----------- |
+| `AWS_ENDPOINT_URL`             | -                                      | Override the auto-resolved LocalStack endpoint |
+| `LSTK_TF_CMD`                  | `terraform`                            | Binary to invoke, e.g. `tofu` |
+| `LSTK_TF_OVERRIDE_FILE_NAME`   | `localstack_providers_override.tf`     | Override file name |
+| `LSTK_TF_DRY_RUN`              | -                                      | When set, generate the override file but do not run Terraform |
+| `AWS_REGION`                   | -                                      | Fallback for `--region` |
+| `AWS_ACCESS_KEY_ID`            | -                                      | Fallback for `--account` |
 
 ## Manual Configuration
 
-Instead of using the `tflocal` script, you have the option to manually configure the local service endpoints and credentials.
+Instead of using `lstk terraform`, you have the option to manually configure the local service endpoints and credentials.
 The following sections will provide detailed steps for this manual configuration.
 
 ### General Configuration
@@ -182,7 +176,7 @@ resource "aws_s3_bucket" "test-bucket" {
 ### Endpoint Configuration
 
 Here's a configuration example with additional service endpoints.
-Please note that these provider configurations may not be necessary if you use the `tflocal` script (as described above).
+Please note that these provider configurations may not be necessary if you use `lstk terraform` (as described above).
 You can save the following configuration in a file named `provider.tf` and include it in your Terraform configuration.
 
 ```hcl showshowLineNumbers
@@ -238,10 +232,10 @@ If you use a different account ID within LocalStack, you can customize the snipp
 
 ## OpenTofu
 
-OpenTofu is an open-source fork of Terraform acting as a drop-in replacement for Terraform, as it's compatible with Terraform versions 1.5.x and most of 1.6.x. You can use OpenTofu with LocalStack to create and manage your AWS resources with your pre-existing Terraform configurations. You can use the `TF_CMD` environment variable with `tflocal` to specify the `tofu` binary to call, or setup a manual configuration to point the individual services to LocalStack.
+OpenTofu is an open-source fork of Terraform acting as a drop-in replacement for Terraform, as it's compatible with Terraform versions 1.5.x and most of 1.6.x. You can use OpenTofu with LocalStack to create and manage your AWS resources with your pre-existing Terraform configurations. You can use the `LSTK_TF_CMD` environment variable with `lstk terraform` to specify the `tofu` binary to call, or setup a manual configuration to point the individual services to LocalStack.
 
 ```bash
-TF_CMD=tofu tflocal --help
+LSTK_TF_CMD=tofu lstk terraform --help
 ```
 
 ```bash title="Output"


### PR DESCRIPTION
## Summary

Migrate the entire "Connecting" section to use `lstk`, instead of the existing `localstack`, `awslocal`, `tflocal`, `samlocal`, or `cdklocal` wrappers.

- Migrates the AWS CLI page from `awslocal` to `lstk aws`. Remove warnings/issues that are no longer relevant.
- Migrates Terraform, AWS SAM, and AWS CDK guides from `tflocal`/`samlocal`/`cdklocal` to `lstk terraform`, `lstk sam`, `lstk cdk`. Update lists of configuration options and variables.
- Swaps a few `awslocal` mentions in Crossplane, Cloud Custodian, Former2, and Pulumi guides.
- Swaps `localstack start` for `lstk start` in the Serverless Framework and Chalice guides.
- Adds a new "Deprecated Wrapper Scripts" reference page documenting the old scripts for anyone still relying on them, linked from each migrated page.
- Note that the other sections of "Connecting" (IDEs, Console, SDKs, Credentials) did not require any change.

Fixes [DEVX-990](https://linear.app/localstack/issue/DEVX-990/migrate-connecting-docs-section-to-use-lstk)

🤖 Generated with [Claude Code](https://claude.com/claude-code), guided gently and reviewed by Peter.