### PR TITLE
DOC 388 (`hotfix`) fix code rendering

### DIFF
--- a/src/content/docs/aws/getting-started/installation.mdx
+++ b/src/content/docs/aws/getting-started/installation.mdx
@@ -25,6 +25,7 @@ LocalStack for AWS features require an [Auth Token](/aws/getting-started/auth-to
 
 ### Install lstk
 
+{/* prettier-ignore-start */}
 <Tabs>
   <TabItem label="Homebrew">
     ```bash
@@ -38,6 +39,8 @@ LocalStack for AWS features require an [Auth Token](/aws/getting-started/auth-to
     `PATH`.
   </TabItem>
 </Tabs>
+
+{/* prettier-ignore-end */}
 
 ### Start lstk
 

--- a/src/content/docs/aws/getting-started/installation.mdx
+++ b/src/content/docs/aws/getting-started/installation.mdx
@@ -27,7 +27,9 @@ LocalStack for AWS features require an [Auth Token](/aws/getting-started/auth-to
 
 <Tabs>
   <TabItem label="Homebrew">
-    ```bash brew install localstack/tap/lstk ```
+    ```bash
+    brew install localstack/tap/lstk
+    ```
   </TabItem>
   <TabItem label="npm">```bash npm install -g @localstack/lstk ```</TabItem>
   <TabItem label="Binary">


### PR DESCRIPTION
Fixes an instance where the linter would collapse a code block causing it to render incorrectly.