### PR TITLE
DOC-292(`hotfix`): Remove proxy mode references from Snowflake docs

### DIFF
--- a/src/content/docs/snowflake/capabilities/configuration.md
+++ b/src/content/docs/snowflake/capabilities/configuration.md
@@ -30,7 +30,6 @@ Options that affect the core Snowflake emulator functionality.
 | `SF_CSV_IMPORT_MAX_ROWS` | `50000` (default) | Maximum number of rows to import from CSV files into tables |
 | `SF_DEFAULT_USER` | `test` (default) | Specify the default user to be used by the Snowflake emulator. |
 | `SF_DEFAULT_PASSWORD` | `test` (default) | Specify the default password to be used by the Snowflake emulator. |
-| `SF_PROXY_PRIVATE_KEY` | | Specify the private key to be used by the Snowflake emulator. |
 
 ### Custom Snowflake hostnames
 
@@ -84,16 +83,6 @@ Options to configure how LocalStack interacts with Docker.
 | `LEGACY_DOCKER_CLIENT` | `0`\|`1` | Whether LocalStack should use the command-line Docker client and subprocess execution to run Docker commands, rather than the Docker SDK. |
 | `DOCKER_CMD` | `docker` (default), `sudo docker`| Shell command used to run Docker containers (only used in combination with `LEGACY_DOCKER_CLIENT`) |
 | `FORCE_NONINTERACTIVE` | | When running with Docker, disables the `--interactive` and `--tty` flags. Useful when running headless. |
-
-## Proxy Configuration
-
-Options to configure Snowflake proxy settings for LocalStack.
-
-| Variable | Example Values | Description |
-| - | - | - |
-| `SF_PROXY_HOST` | `proxy.example.com` | Hostname or IP address of the proxy server to be used for connecting to Snowflake. |
-| `SF_PROXY_USER` | `proxy_user` | Username for authentication with the proxy server. |
-| `SF_PROXY_PASSWORD` | `password123` | Password associated with the proxy user account. |
 
 ## Profiles
 

--- a/src/content/docs/snowflake/tooling/user-interface.md
+++ b/src/content/docs/snowflake/tooling/user-interface.md
@@ -10,9 +10,8 @@ The Snowflake emulator provides a User Interface (UI) via the [LocalStack Web Ap
 
 * Run SQL queries and view results using a Query Editor.
 * View detailed request/response traces of API calls.
-* Forward queries to a real Snowflake instance using a proxy.
 
-To access the User Interface, you need to start the Snowflake emulator and access the **Snowflake** tab in your default instance of the LocalStack Web Application. This User Interface is available only when the Snowflake emulator is running. Please note that it does not connect to the real Snowflake cloud environment (except during a proxy connection) or any other external service on the Internet.
+To access the User Interface, you need to start the Snowflake emulator and access the **Snowflake** tab in your default instance of the LocalStack Web Application. This User Interface is available only when the Snowflake emulator is running. Please note that it does not connect to the real Snowflake cloud environment or any other external service on the Internet.
 
 :::note
 Please note that the Snowflake User Interface is still experimental and under active development.


### PR DESCRIPTION
## Summary
- Remove the `## Proxy Configuration` section (`SF_PROXY_HOST`, `SF_PROXY_USER`, `SF_PROXY_PASSWORD`) and the `SF_PROXY_PRIVATE_KEY` row from the Core table in `snowflake/capabilities/configuration.md`. `SF_PROXY_PASSWORD` asked users to pass a real Snowflake password as a plaintext env var, and this proxy feature is no longer exposed in the web UI.
- Remove the "Forward queries to a real Snowflake instance using a proxy" bullet and the proxy-connection caveat from `snowflake/tooling/user-interface.md`.
- Left `snowflake/changelog.md`'s historical "Add Snowflake proxy request handler" entry untouched, since changelogs document past releases rather than current behavior.

Linear: https://linear.app/localstack/issue/DOC-292/remove-proxy-mode-references-from-snowflake-docs

## Test plan
- [x] `astro build` completes successfully
- [x] `starlight-links-validator` reports all internal links valid
- [x] Confirmed no remaining proxy-mode references in the Snowflake docs outside the changelog
