### PR TITLE
DOCS (`hotfix`): Remove LocalStack CLI from MCP server prerequisites

### DIFF
--- a/src/content/docs/aws/developer-tools/running-localstack/mcp-server.mdx
+++ b/src/content/docs/aws/developer-tools/running-localstack/mcp-server.mdx
@@ -17,7 +17,7 @@ It enables AI agents to manage the full local cloud development lifecycle: start
 Before configuring the MCP server, ensure the following are installed and available on your system `PATH`:
 
 - [Node.js](https://nodejs.org/en/download/) (v22.x or later) to run `npx`.
-- [LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/) and [Docker](https://docs.docker.com/get-docker/) to manage the LocalStack container.
+- [Docker](https://docs.docker.com/get-docker/) to manage the LocalStack container.
 - A [LocalStack Auth Token](/aws/getting-started/auth-token/) configured as `LOCALSTACK_AUTH_TOKEN`. All MCP server tools require a valid Auth Token.
 - [`cdklocal`](https://github.com/localstack/aws-cdk-local), [`tflocal`](https://github.com/localstack/terraform-local), or [`samlocal`](https://github.com/localstack/aws-sam-cli-local) if you plan to use the infrastructure deployment tool. (**optional**)
 - [Snowflake CLI](https://docs.snowflake.com/en/developer-guide/snowflake-cli/index) (`snow`) if you plan to use the Snowflake client tool. (**optional**)


### PR DESCRIPTION
## Summary
- Removes the LocalStack CLI from the Prerequisites list on the [MCP Server](https://docs.localstack.cloud/aws/developer-tools/running-localstack/mcp-server/) page — the MCP server runs via `npx` and manages the container through Docker directly, so the CLI isn't required to use it.

## Test plan
- [ ] Preview the page and confirm the Prerequisites section reads correctly