### PR TITLE
DOC-318 (`hotfix`): Add deprecation note for retired Azure image name

### DIFF
--- a/src/content/docs/azure/getting-started/index.mdx
+++ b/src/content/docs/azure/getting-started/index.mdx
@@ -18,6 +18,12 @@ LocalStack for Azure features require an [Auth Token](/azure/getting-started/aut
 
 Alternatively, you can set up the Azure emulator directly using the LocalStack for Azure Docker image, [`localstack/localstack-azure`](https://hub.docker.com/r/localstack/localstack-azure), with the [`docker` CLI](#docker-cli) or [Docker Compose](#docker-compose).
 
+:::note
+The Azure emulator image was previously published as `localstack/localstack-azure-alpha`.
+That name is no longer updated, and the Docker Hub repository is scheduled for removal at the end of August 2026.
+If your setup still references `localstack/localstack-azure-alpha`, switch to `localstack/localstack-azure` before then.
+:::
+
 ## lstk
 
 `lstk` is a lightweight CLI for LocalStack that manages the authentication and container lifecycle for the AWS, Azure, and Snowflake emulators.


### PR DESCRIPTION
localstack-azure-alpha references were already migrated in #730 and azure-docs#65. Add a note on the installation page flagging that the old name is unmaintained and its Docker Hub repo is removed end of August 2026.

This pr fixes [DOC-318](https://linear.app/localstack/issue/DOC-318/replace-retired-localstack-azure-alpha-image-name-in-the-azure-docs)