### PR TITLE
docs(aws/developer-tools): migrate /aws/developer-tools section to use `lstk`

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -483,10 +483,6 @@ export default defineConfig({
                       slug: 'aws/developer-tools/running-localstack',
                     },
                     {
-                      label: 'LocalStack CLI',
-                      slug: 'aws/developer-tools/running-localstack/localstack-cli',
-                    },
-                    {
                       label: 'lstk CLI',
                       slug: 'aws/developer-tools/running-localstack/lstk',
                     },
@@ -497,6 +493,10 @@ export default defineConfig({
                     {
                       label: 'LocalStack Desktop',
                       slug: 'aws/developer-tools/running-localstack/localstack-desktop',
+                    },
+                    {
+                      label: 'Deprecated LocalStack CLI',
+                      slug: 'aws/developer-tools/running-localstack/localstack-cli',
                     },
                   ],
                 },

--- a/src/components/SectionCards.astro
+++ b/src/components/SectionCards.astro
@@ -7,9 +7,10 @@ interface Props {
   title?: string;
   customTitles?: Record<string, string>;
   useDirectFiles?: boolean;
+  excludeFiles?: string[];
 }
 
-const { basePath, title, customTitles = {}, useDirectFiles = false } = Astro.props;
+const { basePath, title, customTitles = {}, useDirectFiles = false, excludeFiles = [] } = Astro.props;
 
 // Get sections - either index files from subdirectories or direct files
 const allSections = await getCollection('docs', ({ id }) => {
@@ -49,14 +50,18 @@ const sortedSections = allSections.sort((a, b) => {
   return titleA.localeCompare(titleB);
 });
 
-const sectionData = sortedSections.map(section => {
+const sectionData = sortedSections.flatMap(section => {
   // Extract the key name from the section ID
   const relativePath = section.id.substring(basePath.length);
   const keyName = relativePath.split('/').filter(part => part !== '')[0];
-  
+
   // For direct files, we need to remove the file extension from the key
   const cleanKey = useDirectFiles ? keyName.replace(/\.(md|mdx)$/, '') : keyName;
-  
+
+  if (excludeFiles.includes(cleanKey)) {
+    return [];
+  }
+
   // Use custom title if provided, otherwise fall back to the section title
   const sectionTitle = customTitles[cleanKey] || section.data.title || section.data.linkTitle || 'Unknown Section';
   const description = section.data.description || `Learn more about ${sectionTitle}`;

--- a/src/content/docs/aws/developer-tools/aws-replicator/index.mdx
+++ b/src/content/docs/aws/developer-tools/aws-replicator/index.mdx
@@ -20,17 +20,14 @@ LocalStack AWS Replicator creates identical copies of AWS resources in a running
 This means that external resources can easily be replicated before deploying the main application, and removes the need to change existing stacks or create custom infrastructure, making LocalStack setup easier.
 
 :::note
-The AWS Replicator is in a preview state, supporting only [selected resources](#supported-resources).
+The AWS Replicator is in a preview state, supporting only [selected resources](#supported-resources). The new CLI experience, `lstk`, does not yet support the AWS Replicator. 
+Continue using the legacy [LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/) version 4.2.0 or newer.
 :::
 
 ## Getting started
 
 A valid `LOCALSTACK_AUTH_TOKEN` must be configured to start the LocalStack for AWS image.
 
-:::note
-The Replicator is in limited preview and is available from LocalStack CLI version 4.2.0.
-If you encounter issues, update your [LocalStack CLI](/aws/getting-started/installation/#update-localstack-cli).
-:::
 
 ### Retrieve credentials to access AWS
 

--- a/src/content/docs/aws/developer-tools/chaos-engineering/chaos-api.md
+++ b/src/content/docs/aws/developer-tools/chaos-engineering/chaos-api.md
@@ -33,7 +33,7 @@ If you'd like to try it out, please [contact us](https://www.localstack.cloud/de
 
 The prerequisites for this guide are:
 
-- LocalStack for AWS and [LocalStack CLI](/aws/getting-started/installation/) 
+- LocalStack for AWS and [`lstk`](/aws/developer-tools/running-localstack/lstk/#installation)
 - [LocalStack Auth Token](/aws/getting-started/auth-token/)
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
 - [Python](https://www.python.org/downloads/)
@@ -119,7 +119,7 @@ All calls to these services in these regions will return a 503 Service Unavailab
 To see this in action, try to create an S3 bucket in `us-east-1`:
 
 ```bash
-awslocal s3 mb s3://test-bucket --region us-east-1
+lstk aws s3 mb s3://test-bucket --region us-east-1
 ```
 
 ```bash
@@ -129,7 +129,7 @@ make_bucket failed: s3://test-bucket An error occurred (ServiceUnavailableExcept
 However, the same operation, when run in `eu-central-1` will work as expected.
 
 ```bash
-awslocal s3 mb s3://test-bucket --region eu-central-1
+lstk aws s3 mb s3://test-bucket --region eu-central-1
 ```
 
 ```bash

--- a/src/content/docs/aws/developer-tools/cloud-sandbox/app-preview.md
+++ b/src/content/docs/aws/developer-tools/cloud-sandbox/app-preview.md
@@ -105,7 +105,7 @@ preview-cmd: |
     make deploy;
     make build-frontend;
     make deploy-frontend;
-    distributionId=$(awslocal cloudfront list-distributions | jq -r '.DistributionList.Items[0].Id');
+    distributionId=$(lstk aws cloudfront list-distributions | jq -r '.DistributionList.Items[0].Id');
     echo LS_PREVIEW_URL=$AWS_ENDPOINT_URL/cloudfront/$distributionId/ >> $GITHUB_ENV;
 ```
 

--- a/src/content/docs/aws/developer-tools/cloud-sandbox/ephemeral-instances.md
+++ b/src/content/docs/aws/developer-tools/cloud-sandbox/ephemeral-instances.md
@@ -13,7 +13,8 @@ Ephemeral Instances allows you to run a LocalStack instance in the cloud.
 You can interact with these instances via the LocalStack Web Application, or by configuring your integrations and developer tools with the endpoint URL of the ephemeral instance.
 
 :::note
-Ephemeral Instances is offered as a **preview** feature and is under active development.
+Ephemeral Instances is offered as a **preview** feature. `lstk` does not yet support Ephemeral Instances.
+Continue using the legacy [LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/) for this feature.
 :::
 
 ## Getting started

--- a/src/content/docs/aws/developer-tools/lambda-tools/hot-reloading.mdx
+++ b/src/content/docs/aws/developer-tools/lambda-tools/hot-reloading.mdx
@@ -142,7 +142,7 @@ To create the Lambda function, you just need to take care of two things:
 So, using the AWS example, this would be:
 
 ```bash
-awslocal lambda create-function --function-name my-cool-local-function \
+lstk aws lambda create-function --function-name my-cool-local-function \
     --code S3Bucket="hot-reload",S3Key="/tmp/aws-doc-sdk-examples/python/example_code/lambda" \
     --handler lambda_handler_basic.lambda_handler \
     --runtime python3.8 \
@@ -153,23 +153,12 @@ You can also check out some of our [Deployment Configuration Examples](#deployme
 
 We can also quickly make sure that it works by invoking it with a simple payload:
 
-<Tabs>
-<TabItem label="AWS CLI v1">
 ```bash
-awslocal lambda invoke --function-name my-cool-local-function \
-    --payload '{"action": "increment", "number": 3}' \
-    output.txt
-```
-</TabItem>
-<TabItem label="AWS CLI v2">
-```bash
-awslocal lambda invoke --function-name my-cool-local-function \
+lstk aws lambda invoke --function-name my-cool-local-function \
     --cli-binary-format raw-in-base64-out \
     --payload '{"action": "increment", "number": 3}' \
     output.txt
 ```
-</TabItem>
-</Tabs>
 
 The invocation returns itself returns:
 
@@ -332,10 +321,10 @@ To create the Lambda function, you need to take care of two things:
 * Set the S3 key to the path of the directory your lambda function resides in.
   The handler is then referenced by the filename of your lambda code and the function in that code that needs to be invoked.
 
-Create the Lambda Function using the `awslocal` CLI:
+Create the Lambda Function using `lstk aws`:
 
 ```bash
-awslocal lambda create-function \
+lstk aws lambda create-function \
     --function-name hello-world \
     --runtime "nodejs16.x" \
     --role arn:aws:iam::123456789012:role/lambda-ex \
@@ -345,25 +334,13 @@ awslocal lambda create-function \
 
 You can quickly make sure that it works by invoking it with a simple payload:
 
-<Tabs>
-<TabItem label="AWS CLI v1">
 ```bash
-awslocal lambda invoke \
-    --function-name hello-world \
-    --payload '{"action": "test"}' \
-    output.txt
-```
-</TabItem>
-<TabItem label="AWS CLI v2">
-```bash
-awslocal lambda invoke \
+lstk aws lambda invoke \
     --function-name hello-world \
     --cli-binary-format raw-in-base64-out \
     --payload '{"action": "test"}' \
     output.txt
 ```
-</TabItem>
-</Tabs>
 
 The invocation returns itself returns:
 
@@ -422,10 +399,10 @@ This is enabled using the [`nodemon-webpack-plugin`](https://www.npmjs.com/packa
 
 ##### Creating the Lambda Function with Webpack
 
-You can now create the Lambda function using the `awslocal` CLI:
+You can now create the Lambda function using `lstk aws`:
 
 ```bash
-awslocal lambda create-function \
+lstk aws lambda create-function \
     --function-name localstack-example \
     --runtime nodejs18.x \
     --role arn:aws:iam::000000000000:role/lambda-ex \
@@ -436,7 +413,7 @@ awslocal lambda create-function \
 Additionally, you can create a Lambda Function URL with the following command:
 
 ```bash
-function_url=$(awslocal lambda create-function-url-config \
+function_url=$(lstk aws lambda create-function-url-config \
     --function-name localstack-example \
     --auth-type NONE | jq -r '.FunctionUrl')
 ```
@@ -629,8 +606,8 @@ LAMBDA_MOUNT_CWD=$(pwd)/build/hot serverless deploy --stage local
 <TabItem label="AWS Cloud Development Kit (CDK)">
 ```bash
 STAGE=local && LAMBDA_MOUNT_CWD=$(pwd)/build/hot &&
-  cdklocal bootstrap aws://000000000000/$(AWS_REGION) && \
-  cdklocal deploy
+  lstk cdk bootstrap aws://000000000000/$(AWS_REGION) && \
+  lstk cdk deploy
 ```
 </TabItem>
 <TabItem label="Terraform">
@@ -686,7 +663,7 @@ Please note that this environment variable name is arbitrary - you can use any y
 You can then deploy a hot-reloading function with the following command:
 
 ```bash
-awslocal lambda create-function \
+lstk aws lambda create-function \
   --function-name test-function \
   --code S3Bucket=hot-reload,S3Key='$HOST_LAMBDA_DIR/src' \
   --handler handler.handler \

--- a/src/content/docs/aws/developer-tools/lambda-tools/remote-debugging.mdx
+++ b/src/content/docs/aws/developer-tools/lambda-tools/remote-debugging.mdx
@@ -42,7 +42,7 @@ This guide describes how to use the AWS Toolkit for VS Code to debug Lambda func
 
 ### Prerequisites
 
-* Upgrade to LocalStack v4.8 (or higher) for both your LocalStack CLI and your LocalStack Docker image.
+* Install the [`lstk` CLI](/aws/developer-tools/running-localstack/lstk)
 * [VS Code](https://code.visualstudio.com/) (>= v1.83.0)
 * [AWS Toolkit for VS Code](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-toolkit-vscode) (>= v3.74)
 * [LocalStack Toolkit for VS Code](https://marketplace.visualstudio.com/items?itemName=LocalStack.localstack) (>= v1.2.0)
@@ -196,10 +196,19 @@ necessary tools and flexibility to troubleshoot effectively.
 
 To enable Lambda Debug Mode, set the `LAMBDA_DEBUG_MODE` environment variable as shown below:
 
+```toml
+# .lstk/config.toml
+[[containers]]
+type = "aws"
+env  = ["lambda-debug"]
+
+[env.lambda-debug]
+LAMBDA_DEBUG_MODE = "1"
+LAMBDA_DOCKER_FLAGS = "-p 19891:19891"
+```
+
 ```bash
-LAMBDA_DEBUG_MODE=1 \
-LAMBDA_DOCKER_FLAGS='-p 19891:19891' \
-localstack start
+lstk start
 ```
 
 When enabled, Lambda Debug Mode automatically adjusts timeouts to accommodate debugging needs:
@@ -217,11 +226,21 @@ Manually setting `LAMBDA_DOCKER_FLAGS` is unnecessary when using this configurat
 Here is an example of mounting a `debug_config.yaml` in your LocalStack container to start your Debug Mode:
 
 <Tabs>
-<TabItem label="LocalStack CLI">
+<TabItem label="lstk">
+```toml
+# .lstk/config.toml
+[[containers]]
+type    = "aws"
+env     = ["lambda-debug-advanced"]
+volumes = ["/path/to/debug-config.yaml:/tmp/lambda_debug_mode_config.yaml"]
+
+[env.lambda-debug-advanced]
+LAMBDA_DEBUG_MODE = "1"
+LAMBDA_DEBUG_MODE_CONFIG_PATH = "/tmp/debug_config.yaml"
+```
+
 ```bash
-LOCALSTACK_LAMBDA_DEBUG_MODE=1 \
-LOCALSTACK_LAMBDA_DEBUG_MODE_CONFIG_PATH=/tmp/debug_config.yaml \
-localstack start --volume /path/to/debug-config.yaml:/tmp/lambda_debug_mode_config.yaml
+lstk start
 ```
 </TabItem>
 <TabItem label="Docker Compose">
@@ -338,8 +357,18 @@ to [iterate quickly over your function code](/aws/developer-tools/lambda-tools/h
 
 First, make sure that LocalStack is started with the following configuration (see the [Configuration docs](/aws/customization/configuration-options#lambda) for more information):
 
+```toml
+# .lstk/config.toml
+[[containers]]
+type = "aws"
+env  = ["lambda-debug"]
+
+[env.lambda-debug]
+LAMBDA_DOCKER_FLAGS = "-p 19891:19891"
+```
+
 ```bash
-LAMBDA_DOCKER_FLAGS='-p 19891:19891' localstack start
+lstk start
 ```
 
 #### Preparing your code
@@ -479,7 +508,7 @@ To create the Lambda function, you just need to take care of two things:
 Using the AWS CLI, this would be:
 
 ```bash
-awslocal lambda create-function --function-name my-cool-local-function \
+lstk aws lambda create-function --function-name my-cool-local-function \
     --code S3Bucket="hot-reload",S3Key="$(pwd)/" \
     --handler handler.handler \
     --runtime python3.13 \
@@ -489,23 +518,12 @@ awslocal lambda create-function --function-name my-cool-local-function \
 
 We can quickly verify that it works by invoking it with a simple payload:
 
-<Tabs>
-<TabItem label="AWS CLI v1">
 ```bash
-awslocal lambda invoke --function-name my-cool-local-function \
-    --payload '{"message": "Hello from LocalStack!"}' \
-    output.txt
-```
-</TabItem>
-<TabItem label="AWS CLI v2">
-```bash
-awslocal lambda invoke --function-name my-cool-local-function \
+lstk aws lambda invoke --function-name my-cool-local-function \
     --cli-binary-format raw-in-base64-out \
     --payload '{"message": "Hello from LocalStack!"}' \
     output.txt
 ```
-</TabItem>
-</Tabs>
 
 ### Debugging JVM Lambda functions
 
@@ -527,7 +545,7 @@ services:
 When creating your Lambda function, set the `_JAVA_OPTIONS` environment variable like so:
 
 ```bash
-awslocal lambda create-function --function-name debugfunc \
+lstk aws lambda create-function --function-name debugfunc \
     --zip-file fileb://java-handler.zip \
     --handler myindex.handler \
     --runtime java8.al2 \
@@ -688,7 +706,7 @@ exports.handler = async (event) => {
 Create the lambda function using:
 
 ```bash
-awslocal lambda create-function --function-name func1 \
+lstk aws lambda create-function --function-name func1 \
     --code S3Bucket="hot-reload",S3Key="$(pwd)/" \
     --handler myindex.handler \
     --runtime nodejs14.x \
@@ -700,23 +718,12 @@ Now to debug your lambda function, click on the `Debug` icon with
 `Attach to Remote Node.js` configuration selected, and then invoke your
 lambda function:
 
-<Tabs>
-<TabItem label="AWS CLI v1">
 ```bash
-awslocal lambda invoke --function-name func1 \
-    --payload '{"hello":"world"}' \
-    output.txt
-```
-</TabItem>
-<TabItem label="AWS CLI v2">
-```bash
-awslocal lambda invoke --function-name func1 \
+lstk aws lambda invoke --function-name func1 \
     --cli-binary-format raw-in-base64-out \
     --payload '{"hello":"world"}' \
     output.txt
 ```
-</TabItem>
-</Tabs>
 
 
 ## Examples

--- a/src/content/docs/aws/developer-tools/running-localstack/index.mdx
+++ b/src/content/docs/aws/developer-tools/running-localstack/index.mdx
@@ -9,14 +9,17 @@ sidebar:
 
 import SectionCards from '../../../../../components/SectionCards.astro';
 
-Several tools are available to initialize, manage, and terminate the LocalStack emulator. Whether you utilize the standard LocalStack CLI, the next-generation `lstk` CLI, or the MCP server for AI-driven management, these interfaces provide complete control over the lifecycle of your local cloud environment.
+Several tools are available to install, start, and manage the LocalStack emulator. Your starting point should be `lstk`, the modern CLI for managing LocalStack. The MCP server is also available for AI-driven management, giving you complete control over the lifecycle of your local cloud environment.
+
+Note that the previous `localstack` CLI is now deprecated, but can [still be used](/aws/developer-tools/running-localstack/localstack-cli/) if necessary.
 
 <SectionCards
   basePath="aws/developer-tools/running-localstack/"
   useDirectFiles
   customTitles={{
-    "localstack-cli": "LocalStack CLI",
+    "localstack-cli": "Deprecated LocalStack CLI",
     "lstk": "lstk",
     "mcp-server": "LocalStack MCP Server",
   }}
+  excludeFiles={["localstack-cli"]}
 />

--- a/src/content/docs/aws/developer-tools/running-localstack/localstack-cli.mdx
+++ b/src/content/docs/aws/developer-tools/running-localstack/localstack-cli.mdx
@@ -1,6 +1,6 @@
 ---
-title: LocalStack CLI
-description: Reference guide for LocalStack CLI commands, options, and usage.
+title: Deprecated LocalStack CLI
+description: Reference guide for the deprecated LocalStack CLI commands, options, and usage. We recommend using lstk instead.
 template: doc
 sidebar:
   order: 10

--- a/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
+++ b/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
@@ -20,6 +20,10 @@ Running `lstk` with no arguments takes you through the entire startup flow autom
 
 `lstk` also proxies developer tools so they run directly against LocalStack: the AWS CLI (`lstk aws`), the Azure CLI (`lstk az`), Terraform (`lstk terraform`), the AWS CDK (`lstk cdk`), and the AWS SAM CLI (`lstk sam`).
 
+:::tip[Recommended]
+`lstk` is the recommended way to run and manage LocalStack. The [legacy LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/) is deprecated.
+:::
+
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) installed and running.

--- a/src/content/docs/aws/developer-tools/running-localstack/mcp-server.mdx
+++ b/src/content/docs/aws/developer-tools/running-localstack/mcp-server.mdx
@@ -22,6 +22,10 @@ Before configuring the MCP server, ensure the following are installed and availa
 - [`cdklocal`](https://github.com/localstack/aws-cdk-local), [`tflocal`](https://github.com/localstack/terraform-local), or [`samlocal`](https://github.com/localstack/aws-sam-cli-local) if you plan to use the infrastructure deployment tool. (**optional**)
 - [Snowflake CLI](https://docs.snowflake.com/en/developer-guide/snowflake-cli/index) (`snow`) if you plan to use the Snowflake client tool. (**optional**)
 
+:::note
+The MCP server currently manages LocalStack via the legacy `localstack` CLI and the `awslocal`, `cdklocal`, `tflocal`, and `samlocal` wrapper scripts. `lstk` support is not yet available for the MCP server.
+:::
+
 ## Installation
 
 The LocalStack MCP Server is published on npm as [`@localstack/localstack-mcp-server`](https://www.npmjs.com/package/@localstack/localstack-mcp-server).

--- a/src/content/docs/aws/developer-tools/security-testing/custom-tls-certificates.mdx
+++ b/src/content/docs/aws/developer-tools/security-testing/custom-tls-certificates.mdx
@@ -30,7 +30,7 @@ They all can be summarised as:
 
 ## Creating a custom docker image
 
-If you run LocalStack in a docker container (which includes using [the CLI](/aws/getting-started/installation/#install-localstack-cli), [docker](/aws/getting-started/installation/#docker-compose), [docker-compose](/aws/getting-started/installation/#docker-compose), or [helm](/aws/customization/kubernetes/deploy-helm-chart)), to include a custom TLS root certificate a new docker image should be created.
+If you run LocalStack in a docker container (which includes using [`lstk`](/aws/developer-tools/running-localstack/lstk/), [docker](/aws/getting-started/installation/#docker-compose), [docker-compose](/aws/getting-started/installation/#docker-compose), or [helm](/aws/customization/kubernetes/deploy-helm-chart)), to include a custom TLS root certificate a new docker image should be created.
 
 Create a `Dockerfile` containing the following commands:
 
@@ -63,9 +63,16 @@ LocalStack now needs to be configured to use this custom image.
 The workflow is different depending on how you start localstack.
 
 <Tabs>
-<TabItem label="CLI">
+<TabItem label="lstk">
+```toml
+# .lstk/config.toml
+[[containers]]
+type  = "aws"
+image = "<image name>"
+```
+
 ```bash
-IMAGE_NAME=<image name> localstack start
+lstk start
 ```
 </TabItem>
 <TabItem label="Docker">
@@ -112,8 +119,18 @@ and follow the instructions fn the [init hooks documentation](/aws/customization
 
 If your proxy intercepts traffic to LocalStack cloud services (e.g., license server), you can disable TLS verification for these specific requests using the `SSL_NO_VERIFY` [configuration variable](/aws/customization/configuration-options#security) (or `LOCALSTACK_SSL_NO_VERIFY` in Docker).
 
+```toml
+# .lstk/config.toml
+[[containers]]
+type = "aws"
+env  = ["tls"]
+
+[env.tls]
+SSL_NO_VERIFY = "1"
+```
+
 ```bash
-SSL_NO_VERIFY=1 localstack start
+lstk start
 ```
 
 :::caution

--- a/src/content/docs/aws/developer-tools/security-testing/explainable-iam.md
+++ b/src/content/docs/aws/developer-tools/security-testing/explainable-iam.md
@@ -14,12 +14,23 @@ You can enable `DEBUG=1` to gain visibility into these log messages, allowing yo
 
 ## Getting started
 
-This guide is designed for users new to Explainable IAM and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to Explainable IAM and assumes basic knowledge of the AWS CLI and our [`lstk aws` AWS CLI proxy](/aws/developer-tools/running-localstack/lstk#aws).
 
 Start your LocalStack container with the `DEBUG=1` and `ENFORCE_IAM=1` environment variables set:
 
+```toml
+# .lstk/config.toml
+[[containers]]
+type = "aws"
+env  = ["iam-enforcement"]
+
+[env.iam-enforcement]
+DEBUG = "1"
+ENFORCE_IAM = "1"
+```
+
 ```bash
-DEBUG=1 ENFORCE_IAM=1 localstack start
+lstk start
 ```
 
 In this guide, we will create a policy for creating Lambda functions by only allowing the `lambda:CreateFunction` permission.
@@ -46,7 +57,7 @@ Create a policy document named `policy_1.json` and add the following content:
 You can now create a new user named `test-user`, and put the policy in place by executing the following commands:
 
 ```bash
-awslocal iam create-user --user-name test-user
+lstk aws iam create-user --user-name test-user
 ```
 
 ```bash
@@ -62,13 +73,13 @@ awslocal iam create-user --user-name test-user
 ```
 
 ```bash
-awslocal iam put-user-policy --user-name test-user --policy-name policy1 --policy-document file://policy_1.json
+lstk aws iam put-user-policy --user-name test-user --policy-name policy1 --policy-document file://policy_1.json
 ```
 
 You can further create an access key for the user by executing the following command:
 
 ```bash
-awslocal iam create-access-key --user-name test-user
+lstk aws iam create-access-key --user-name test-user
 ```
 
 Export the access key and secret key as environment variables:
@@ -83,7 +94,7 @@ export AWS_SECRET_ACCESS_KEY=...
 You can now attempt to create a Lambda function using the newly created user's credentials:
 
 ```bash
-awslocal lambda create-function \
+lstk aws lambda create-function \
     --function-name test-function \
     --role arn:aws:iam::000000000000:role/lambda-role \
     --runtime python3.8 \

--- a/src/content/docs/aws/developer-tools/security-testing/iam-policy-enforcement.md
+++ b/src/content/docs/aws/developer-tools/security-testing/iam-policy-enforcement.md
@@ -15,12 +15,23 @@ Per default, IAM enforcement is disabled, and all APIs can be accessed without a
 
 ## Getting started
 
-This guide is designed for users new to IAM Policy Enforcement and assumes basic knowledge of the AWS CLI and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script.
+This guide is designed for users new to IAM Policy Enforcement and assumes basic knowledge of the AWS CLI and our `lstk aws` AWS CLI proxy.
 
 Start your LocalStack container with the `DEBUG=1` and `ENFORCE_IAM=1` environment variables set:
 
+```toml
+# .lstk/config.toml
+[[containers]]
+type = "aws"
+env  = ["iam-enforcement"]
+
+[env.iam-enforcement]
+DEBUG = "1"
+ENFORCE_IAM = "1"
+```
+
 ```bash
-DEBUG=1 ENFORCE_IAM=1 localstack start
+lstk start
 ```
 
 We will demonstrate IAM Policy Enforcement, by creating a user and obtaining the access/secret keys.
@@ -36,7 +47,7 @@ This way, we can demonstrate the differentiation in access permissions between t
 In **Terminal 1**, execute the following commands to create a `test` user and obtain the access/secret keys:
 
 ```bash
-awslocal iam create-user --user-name test
+lstk aws iam create-user --user-name test
 ```
 
 ```bash
@@ -52,7 +63,7 @@ awslocal iam create-user --user-name test
 ```
 
 ```bash
-awslocal iam create-access-key --user-name test
+lstk aws iam create-access-key --user-name test
 ```
 
 ```bash
@@ -74,7 +85,7 @@ Once the access keys are set, you will attempt to create an S3 bucket using thes
 
 ```bash
 export AWS_ACCESS_KEY_ID=LKIAQAAAAAAAHFR7QTN3 AWS_SECRET_ACCESS_KEY=EYUHpIol7bRJpKd/28c/LI2C4bbEnp82LJCRwXRV
-awslocal s3 mb s3://mybucket
+lstk aws s3 mb s3://mybucket
 ```
 
 ```bash
@@ -94,8 +105,8 @@ You can view the LocalStack logs to validate the policy enforcement:
 Let's now return to **Terminal 1** and execute the following commands to attach a policy to the user `test`:
 
 ```bash
-awslocal iam create-policy --policy-name p1 --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:CreateBucket","Resource":"*"}]}'
-awslocal iam attach-user-policy --user-name test --policy-arn arn:aws:iam::000000000000:policy/p1
+lstk aws iam create-policy --policy-name p1 --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:CreateBucket","Resource":"*"}]}'
+lstk aws iam attach-user-policy --user-name test --policy-arn arn:aws:iam::000000000000:policy/p1
 ```
 
 ### Create a bucket
@@ -103,7 +114,7 @@ awslocal iam attach-user-policy --user-name test --policy-arn arn:aws:iam::00000
 Now, let's switch back to **Terminal 2** and observe how the bucket creation succeeds with the `test` IAM user:
 
 ```bash
-awslocal s3 mb s3://mybucket
+lstk aws s3 mb s3://mybucket
 ```
 
 ```bash

--- a/src/content/docs/aws/developer-tools/security-testing/iam-policy-stream.md
+++ b/src/content/docs/aws/developer-tools/security-testing/iam-policy-stream.md
@@ -16,13 +16,14 @@ Subsequently, it displays the suggested policy.
 This feature aids in identifying the correct permissions for cloud applications and can help spot logical errors, such as unexpected actions in a policy.
 
 :::note
-IAM Policy Stream is offered as a **preview** feature and is under active development.
+IAM Policy Stream is offered as a **preview** feature and is under active development. `lstk` does not yet support IAM Policy Stream.
+Continue using the legacy [LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/) for this feature.
 :::
 
 ## Getting started
 
 This guide is designed for users who are new to the IAM Policy Stream.
-It assumes you have basic knowledge of the AWS CLI (and our [`awslocal`](https://github.com/localstack/awscli-local) wrapper script).
+It assumes you have basic knowledge of the AWS CLI (and our [`lstk aws`](/aws/developer-tools/running-localstack/lstk#aws) AWS CLI proxy).
 
 ### Start your LocalStack container
 
@@ -52,7 +53,7 @@ In a separate terminal tab, we will create AWS resources to observe the necessar
 In this example, we are creating an SNS topic using the following command:
 
 ```bash
-awslocal sns create-topic --name test-topic
+lstk aws sns create-topic --name test-topic
 ```
 
 In the other tab, the required policy will be generated.
@@ -97,7 +98,7 @@ To use this feature, open the LocalStack Web Application in your browser, go to 
 Run the following command in your terminal to generate a corresponding policy in the IAM Policy Stream dashboard:
 
 ```bash
-awslocal sns create-topic --name test-topic
+lstk aws sns create-topic --name test-topic
 ```
 
 You will see the following output in the IAM Policy Stream dashboard:


### PR DESCRIPTION
## Summary

Update the "Developer Tools" section to use `lstk`, rather than the legacy `localstack` CLI or `xxxlocal` wrapper scripts. This PR covers all parts of "Developer Tools", with the exception of "Snapshots" which is a much bigger change (for another PR).

Note that several "preview" features are not currently supported by `lstk` (and may never be supported), so were marked with "continue to use `localstack`" call-outs:

- **AWS Replicator** — `lstk` doesn't support it yet, and it'll likely be added to `lstk deploy`
- **LocalStack MCP Server** — currently manages LocalStack via the legacy `localstack` CLI. Discussions on the correct strategy are ongoing.
- **Ephemeral Instances** — `lstk` doesn't support these, and will likely be replaced by a new "Cloud Sandboxes" feature.
- **IAM Policy Stream**'s `localstack aws iam stream` command  — Will likely be merged into App Inspector.

All changes were manually reviewed, and all pages were studied end-to-end to avoid missing anything.
