### PR TITLE
DOC-356 (`hotfix`): Refresh EKS supported versions

### DIFF
--- a/src/content/docs/aws/services/eks.mdx
+++ b/src/content/docs/aws/services/eks.mdx
@@ -863,17 +863,17 @@ spec:
 LocalStack uses [k3s](https://github.com/k3s-io/k3s) under the hood for creating EKS clusters.
 Below is the list of supported Kubernetes versions and their corresponding k3s versions.
 
-The default version is `1.35`.
+The default version is `1.36`.
 
 | Kubernetes Version   | k3s Version   | EKS Platform Version   |
 |----------------------|---------------|------------------------|
-| 1.36                 | v1.36.1-k3s1  | eks.3                  |
-| 1.35                 | v1.35.5-k3s1  | eks.13                 |
-| 1.34                 | v1.34.8-k3s1  | eks.23                 |
-| 1.33                 | v1.33.12-k3s1 | eks.37                 |
-| 1.32                 | v1.32.13-k3s1 | eks.44                 |
-| 1.31                 | v1.31.14-k3s1 | eks.60                 |
-| 1.30                 | v1.30.14-k3s2 | eks.68                 |
+| 1.36                 | v1.36.2-k3s1  | eks.7                  |
+| 1.35                 | v1.35.6-k3s1  | eks.18                 |
+| 1.34                 | v1.34.9-k3s1  | eks.28                 |
+| 1.33                 | v1.33.13-k3s1 | eks.42                 |
+| 1.32                 | v1.32.13-k3s1 | eks.49                 |
+| 1.31                 | v1.31.14-k3s1 | eks.65                 |
+| 1.30                 | v1.30.14-k3s2 | eks.73                 |
 
 Users can specify the desired version when creating an EKS cluster in LocalStack using the `K3S_IMAGE_TAG` configuration variable when starting LocalStack.
 


### PR DESCRIPTION
## Summary
- set Kubernetes 1.36 as the default version for LocalStack EKS clusters
- refresh the documented k3s image tags and EKS platform versions to match LocalStack PR #7918

