### PR TITLE
DOC-351: Update AWS trial duration messaging to 30 days

### DIFF
--- a/src/content/docs/aws/organizations-admin/accounts.md
+++ b/src/content/docs/aws/organizations-admin/accounts.md
@@ -29,7 +29,7 @@ To create an account for LocalStack for AWS, please visit our [pricing page](h
 
 Follow the prompts to fill out your information and remember to verify your email to continue. 
 
-All new users are granted a 14-day free Trial of our Ultimate tier with no commitment. 
+All new users get their first month free (a 30-day trial of our Ultimate tier) with no commitment. 
 
 At the end of your free trial period, you may select your preferred plan.
 


### PR DESCRIPTION
## Summary
- Update the AWS trial duration messaging in `accounts.md` to the "first month free" / 30-day framing, per the trial-duration change described in the ticket.
- Searched the whole repo for other trial-duration references (45-day, 30-day, day-count callouts, Snowflake trial comparisons) — this was the only concrete customer-facing duration statement found; no other pages, code samples, or screenshots reference a specific trial length.

Linear: https://linear.app/localstack/issue/DOC-351/docs-update-aws-trial-duration-messaging-to-30-days

## Test plan
- [x] `astro build` completes successfully
- [x] `starlight-links-validator` reports all internal links valid
