### PR TITLE
DOC-377: Add OIDC identity source support for Verified Permissions

### DIFF
--- a/src/content/docs/aws/customization/configuration-options.md
+++ b/src/content/docs/aws/customization/configuration-options.md
@@ -367,6 +367,12 @@ Please consult the [migration guide](/aws/services/lambda#migrating-to-lambda-v2
 | - | - | - |
 | `SFN_MOCK_CONFIG` | `/tmp/MockConfigFile.json` | Specifies the file path to the mock configuration file that defines mock service integrations for Step Functions. |
 
+### Verified Permissions
+
+| Variable | Example Values | Description |
+| - | - | - |
+| `VERIFIEDPERMISSIONS_DISABLE_JWT_VERIFICATION` | `0` (default) \| `1` | Disables JWT signature verification for OIDC identity sources. When enabled, LocalStack will decode tokens without validating signatures against the issuer's JWKS, allowing use of unreachable or self-signed OIDC providers in local development. |
+
 ## Security
 
 :::danger

--- a/src/content/docs/aws/services/verifiedpermissions.mdx
+++ b/src/content/docs/aws/services/verifiedpermissions.mdx
@@ -12,7 +12,7 @@ Amazon Verified Permissions is a scalable service for managing fine-grained perm
 It helps secure applications by moving authorization logic outside the app and managing policies in one place, using the [Cedar policy language](https://docs.cedarpolicy.com/) to define access rules.  
 It checks if a principal can take an action on a resource in a specific context in your application.
 
-LocalStack allows you to use the Verified Permissions APIs in your local environment to test your authorization logic, with integrations with other AWS services like Cognito. LocalStack uses the Cedar engine to evaluate permissions, ensuring authorization testing closely matches AWS Verified Permissions behavior.
+LocalStack allows you to use the Verified Permissions APIs in your local environment to test your authorization logic, with integrations with other AWS services like Cognito and support for custom OIDC identity providers. LocalStack uses the Cedar engine to evaluate permissions, ensuring authorization testing closely matches AWS Verified Permissions behavior.
 The supported APIs are available on our [API Coverage section](#api-coverage), which provides information on the extent of Verified Permissions' integration with LocalStack.
 
 ## Getting started
@@ -128,11 +128,24 @@ You should get the following output, indicating that your request was allowed:
 }
 ```
 
+## Identity Sources
+
+LocalStack supports both Cognito User Pools and custom OIDC (OpenID Connect) identity providers as identity sources for Verified Permissions.
+
+When you create an identity source with an [`OpenIdConnectConfiguration`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_OpenIdConnectConfiguration.html), LocalStack:
+- Fetches the OIDC discovery document and JWKS (JSON Web Key Set) from the configured issuer
+- Validates JWT signatures against the issuer's public keys
+- Enforces token expiration (`exp` claim)
+- Extracts principal information and group memberships from token claims
+- Evaluates authorization requests using [`IsAuthorizedWithToken`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorizedWithToken.html) and [`BatchIsAuthorizedWithToken`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_BatchIsAuthorizedWithToken.html)
+
+:::note
+For local development scenarios where the OIDC issuer may not be reachable or uses a self-signed certificate, you can disable JWT signature verification by setting the `VERIFIEDPERMISSIONS_DISABLE_JWT_VERIFICATION=1` environment variable. See the [Configuration reference](/aws/customization/configuration-options/#verified-permissions) for details.
+:::
+
 ## Current limitations
 
 - No Schema validation when creating a new schema using `PutSchema`, and no Policy validation using said schema when creating policies and template policies.
-- Only Cognito is supported as an `IdentitySource`, external OIDC providers are not yet implemented.
-- The validation around Identity Sources and JWT is not fully yet implemented: the identity source is not validated to have a valid `jwks.json` endpoint, and the issuer, signature and expiration of the incoming JWT are not validated.
 
 ## API Coverage
 

--- a/src/content/docs/aws/services/verifiedpermissions.mdx
+++ b/src/content/docs/aws/services/verifiedpermissions.mdx
@@ -137,7 +137,8 @@ When you create an identity source with an [`OpenIdConnectConfiguration`](https:
 - Validates JWT signatures against the issuer's public keys
 - Enforces token expiration (`exp` claim)
 - Extracts principal information and group memberships from token claims
-- Evaluates authorization requests using [`IsAuthorizedWithToken`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorizedWithToken.html) and [`BatchIsAuthorizedWithToken`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_BatchIsAuthorizedWithToken.html)
+
+Once the identity source is configured, you can evaluate authorization requests using tokens from that provider with [`IsAuthorizedWithToken`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorizedWithToken.html) and [`BatchIsAuthorizedWithToken`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_BatchIsAuthorizedWithToken.html).
 
 :::note
 For local development scenarios where the OIDC issuer may not be reachable or uses a self-signed certificate, you can disable JWT signature verification by setting the `VERIFIEDPERMISSIONS_DISABLE_JWT_VERIFICATION=1` environment variable. See the [Configuration reference](/aws/customization/configuration-options/#verified-permissions) for details.


### PR DESCRIPTION
## Summary

This PR updates the LocalStack documentation to reflect the new OIDC identity source support in AWS Verified Permissions, as implemented in [localstack/localstack-pro#8072](https://github.com/localstack/localstack-pro/pull/8072).

## Changes

### 1. Updated Verified Permissions Service Documentation (`src/content/docs/aws/services/verifiedpermissions.mdx`)

- **Introduction**: Updated to mention support for custom OIDC identity providers alongside Cognito
- **New "Identity Sources" section**: Added comprehensive documentation explaining OIDC support, including:
  - How LocalStack validates OIDC tokens (discovery document, JWKS, JWT signatures, expiration)
  - Principal and group membership extraction from token claims
  - Reference to the new `VERIFIEDPERMISSIONS_DISABLE_JWT_VERIFICATION` configuration option for local development
- **Updated "Current limitations" section**: Removed the outdated statement that "only Cognito is supported" and removed JWT validation limitations that have been addressed

### 2. Added Configuration Variable (`src/content/docs/aws/customization/configuration-options.md`)

Added a new "Verified Permissions" section under "Local AWS Services" with the `VERIFIEDPERMISSIONS_DISABLE_JWT_VERIFICATION` environment variable:
- Default value: `0` (verification enabled)
- Purpose: Allows disabling JWT signature verification for OIDC identity sources in local development scenarios where the OIDC issuer may be unreachable or uses self-signed certificates

## Audit Trail

### Research Protocol Followed

**Coverage Analysis:**
- Reviewed `src/data/coverage/verifiedpermissions.json`
- Confirmed all identity source APIs (`CreateIdentitySource`, `UpdateIdentitySource`, `GetIdentitySource`, `DeleteIdentitySource`, `ListIdentitySources`) are marked as implemented with `aws_validated: true`
- Confirmed token-based authorization APIs (`IsAuthorizedWithToken`, `BatchIsAuthorizedWithToken`) are fully supported

**Existing Documentation:**
- Read complete existing service doc at `src/content/docs/aws/services/verifiedpermissions.mdx`
- Identified outdated limitations section that contradicted the new feature implementation

**AWS Documentation Referenced:**
- [AWS Verified Permissions - OIDC Identity Sources](https://docs.aws.amazon.com/verifiedpermissions/latest/userguide/identity-sources-oidc.html)
- [OpenIdConnectConfiguration API Reference](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_OpenIdConnectConfiguration.html)
- [IsAuthorizedWithToken API Reference](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorizedWithToken.html)
- [BatchIsAuthorizedWithToken API Reference](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_BatchIsAuthorizedWithToken.html)

**Linear Ticket Context:**
- Ticket DOC-377: [https://linear.app/localstack/issue/DOC-377](https://linear.app/localstack/issue/DOC-377)
- Implementation PR: [localstack/localstack-pro#8072](https://github.com/localstack/localstack-pro/pull/8072)
- Explicitly requested documentation changes:
  1. ✅ Add `VERIFIEDPERMISSIONS_DISABLE_JWT_VERIFICATION` to configuration reference
  2. ✅ Update Verified Permissions coverage page for OIDC support

### Verification

- ✅ Ran `npm run build` successfully with no errors
- ✅ All internal links validated
- ✅ Frontmatter follows schema defined in `src/content.config.ts`
- ✅ Writing style follows `agents.md` conventions (direct, instructional, second person, present tense)
- ✅ Configuration variable added in correct alphabetical order (after Step Functions)
- ✅ Internal links use root-relative paths

### Confidence Assessment

**High Confidence** - All information is directly sourced from:
1. The Linear ticket description and documentation requirements
2. The implementation PR details describing the exact behavior
3. The coverage JSON file confirming API support
4. Official AWS documentation for OIDC identity sources

**No Gaps or Conflicts** - The feature implementation aligns with AWS behavior as documented, and all previously listed limitations regarding OIDC have been addressed by the implementation.

---

Closes DOC-377
---

> [!IMPORTANT]
> An AI agent generated this pull request. Review all changes before you merge.

- Linear ticket: [DOC-377](https://linear.app/localstack/issue/DOC-377)
- Workflow run: https://github.com/localstack/localstack-docs/actions/runs/31017706204
