### PR TITLE
DOC-389 (`hotfix`) Fix npm tab rendering inline code fence on the AWS installation page

### DIFF
--- a/src/content/docs/aws/getting-started/installation.mdx
+++ b/src/content/docs/aws/getting-started/installation.mdx
@@ -32,7 +32,11 @@ LocalStack for AWS features require an [Auth Token](/aws/getting-started/auth-to
     brew install localstack/tap/lstk
     ```
   </TabItem>
-  <TabItem label="npm">```bash npm install -g @localstack/lstk ```</TabItem>
+  <TabItem label="npm">
+    ```bash
+    npm install -g @localstack/lstk
+    ```
+  </TabItem>
   <TabItem label="Binary">
     Download the binary for your platform from the [GitHub
     Releases](https://github.com/localstack/lstk/releases) and add it to your


### PR DESCRIPTION
The Homebrew tab was fixed in #845, but the npm `TabItem` on the AWS installation page still had its fence and command on a single line, so it never parsed as a code block and the `bash` label leaked in front of the command. Splitting it across lines like the Homebrew tab restores the expressive-code terminal frame.

This was the last remaining single-line fence in `src/content/docs` (verified with `rg '```[a-zA-Z0-9]*[^`\n]+```'`).

Verified in the dev server:

![npm tab rendering in the terminal frame](https://uploads.linear.app/3888efef-62d8-4ae8-9866-dbabfd802020/840e6a3a-a2c0-4c2a-a4bf-b119f4c463b8/3260fb9c-7a07-41dc-b062-7f30d52c868c?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzM4ODhlZmVmLTYyZDgtNGFlOC05ODY2LWRiYWJmZDgwMjAyMC84NDBlNmEzYS1hMmMwLTRjMmEtYTRiZi1iMTE5ZjRjNDYzYjgvMzI2MGZiOWMtN2EwNy00MWRjLWIwNjItN2YzMGQ1MmM4NjhjIiwiaWF0IjoxNzg1ODY1MTM0LCJleHAiOjE4MTc0MzU2OTR9.WFUYDK_xVCMSaFD0S-0uTcNWqTEgfg-KZXLE8pQgbCk)
