### PR TITLE
DOC-315 (`hotfix`): Document RAM ram:RequestedAllowsExternalPrincipals condition key

### DIFF
--- a/src/content/docs/aws/developer-tools/security-testing/iam-coverage.md
+++ b/src/content/docs/aws/developer-tools/security-testing/iam-coverage.md
@@ -152,7 +152,7 @@ It only includes operations performed with a principal, not as root, so test set
 |                | - StringEqualsIgnoreCase                                                             |
 |                | - StringLike                                                                         |
 |                | - ArnLike/ArnEquals                                                                  |
-|                | Supported condition keys:                                                            |
+|                | Supported [global condition keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html): |
 |                | - aws:RequestedRegion                                                                |
 |                | - aws:PrincipalArn                                                                   |
 |                | - aws:SourceArn                                                                      |
@@ -161,6 +161,12 @@ It only includes operations performed with a principal, not as root, so test set
 |                | - aws:RequestTag                                                                     |
 |                | - aws:PrincipalTag                                                                    |
 
+## Service-Specific Condition Keys
+
+In addition to the global condition keys above, some services support their own condition keys, matching AWS's [per-service condition key reference](https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html):
+
+- [EC2](/aws/services/ec2/#iam-condition-keys): `ec2:MetadataHttpTokens`, `ec2:Attribute/<AttributeName>`
+- [RAM](/aws/services/ram/#iam-condition-keys): `ram:RequestedAllowsExternalPrincipals`
 
 ## Current Limitations
 

--- a/src/content/docs/aws/services/ram.mdx
+++ b/src/content/docs/aws/services/ram.mdx
@@ -44,6 +44,25 @@ No IAM policies are created or attached, and no permission enforcement takes pla
 
 For all other resource types, the functionality is limited to mocking.
 
+## IAM Condition Keys
+
+When [IAM Policy Enforcement](/aws/developer-tools/security-testing/iam-policy-enforcement/) is enabled, LocalStack supports the following RAM-specific condition key, matching the behavior described in the [AWS condition keys reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsresourceaccessmanager.html#awsresourceaccessmanager-policy-keys):
+
+- `ram:RequestedAllowsExternalPrincipals` &mdash; the `allowExternalPrincipals` value of a `CreateResourceShare` or `UpdateResourceShare` request, useful for restricting resource shares to principals within your organization.
+
+For example, the following policy statement only allows creating or updating a resource share when it does not allow external principals:
+
+```json
+{
+    "Effect": "Allow",
+    "Action": ["ram:CreateResourceShare", "ram:UpdateResourceShare"],
+    "Resource": "*",
+    "Condition": {
+        "Bool": { "ram:RequestedAllowsExternalPrincipals": "false" }
+    }
+}
+```
+
 ## API Coverage
 
 <FeatureCoverage service="ram" client:load />


### PR DESCRIPTION
## Summary
- Add an "IAM Condition Keys" section to the RAM docs (`ram.mdx`), mirroring the existing EC2 pattern.
- Documents `ram:RequestedAllowsExternalPrincipals`, populated from the `allowExternalPrincipals` field on `CreateResourceShare`/`UpdateResourceShare`, with an example policy restricting resource shares to principals within the organization.

Related engineering PR: https://github.com/localstack/localstack-pro/pull/7560
Linear: https://linear.app/localstack/issue/DOC-315/doc-ram-add-condition-key-ramrequestedallowsexternalprincipals

## Test plan
- [x] `astro build` completes successfully
- [x] `starlight-links-validator` reports all internal links valid
