### PR TITLE
Update Persistence Docs

### DIFF
--- a/src/data/persistence/coverage.json
+++ b/src/data/persistence/coverage.json
@@ -615,13 +615,6 @@
     "test_suite": true,
     "limitations": ""
   },
-  "s3-tables": {
-    "service": "s3-tables",
-    "full_name": "s3-tables",
-    "support": "unknown",
-    "test_suite": false,
-    "limitations": ""
-  },
   "s3control": {
     "service": "s3control",
     "full_name": "S3 Control (Simple Storage Service Control)",
@@ -767,20 +760,6 @@
     "full_name": "timestream",
     "support": "supported",
     "test_suite": true,
-    "limitations": ""
-  },
-  "timestream-query": {
-    "service": "timestream-query",
-    "full_name": "Timestream Query",
-    "support": "unknown",
-    "test_suite": false,
-    "limitations": ""
-  },
-  "timestream-write": {
-    "service": "timestream-write",
-    "full_name": "Timestream Write",
-    "support": "unknown",
-    "test_suite": false,
     "limitations": ""
   },
   "transcribe": {


### PR DESCRIPTION
Updating Persistence Coverage Documentation based on the [Persistence Catalog](https://www.notion.so/localstack/Persistence-Catalog-a9e0e5cb89df4784adb4a1ed377b3c23) on Notion.