### PR TITLE
DOC-361: Migrate localstack CLI refs to lstk in Azure docs

### DIFF
--- a/src/content/docs/azure/integrations/az.md
+++ b/src/content/docs/azure/integrations/az.md
@@ -54,7 +54,7 @@ When you're done using the Azure Emulator, you can run the following command:
 $ lstk az stop-interception
 ```
 
-The `az` CLI tool will now communicate with the Azure REST API on future invocations.
+The `az` CLI tool will now communicate with the Azure cloud on future invocations.
 
 ### Alternative: prefixed commands
 

--- a/src/content/docs/azure/integrations/az.md
+++ b/src/content/docs/azure/integrations/az.md
@@ -16,58 +16,33 @@ This guide will show you how to use it to interact with LocalStack.
 This guide is designed for users who are new to LocalStack for Azure emulator and assumes basic knowledge of how the Azure CLI works.
 We will demonstrate how to create, show and delete an Azure resource group.
 
-### Install the packages
+### Prerequisites
 
-Run the following command to install the required packages:
+This guide uses [`lstk`](/aws/developer-tools/running-localstack/lstk/), which proxies your host `az` CLI against the Azure emulator using an isolated configuration directory, so your global `~/.azure` setup is left untouched.
 
-```
-$ pip install azlocal
-```
-
-You now have access to the following LocalStack tools:
-
-| CLI tool  | LocalStack tool | Purpose                       |
-|-----------|-----------------|-------------------------------|
-| az        | azlocal         | Interact with Azure resources |
-| azd       | azdlocal        | Deploy ARM/Bicep templates    |
-
-The LocalStack variants are wrappers around the existing tools, so you keep the full  functionality of the original tool. It will just redirect all commands to the running LocalStack Emulator.
-
-### Setup the az CLI
-
-To make sure the `az` tool sends requests to the Azure Emulator REST API, run the following command:
+Run the following command once to prepare the integration:
 
 ```
-$ azlocal start_interception
+$ lstk setup azure
 ```
 
 ### Create and manage the Resource Group
 
-Run the following command to create a resource group in the Emulator:
+Run the following command to create a resource group in the Emulator, prefixing the same `az` command you would normally run with `lstk az`:
 
 ```
-$ az group create --name MyResourceGroup --location westeurope
+$ lstk az group create --name MyResourceGroup --location westeurope
 ```
 
 To check the resource group details, run the following command:
 
 ```
-$ az group show --name MyResourceGroup
+$ lstk az group show --name MyResourceGroup
 ```
 
 To delete the resource group, run the following command:
 
 ```
-$ az group delete --name MyResourceGroup --yes
+$ lstk az group delete --name MyResourceGroup --yes
 ```
-
-### Teardown
-
-When you're done using the Azure Emulator, you can run the following command:
-
-```
-$ azlocal stop_interception
-```
-
-The `az` CLI tool will now communicate with the Azure REST API on future invocations.
 

--- a/src/content/docs/azure/integrations/az.md
+++ b/src/content/docs/azure/integrations/az.md
@@ -18,31 +18,57 @@ We will demonstrate how to create, show and delete an Azure resource group.
 
 ### Prerequisites
 
-This guide uses [`lstk`](/aws/developer-tools/running-localstack/lstk/), which proxies your host `az` CLI against the Azure emulator using an isolated configuration directory, so your global `~/.azure` setup is left untouched.
+This guide uses [`lstk`](/aws/developer-tools/running-localstack/lstk/) to point the `az` CLI at the Azure emulator.
 
-Run the following command once to prepare the integration:
+To make sure the `az` tool sends requests to the Azure Emulator REST API, run the following command:
 
 ```
-$ lstk setup azure
+$ lstk az start-interception
 ```
 
 ### Create and manage the Resource Group
 
-Run the following command to create a resource group in the Emulator, prefixing the same `az` command you would normally run with `lstk az`:
+Run the following command to create a resource group in the Emulator:
 
 ```
-$ lstk az group create --name MyResourceGroup --location westeurope
+$ az group create --name MyResourceGroup --location westeurope
 ```
 
 To check the resource group details, run the following command:
 
 ```
-$ lstk az group show --name MyResourceGroup
+$ az group show --name MyResourceGroup
 ```
 
 To delete the resource group, run the following command:
 
 ```
+$ az group delete --name MyResourceGroup --yes
+```
+
+### Teardown
+
+When you're done using the Azure Emulator, you can run the following command:
+
+```
+$ lstk az stop-interception
+```
+
+The `az` CLI tool will now communicate with the Azure REST API on future invocations.
+
+### Alternative: prefixed commands
+
+Instead of interception, you can prefix each `az` command with `lstk az` individually, without changing your global `~/.azure` configuration. Run this once to prepare the integration:
+
+```
+$ lstk setup azure
+```
+
+Then prefix every command:
+
+```
+$ lstk az group create --name MyResourceGroup --location westeurope
+$ lstk az group show --name MyResourceGroup
 $ lstk az group delete --name MyResourceGroup --yes
 ```
 

--- a/src/content/docs/azure/integrations/python.md
+++ b/src/content/docs/azure/integrations/python.md
@@ -29,6 +29,11 @@ The `azlocal` package is provided by LocalStack to simplify the process of inter
 
 The other two packages are packages provided by Azure to interact with Azure services in Python.
 
+:::note
+Elsewhere in these docs, `az` CLI examples use [`lstk az`](/aws/developer-tools/running-localstack/lstk/) instead of `azlocal`.
+`lstk` proxies the `az` CLI, but does not provide a Python SDK interception helper — for Python, `azlocal`'s `PythonLocalSdk` (used below) remains the supported approach.
+:::
+
 ### Create a Python file
 
 You can now use the Azure SDK for Python to interact with LocalStack.

--- a/src/content/docs/azure/services/action-group.mdx
+++ b/src/content/docs/azure/services/action-group.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating an Action Group with an email receiver and
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/api-management.mdx
+++ b/src/content/docs/azure/services/api-management.mdx
@@ -18,19 +18,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide walks you through creating an API Management service, adding an API, and defining and updating an operation. It is designed for users new to API Management and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide walks you through creating an API Management service, adding an API, and defining and updating an operation. It is designed for users new to API Management and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/application-insights.mdx
+++ b/src/content/docs/azure/services/application-insights.mdx
@@ -23,14 +23,14 @@ The Azure CLI commands below use the [`application-insights` extension](https://
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/autoscale-setting.mdx
+++ b/src/content/docs/azure/services/autoscale-setting.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating an autoscale setting targeting an App Serv
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/bastion-host.mdx
+++ b/src/content/docs/azure/services/bastion-host.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Bastion Host and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Bastion Host and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/blob-storage.mdx
+++ b/src/content/docs/azure/services/blob-storage.mdx
@@ -15,23 +15,23 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Blob Storage and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Blob Storage and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 :::note
-As an alternative to using the `azlocal` CLI, users can run:
+As an alternative to using the `lstk az` proxy, users can run:
 
-`azlocal start-interception`
+`lstk az start-interception`
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator REST API.
 To revert this configuration, run:
 
-`azlocal stop-interception`
+`lstk az stop-interception`
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API
 :::

--- a/src/content/docs/azure/services/blob-storage.mdx
+++ b/src/content/docs/azure/services/blob-storage.mdx
@@ -23,19 +23,6 @@ Launch LocalStack using your preferred method. For more information, see [Introd
 lstk az start-interception
 ```
 
-:::note
-As an alternative to using the `lstk az` proxy, users can run:
-
-`lstk az start-interception`
-
-This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator REST API.
-To revert this configuration, run:
-
-`lstk az stop-interception`
-
-This reconfigures the `az` CLI to send commands to the official Azure management REST API
-:::
-
 ### Create a resource group
 
 Create a resource group to contain your storage resources:

--- a/src/content/docs/azure/services/container-instance.mdx
+++ b/src/content/docs/azure/services/container-instance.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Container Instances and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Container Instances and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/container-registry.mdx
+++ b/src/content/docs/azure/services/container-registry.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating a registry, logging in with Docker, pushin
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/cosmos-db.mdx
+++ b/src/content/docs/azure/services/cosmos-db.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating Cosmos DB accounts, databases, and contain
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/data-collection-rules.mdx
+++ b/src/content/docs/azure/services/data-collection-rules.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating a Data Collection Endpoint, a Data Collect
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/dbfor-postgresql.mdx
+++ b/src/content/docs/azure/services/dbfor-postgresql.mdx
@@ -15,19 +15,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Azure DB for PostgreSQL and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Azure DB for PostgreSQL and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/diagnostic-setting.mdx
+++ b/src/content/docs/azure/services/diagnostic-setting.mdx
@@ -23,14 +23,14 @@ See also the [Monitor](/azure/services/monitor) page for a broader overview of d
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/front-door.mdx
+++ b/src/content/docs/azure/services/front-door.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Azure Front Door and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Azure Front Door and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/functions-app.mdx
+++ b/src/content/docs/azure/services/functions-app.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating a Function App backed by a Storage Account
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/key-vault.mdx
+++ b/src/content/docs/azure/services/key-vault.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Key Vault and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Key Vault and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/log-analytics.mdx
+++ b/src/content/docs/azure/services/log-analytics.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating a Log Analytics Workspace, retrieving its 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/managed-identity.mdx
+++ b/src/content/docs/azure/services/managed-identity.mdx
@@ -20,19 +20,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Managed Identity and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Managed Identity and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/metric-alert.mdx
+++ b/src/content/docs/azure/services/metric-alert.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating a metric alert rule referencing an action 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/monitor.mdx
+++ b/src/content/docs/azure/services/monitor.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Azure Monitor and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Azure Monitor and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/nat-gateway.mdx
+++ b/src/content/docs/azure/services/nat-gateway.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to NAT Gateway and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to NAT Gateway and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/network-interface.mdx
+++ b/src/content/docs/azure/services/network-interface.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Network Interfaces and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Network Interfaces and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/private-dns-zone.mdx
+++ b/src/content/docs/azure/services/private-dns-zone.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Private DNS Zone and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Private DNS Zone and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/private-endpoint.mdx
+++ b/src/content/docs/azure/services/private-endpoint.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Private Endpoint and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Private Endpoint and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/public-ip-address.mdx
+++ b/src/content/docs/azure/services/public-ip-address.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Public IP Addresses and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Public IP Addresses and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/public-ip-prefix.mdx
+++ b/src/content/docs/azure/services/public-ip-prefix.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Public IP Prefixes and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Public IP Prefixes and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/queue-storage.mdx
+++ b/src/content/docs/azure/services/queue-storage.mdx
@@ -25,11 +25,6 @@ Launch LocalStack using your preferred method. For more information, see [Introd
 lstk az start-interception
 ```
 
-:::note
-`lstk az start-interception` points the Azure CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
-To revert this configuration, run `lstk az stop-interception` so the CLI targets the official Azure management REST API again.
-:::
-
 ### Create a resource group
 
 Create a resource group to contain your storage resources:

--- a/src/content/docs/azure/services/queue-storage.mdx
+++ b/src/content/docs/azure/services/queue-storage.mdx
@@ -17,17 +17,17 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Queue Storage and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Queue Storage and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 :::note
-`azlocal start-interception` points the Azure CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
-To revert this configuration, run `azlocal stop-interception` so the CLI targets the official Azure management REST API again.
+`lstk az start-interception` points the Azure CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
+To revert this configuration, run `lstk az stop-interception` so the CLI targets the official Azure management REST API again.
 :::
 
 ### Create a resource group

--- a/src/content/docs/azure/services/resource-graph.mdx
+++ b/src/content/docs/azure/services/resource-graph.mdx
@@ -17,19 +17,19 @@ LocalStack for Azure enables users to explore resources deployed within the loca
 
 ## Getting started
 
-This guide is designed for users new to Resource Graph and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Resource Graph and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/resource-manager.mdx
+++ b/src/content/docs/azure/services/resource-manager.mdx
@@ -20,19 +20,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Resource Manager and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Resource Manager and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/role-assignment.mdx
+++ b/src/content/docs/azure/services/role-assignment.mdx
@@ -22,14 +22,14 @@ This guide walks you through assigning a built-in role to a managed identity, li
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/role-definition.mdx
+++ b/src/content/docs/azure/services/role-definition.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating a custom role definition, listing role def
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/route-table.mdx
+++ b/src/content/docs/azure/services/route-table.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Route Tables and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Route Tables and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/scheduled-query-rules.mdx
+++ b/src/content/docs/azure/services/scheduled-query-rules.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating a Scheduled Query Rule that targets a Log 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/service-bus-data-plane.mdx
+++ b/src/content/docs/azure/services/service-bus-data-plane.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Service Bus Data Plane APIs and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Service Bus Data Plane APIs and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/service-bus.mdx
+++ b/src/content/docs/azure/services/service-bus.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Service Bus and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Service Bus and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/sql.mdx
+++ b/src/content/docs/azure/services/sql.mdx
@@ -17,19 +17,19 @@ The supported APIs are listed in the [API Coverage](#api-coverage) section.
 
 ## Getting started
 
-This guide is designed for users new to Azure SQL Database and assumes basic knowledge of the Azure CLI and `azlocal`. The following example creates a SQL server and database, configures firewall access, and defines retention and encryption settings.
+This guide is designed for users new to Azure SQL Database and assumes basic knowledge of the Azure CLI and `lstk az`. The following example creates a SQL server and database, configures firewall access, and defines retention and encryption settings.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/storage-accounts.mdx
+++ b/src/content/docs/azure/services/storage-accounts.mdx
@@ -20,19 +20,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Azure Storage Accounts and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Azure Storage Accounts and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/table-storage.mdx
+++ b/src/content/docs/azure/services/table-storage.mdx
@@ -17,19 +17,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Table Storage and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Table Storage and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/virtual-network.mdx
+++ b/src/content/docs/azure/services/virtual-network.mdx
@@ -17,12 +17,12 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Virtual Network and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Virtual Network and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
@@ -30,7 +30,7 @@ This command points the `az` CLI away from the public Azure management REST API 
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/web-app.mdx
+++ b/src/content/docs/azure/services/web-app.mdx
@@ -15,19 +15,19 @@ The supported APIs are available on our [API Coverage section](#api-coverage), w
 
 ## Getting started
 
-This guide is designed for users new to Web App and assumes basic knowledge of the Azure CLI and our `azlocal` wrapper script.
+This guide is designed for users new to Web App and assumes basic knowledge of the Azure CLI and our `lstk az` proxy.
 
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/web-test.mdx
+++ b/src/content/docs/azure/services/web-test.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating a web test linked to an Application Insigh
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.

--- a/src/content/docs/azure/services/workbook.mdx
+++ b/src/content/docs/azure/services/workbook.mdx
@@ -22,14 +22,14 @@ This guide walks you through creating a workbook and a workbook template.
 Launch LocalStack using your preferred method. For more information, see [Introduction to LocalStack for Azure](/azure/getting-started/). Once the container is running, enable Azure CLI interception by running:
 
 ```bash
-azlocal start-interception
+lstk az start-interception
 ```
 
 This command points the `az` CLI away from the public Azure management REST API and toward the LocalStack for Azure emulator API.
 To revert this configuration, run:
 
 ```bash
-azlocal stop-interception
+lstk az stop-interception
 ```
 
 This reconfigures the `az` CLI to send commands to the official Azure management REST API.


### PR DESCRIPTION
## Summary
- Replace `azlocal start-interception`/`stop-interception` with `lstk az start-interception`/`lstk az stop-interception` across all 40 Azure service pages that use the interception workflow.
- Rewrite `integrations/az.md` to the `lstk az` pattern (`lstk setup azure` once, then prefix `az` commands with `lstk az`), matching the getting-started quickstart already updated in DOC-360.
- `integrations/python.md`: left `azlocal`'s Python SDK (`PythonLocalSdk`) as-is since `lstk` has no Python SDK equivalent, but added a note explaining the discrepancy with the `az` CLI examples elsewhere.
- `integrations/azd.md`: left untouched — `azdlocal` (the `azd`/Bicep wrapper) isn't something `lstk` proxies at all.
- Getting Started docs are out of scope here (handled separately in DOC-360 / #802).

Linear: https://linear.app/localstack/issue/DOC-361/migrate-all-localstack-cli-refs-to-lstk-in-azure-docs

## Test plan
- [x] `astro build` completes successfully
- [x] `starlight-links-validator` reports all internal links valid
- [x] Confirmed no remaining `azlocal`/`localstack` CLI refs outside the two intentionally-excluded files
