### PR TITLE
DOCS (`hotfix`): remove legacy LocalStack CLI mentions from installation section in Getting Started guide

### DIFF
--- a/src/content/docs/aws/customization/advanced/arm64-support.md
+++ b/src/content/docs/aws/customization/advanced/arm64-support.md
@@ -12,7 +12,7 @@ This manifest contains links to a Linux AMD64 as well as a Linux ARM64 image.
 
 ## Pulling the LocalStack image
 
-With the multi-arch Docker manifest, your Docker client (and therefore the [LocalStack CLI](/aws/getting-started/installation/#localstack-cli)) now automatically selects the image according to your platform:
+With the multi-arch Docker manifest, your Docker client (and therefore [`lstk`](/aws/getting-started/installation/#lstk)) now automatically selects the image according to your platform:
 
 ```bash
 docker pull localstack/localstack

--- a/src/content/docs/aws/developer-tools/aws-replicator/index.mdx
+++ b/src/content/docs/aws/developer-tools/aws-replicator/index.mdx
@@ -26,7 +26,7 @@ A valid `LOCALSTACK_AUTH_TOKEN` must be configured to start the LocalStack for A
 
 :::note
 The Replicator is available from LocalStack CLI version 4.2.0.
-If you encounter issues, update your [LocalStack CLI](/aws/getting-started/installation/#update-localstack-cli).
+If you encounter issues, update your [LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/#installation).
 :::
 
 ### Retrieve credentials to access AWS
@@ -86,7 +86,7 @@ Two options apply regardless of strategy:
 #### Using the LocalStack CLI
 
 The Replicator CLI is part of the LocalStack CLI.
-Follow the [installation instructions](/aws/getting-started/installation/#install-localstack-cli) to set it up.
+Follow the [installation instructions](/aws/developer-tools/running-localstack/localstack-cli/#installation) to set it up.
 
 Trigger a job with `localstack replicator start`, identifying the resource by its ARN:
 

--- a/src/content/docs/aws/developer-tools/cloud-sandbox/ephemeral-instances.md
+++ b/src/content/docs/aws/developer-tools/cloud-sandbox/ephemeral-instances.md
@@ -87,7 +87,7 @@ If you have created a Cloud Pod from an older version of LocalStack, you need to
 
 ## Ephemeral Instances CLI
 
-The Ephemeral Instances CLI is included in the [LocalStack CLI installation](/aws/getting-started/installation/#install-localstack-cli), so no additional installations are needed to start using it.
+The Ephemeral Instances CLI is included in the [LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/#installation), so no additional installations are needed to start using it.
 If you're a licensed user, setting the `LOCALSTACK_AUTH_TOKEN` as an environment variable is recommended to access all features of the Ephemeral Instances CLI.
 
 Access the Ephemeral Instances CLI by running the `localstack ephemeral` command from your terminal.

--- a/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
+++ b/src/content/docs/aws/developer-tools/running-localstack/lstk.mdx
@@ -23,7 +23,7 @@ Running `lstk` with no arguments takes you through the entire startup flow autom
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) installed and running.
-- A [LocalStack account](https://www.localstack.cloud/pricing) with a [license](/aws/getting-started/auth-token/#managing-your-license), and `lstk` handles authentication for you (see [Authentication](#authentication)).
+- A [LocalStack account](https://www.localstack.cloud/pricing) with a [license](/aws/getting-started/auth-token/#license-assignment), and `lstk` handles authentication for you (see [Authentication](#authentication)).
 
 ## Installation
 

--- a/src/content/docs/aws/developer-tools/security-testing/custom-tls-certificates.mdx
+++ b/src/content/docs/aws/developer-tools/security-testing/custom-tls-certificates.mdx
@@ -30,7 +30,7 @@ They all can be summarised as:
 
 ## Creating a custom docker image
 
-If you run LocalStack in a docker container (which includes using [the CLI](/aws/getting-started/installation/#install-localstack-cli), [docker](/aws/getting-started/installation/#docker-compose), [docker-compose](/aws/getting-started/installation/#docker-compose), or [helm](/aws/customization/kubernetes/deploy-helm-chart)), to include a custom TLS root certificate a new docker image should be created.
+If you run LocalStack in a docker container (which includes using [`lstk`](/aws/getting-started/installation/#lstk), [Docker Compose](/aws/getting-started/installation/#docker-compose), or [Helm](/aws/getting-started/installation/#helm-kubernetes)), to include a custom TLS root certificate a new docker image should be created.
 
 Create a `Dockerfile` containing the following commands:
 

--- a/src/content/docs/aws/developer-tools/snapshots/cloud-pods.mdx
+++ b/src/content/docs/aws/developer-tools/snapshots/cloud-pods.mdx
@@ -28,7 +28,7 @@ You can save and load the persistent state of Cloud Pods, you can use the [Cloud
 LocalStack provides a remote storage backend that can be used to store the state of your running application and share it with your team members.
 You can interact with the Cloud Pods over the storage backend via the LocalStack Web Application.
 
-Cloud Pods CLI is included in the [LocalStack CLI installation](/aws/getting-started/installation/#install-localstack-cli), so there's no need for additional installations to begin using it.
+Cloud Pods CLI is included in the [LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/#installation), so there's no need for additional installations to begin using it.
 If you're a licensed user, we suggest setting the `LOCALSTACK_AUTH_TOKEN` as an environment variable.
 This enables you to access the complete range of LocalStack Cloud Pods features.
 
@@ -451,7 +451,7 @@ localstack pod list s3-storage-aws
 
 :::note
 Full S3 remotes support is available in the CLI from version 3.2.0.
-If you experience any difficulties, update your [LocalStack CLI](/aws/getting-started/installation/#update-localstack-cli).
+If you experience any difficulties, update your [LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/#installation).
 :::
 
 ### ORAS remote storage

--- a/src/content/docs/aws/getting-started/ai-workflows.mdx
+++ b/src/content/docs/aws/getting-started/ai-workflows.mdx
@@ -21,7 +21,7 @@ This is useful when you want to:
 
 There are three common ways to use LocalStack in AI-assisted development:
 
-- Use the [LocalStack MCP Server](/aws/tooling/mcp-server/) when your AI assistant supports MCP clients such as Cursor, Claude, Codex, or OpenCode.
+- Use the [LocalStack MCP Server](/aws/developer-tools/running-localstack/mcp-server/) when your AI assistant supports MCP clients such as Cursor, Claude, Codex, or OpenCode.
 - Use [LocalStack Skills](https://github.com/localstack/skills) when you want reusable agent instructions for deploying and testing AWS architectures against LocalStack.
 - Use LocalStack with `tflocal`, `cdklocal`, or `awslocal` when you want the agent to generate infrastructure code or commands that you review and run locally.
 
@@ -48,7 +48,7 @@ npx -y @localstack/localstack-mcp-server init
 ```
 
 :::note
-The MCP server runs locally and talks to a LocalStack instance. Your AI assistant is the MCP client. For full installation instructions, detailed setup, and the full tool reference, see the [LocalStack MCP Server guide](/aws/tooling/mcp-server/).
+The MCP server runs locally and talks to a LocalStack instance. Your AI assistant is the MCP client. For full installation instructions, detailed setup, and the full tool reference, see the [LocalStack MCP Server guide](/aws/developer-tools/running-localstack/mcp-server/).
 
 You need a valid [Auth Token](/aws/getting-started/auth-token/) to configure the server.
 :::
@@ -103,6 +103,6 @@ Before applying changes to AWS, check that:
 
 ## Next steps
 
-- Configure the [LocalStack MCP Server](/aws/tooling/mcp-server/) if your AI assistant supports MCP.
+- Configure the [LocalStack MCP Server](/aws/developer-tools/running-localstack/mcp-server/) if your AI assistant supports MCP.
 - Review [LocalStack Skills](https://github.com/localstack/skills) for reusable agent workflows.
 - Browse the [LocalStack for AWS services](/aws/services/) reference, or check the [Getting Started FAQ](/aws/getting-started/faq/) for common setup questions.

--- a/src/content/docs/aws/getting-started/ci-cd.mdx
+++ b/src/content/docs/aws/getting-started/ci-cd.mdx
@@ -58,7 +58,7 @@ For brevity, these snippets show only the LocalStack startup shape. Apart from t
         LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
     ```
 
-    See the [GitHub Actions guide](/aws/integrations/continuous-integration/github-actions/) for the full setup.
+    See the [GitHub Actions guide](/aws/ci-pipelines/github-actions/) for the full setup.
 
   </TabItem>
   <TabItem label="CircleCI">
@@ -88,7 +88,7 @@ For brevity, these snippets show only the LocalStack startup shape. Apart from t
                 localstack wait -t 60
     ```
 
-    See the [CircleCI guide](/aws/integrations/continuous-integration/circleci/) for the full setup.
+    See the [CircleCI guide](/aws/ci-pipelines/circleci/) for the full setup.
 
   </TabItem>
   <TabItem label="Bitbucket">
@@ -116,7 +116,7 @@ For brevity, these snippets show only the LocalStack startup shape. Apart from t
               - localstack wait -t 60
     ```
 
-    See the [Bitbucket Pipelines guide](/aws/integrations/continuous-integration/bitbucket/) for the full setup.
+    See the [Bitbucket Pipelines guide](/aws/ci-pipelines/bitbucket/) for the full setup.
 
   </TabItem>
   <TabItem label="CodeBuild">
@@ -133,7 +133,7 @@ For brevity, these snippets show only the LocalStack startup shape. Apart from t
           - localstack wait -t 30
     ```
 
-    See the [CodeBuild guide](/aws/integrations/continuous-integration/codebuild/) for the full setup.
+    See the [CodeBuild guide](/aws/ci-pipelines/codebuild/) for the full setup.
 
   </TabItem>
   <TabItem label="GitLab CI">
@@ -162,7 +162,7 @@ For brevity, these snippets show only the LocalStack startup shape. Apart from t
         - awslocal s3 mb s3://test-bucket
     ```
 
-    See the [GitLab CI guide](/aws/integrations/continuous-integration/gitlab-ci/) for the full setup.
+    See the [GitLab CI guide](/aws/ci-pipelines/gitlab-ci/) for the full setup.
 
   </TabItem>
   <TabItem label="Travis CI">
@@ -183,12 +183,12 @@ For brevity, these snippets show only the LocalStack startup shape. Apart from t
       - localstack wait -t 30
     ```
 
-    See the [Travis CI guide](/aws/integrations/continuous-integration/travis-ci/) for the full setup.
+    See the [Travis CI guide](/aws/ci-pipelines/travis-ci/) for the full setup.
 
   </TabItem>
 </Tabs>
 
-You can also start from the [CI integrations overview](/aws/integrations/continuous-integration/) if you want a broader explanation of the CI workflow.
+You can also start from the [CI integrations overview](/aws/ci-pipelines/) if you want a broader explanation of the CI workflow.
 
 ## Authentication in CI
 
@@ -202,9 +202,9 @@ Most CI jobs should start with a clean LocalStack instance. A fresh instance mak
 
 If your pipeline needs state across jobs or workflow stages, use one of the state management options documented outside this getting started page:
 
-- [Cloud Pods](/aws/capabilities/state-management/cloud-pods/) to save and restore named LocalStack state snapshots.
-- [State export and import](/aws/capabilities/state-management/export-import-state/) to move state through artifacts or caches.
-- [Persistence](/aws/capabilities/state-management/persistence/) when the same runner keeps a mounted LocalStack volume.
+- [Cloud Pods](/aws/developer-tools/snapshots/cloud-pods/) to save and restore named LocalStack state snapshots.
+- [State export and import](/aws/developer-tools/snapshots/export-import-state/) to move state through artifacts or caches.
+- [Persistence](/aws/developer-tools/snapshots/persistence/) when the same runner keeps a mounted LocalStack volume.
 
 ## Next steps
 

--- a/src/content/docs/aws/getting-started/installation.mdx
+++ b/src/content/docs/aws/getting-started/installation.mdx
@@ -23,22 +23,17 @@ LocalStack for AWS features require an [Auth Token](/aws/getting-started/auth-to
 
 **Requirement:** You must have a working [Docker installation](https://docs.docker.com/get-docker/) before proceeding.
 
-
 ### Install lstk
 
 <Tabs>
   <TabItem label="Homebrew">
-    ```bash
-    brew install localstack/tap/lstk
-    ```
+    ```bash brew install localstack/tap/lstk ```
   </TabItem>
-  <TabItem label="npm">
-    ```bash
-    npm install -g @localstack/lstk
-    ```
-  </TabItem>
+  <TabItem label="npm">```bash npm install -g @localstack/lstk ```</TabItem>
   <TabItem label="Binary">
-    Download the binary for your platform from the [GitHub Releases](https://github.com/localstack/lstk/releases) and add it to your `PATH`.
+    Download the binary for your platform from the [GitHub
+    Releases](https://github.com/localstack/lstk/releases) and add it to your
+    `PATH`.
   </TabItem>
 </Tabs>
 
@@ -138,78 +133,70 @@ Install the [official extension](https://hub.docker.com/extensions/localstack/lo
 
 ## Troubleshooting
 
-#### The LocalStack CLI installation is successful, but I cannot execute `localstack`
+Installation issues typically fall into one of three areas: getting your chosen install method working, activating your license, or reaching LocalStack over the network. This section will guide you to the appropriate guide that contains detailed fixes based on your installation method.
 
-If you can successfully install LocalStack using `pip` but you cannot use it in your terminal, you most likely haven't set up your operating system's / terminal's `PATH` variable (in order to tell them where to find programs installed via `pip`).
+### lstk
 
-- If you are using Windows, you can enable the `PATH` configuration when installing Python, [as described in the official docs of Python](https://docs.python.org/3/using/windows.html#finding-the-python-executable).
-- If you are using a MacOS or Linux operating system, please make sure that the `PATH` is correctly set up - either system wide, or in your terminal.
+If you installed via [`lstk`](#lstk) and LocalStack fails to start, authenticate, or pull its image, see [lstk troubleshooting](/aws/developer-tools/running-localstack/lstk/#troubleshooting).
 
-As a workaround you can call the LocalStack CLI python module directly:
+For first-run authentication (browser login, keyring tokens, or `LOCALSTACK_AUTH_TOKEN` in CI), refer to [Authentication](/aws/developer-tools/running-localstack/lstk/#authentication) and the [Auth Token guide](/aws/getting-started/auth-token/).
 
-```bash
-python3 -m localstack.cli.main
-```
+### Docker Compose and Docker CLI
 
-#### The `localstack` CLI does not start the LocalStack container
+If you started LocalStack with [Docker Compose](#docker-compose) or the [Docker CLI](#docker-cli):
 
-If you are using the `localstack` CLI to start LocalStack, but the container is not starting, please check the following:
+- **License or credential errors**: see [Auth Token troubleshooting](/aws/getting-started/auth-token/#troubleshooting).
+- **Container exits during startup, proxy/DNS/TLS issues, or port conflicts**: see [Startup Troubleshooting FAQs](/aws/getting-started/faq/#startup-troubleshooting-faqs).
+- **DNS server or port conflicts**: see the [DNS Server guide](/aws/customization/networking/dns-server/).
 
-- Uncheck the **Use kernel networking for UDP** option in Docker Desktop (**Settings** → **Resources** → **Network**) or follow the steps in our [documentation](/aws/customization/networking/dns-server#system-dns-configuration) to disable it.
-- Start LocalStack with a specific DNS address:
+Ensure you have exported `LOCALSTACK_AUTH_TOKEN` in your shell before running `docker compose up` or `docker run`.
 
-```bash
-DNS_ADDRESS=0 localstack start
-```
+### View logs
 
-- Remove port 53 as indicated in our [standard `docker-compose.yml` file](https://github.com/localstack/localstack/blob/main/docker-compose-pro.yml).
-
-#### How should I access the LocalStack logs on my local machine?
-
-You can now avail logging output and error reporting using LocalStack logs.
-To access the logs, run the following command:
+Stream container logs using the command that matches your install method:
 
 <Tabs>
 <TabItem label="lstk">
+
 ```bash
 lstk logs
 ```
+
+For `lstk` CLI diagnostics (separate from container logs), see [Logging](/aws/developer-tools/running-localstack/lstk/#logging).
+
+</TabItem>
+<TabItem label="Docker Compose">
+
+```bash
+docker compose logs -f localstack
+```
+
+</TabItem>
+<TabItem label="Docker CLI">
+
+```bash
+docker logs -f localstack-main
+```
+
+Use the container name from your `docker run --name` flag if you set one.
+
+</TabItem>
+<TabItem label="Helm">
+
+```bash
+kubectl logs -f deployment/localstack
+```
+
+The deployment name follows your Helm release name (default: `localstack`).
+
 </TabItem>
 </Tabs>
 
-AWS requests are now logged uniformly in the INFO log level (set by default or when `DEBUG=0`).
-The format is:
+To enable verbose startup logging, capture logs from a failed container, or share a diagnose bundle with support, see [How do I capture and share LocalStack container logs for troubleshooting?](/aws/getting-started/faq/#how-do-i-capture-and-share-localstack-container-logs-for-troubleshooting).
 
-```text
-AWS <service>.<operation> => <http-status> (<error type>)
-```
+### Network connectivity
 
-Requests to HTTP endpoints are logged in a similar way:
-
-```text
-2022-09-12T10:39:21.165  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS s3.ListBuckets => 200
-2022-09-12T10:39:41.315  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS s3.CreateBucket => 200
-2022-09-12T10:40:04.662  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS s3.PutObject => 200
-2022-09-12T11:01:55.799  INFO --- [   asgi_gw_0] localstack.request.http    : GET / => 200
-```
-
-#### How should I share the LocalStack logs for troubleshooting?
-
-You can share the LocalStack logs with us to help us identify issues.
-To share the logs, call the diagnostic endpoint:
-
-```bash
-curl -s localhost:4566/_localstack/diagnose | gzip -cf > diagnose.json.gz
-```
-
-Ensure that the diagnostic endpoint is run after you have tried reproducing the affected task.
-After running the task, run the diagnostic endpoint and share the archive file with your team members or LocalStack Support.
-
-#### My application cannot reach LocalStack over the network
-
-We have extensive network troubleshooting documentation available [here](/aws/customization/networking/).
-
-If this does not solve your problem then please [reach out to LocalStack Support](/aws/help-support/get-help/).
+If your application cannot reach LocalStack after installation, see the [networking documentation](/aws/customization/networking/).
 
 ## Next steps
 

--- a/src/content/docs/aws/getting-started/local-development.mdx
+++ b/src/content/docs/aws/getting-started/local-development.mdx
@@ -271,7 +271,7 @@ Stop your LocalStack container to remove all emulated resources. LocalStack is e
 
 {/* prettier-ignore-end */}
 
-To persist resource state, like S3 buckets or DynamoDB tables, across restarts, check out our [state management tools](/aws/capabilities/state-management/).
+To persist resource state, like S3 buckets or DynamoDB tables, across restarts, check out our [state management tools](/aws/developer-tools/snapshots/).
 
 Remove the local files you created in this guide:
 

--- a/src/content/docs/aws/services/elb.mdx
+++ b/src/content/docs/aws/services/elb.mdx
@@ -177,7 +177,7 @@ In LocalStack, same-scheme listeners (for example, two HTTP listeners on ports 8
 
 ### Configuring LocalStack for multiple listener ports
 
-To reach two same-scheme listeners on distinct ports, both ports must be published in [`GATEWAY_LISTEN`](/aws/configuration/config/configuration/#core) when starting LocalStack:
+To reach two same-scheme listeners on distinct ports, both ports must be published in [`GATEWAY_LISTEN`](/aws/customization/configuration-options/#core) when starting LocalStack:
 
 ```bash
 GATEWAY_LISTEN=0.0.0.0:4566,0.0.0.0:80,0.0.0.0:8080 localstack start

--- a/src/content/docs/aws/tutorials/aws-proxy-localstack-extension.mdx
+++ b/src/content/docs/aws/tutorials/aws-proxy-localstack-extension.mdx
@@ -29,7 +29,7 @@ In this tutorial, you will learn how to install the AWS Cloud Proxy extension an
 
 ## Prerequisites
 
-- [LocalStack CLI](/aws/getting-started/installation#localstack-cli)  with  [`LOCALSTACK_AUTH_TOKEN`](/aws/getting-started/auth-token)
+- [LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/#installation) with [`LOCALSTACK_AUTH_TOKEN`](/aws/getting-started/auth-token)
 - [Docker](https://docs.docker.com/)
 - [AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-install.html) with  [`awslocal` wrapper](https://github.com/localstack/awscli-local)
 - [LocalStack account](https://www.localstack.cloud/pricing)

--- a/src/content/docs/aws/tutorials/cloud-pods-collaborative-debugging.mdx
+++ b/src/content/docs/aws/tutorials/cloud-pods-collaborative-debugging.mdx
@@ -31,7 +31,7 @@ The full sample application can be found [on GitHub](https://github.com/localsta
 
 ### **Prerequisites**
 
-- [LocalStack CLI](/aws/getting-started/installation#localstack-cli) (preferably using `pip`)
+- [LocalStack CLI](/aws/developer-tools/running-localstack/localstack-cli/#installation)
 - [Docker](https://docs.docker.com/engine/install/)
 - [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli) or [OpenTofu](https://opentofu.org/docs/intro/install/) and [terraform-local](/aws/connecting/infrastructure-as-code/terraform#install-the-tflocal-wrapper-script)
 - Optional for Lambda build & editing: [Maven 3.9.4](https://maven.apache.org/install.html) & [Java 21](https://www.java.com/en/download/help/download_options.html)

--- a/src/content/docs/azure/getting-started/auth-token.mdx
+++ b/src/content/docs/azure/getting-started/auth-token.mdx
@@ -88,7 +88,7 @@ The following sections describe the various methods of providing your Auth Token
 
 `lstk` handles authentication for you — just run `lstk` or `lstk start` and it takes care of the rest. See the [lstk documentation](/aws/developer-tools/running-localstack/lstk/) for details on how it resolves your Auth Token.
 
-On first run, `lstk` prompts you to pick an emulator and remembers your choice. If your `config.toml` already defaults to a different emulator, see [Already using lstk with a different default emulator?](/azure/getting-started/installation/#already-using-lstk-with-a-different-default-emulator) to target Azure instead.
+On first run, `lstk` prompts you to pick an emulator and remembers your choice. If your `config.toml` already defaults to a different emulator, see [Already using lstk with a different default emulator?](/azure/getting-started/#already-using-lstk-with-a-different-default-emulator) to target Azure instead.
 
 For CI environments, see [CI Environments](#ci-environments) below.
 

--- a/src/content/docs/azure/getting-started/quickstart.md
+++ b/src/content/docs/azure/getting-started/quickstart.md
@@ -13,7 +13,7 @@ In this guide, you will run some basic Azure CLI commands to manage resource gro
 
 ## Prerequisites
 
-- [`lstk`](/azure/getting-started/installation/#lstk)
+- [`lstk`](/azure/getting-started/#lstk)
 - [Azure CLI (`az`)](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 - A LocalStack account with a license that covers Azure usage — `lstk` handles authentication for you (see [Authentication](/azure/getting-started/auth-token/))
 

--- a/src/content/docs/snowflake/getting-started/quickstart.md
+++ b/src/content/docs/snowflake/getting-started/quickstart.md
@@ -13,7 +13,7 @@ This guide explains how to set up the Snowflake emulator and use Snowflake CLI t
 ## Prerequisites
 
 - [LocalStack for Snowflake](/snowflake/getting-started/)
-- [`localstack` CLI](/aws/getting-started/installation/#localstack-cli)
+- [LocalStack CLI](/snowflake/getting-started/)
 - A [LocalStack Auth Token](/snowflake/getting-started/auth-token/)
 - [Snowflake CLI](/snowflake/integrations/snow-cli/)
 


### PR DESCRIPTION
The troubleshooting mostly focused on the legacy LocalStack CLI which was no longer covered in the installation page at all. These have been revised to link to troubleshooting details depending on the nature of the issue and the installation method chosen.

Fixes [DOC-380](https://linear.app/localstack/issue/DOC-380/revise-or-remove-legacy-localstack-cli-from-install-troubleshooting)