### PR TITLE
DOC-373: Fix broken Update Parity Docs pipeline

### DIFF
--- a/.github/workflows/docs-parity-updates.yml
+++ b/.github/workflows/docs-parity-updates.yml
@@ -48,8 +48,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
           REPOSITORY_NAME: localstack-pro
           ARTIFACT_ID: parity-metric-pro-raw-amd*
-          WORKFLOW: "AWS / Build, Test, Push" 
+          WORKFLOW: "AWS / Build, Test, Push"
           PREFIX_ARTIFACT: pro-integration-test
+          # The parity-metric-* artifacts are only uploaded by scheduled (nightly) runs of the
+          # AWS main pipeline; push-triggered runs only execute acceptance tests. Scan a larger
+          # window of runs so the search reaches the latest successful nightly run among the
+          # far more frequent push-triggered runs.
+          LIMIT: 200
 
       - name: Download coverage (capture-notimplemented) data from Enterprise pipeline (GitHub)
         working-directory: docs
@@ -70,6 +75,8 @@ jobs:
           ARTIFACT_ID: parity-metric-raw-amd*
           WORKFLOW: "AWS / Build, Test, Push"
           PREFIX_ARTIFACT: community-integration-test
+          # See the comment on the Enterprise pipeline metrics step above.
+          LIMIT: 200
 
       - name: Download coverage (capture-notimplemented) data from Free Plan pipeline (GitHub)
         working-directory: docs
@@ -100,16 +107,6 @@ jobs:
           ARTIFACT_ID: parity-metric-pro-k8s-integration-raw-amd64-*
           WORKFLOW: "AWS / Pro K8s tests"
           PREFIX_ARTIFACT: k8s-integration-test
-
-      - name: Download coverage data for Free Plan K8s pipeline (integration tests) (GitHub)
-        working-directory: docs
-        run: /tmp/get_latest_github_metrics.sh ./target main
-        env:
-          GITHUB_TOKEN: ${{ secrets.PRO_ACCESS_TOKEN }}
-          REPOSITORY_NAME: localstack-pro
-          ARTIFACT_ID: parity-metric-community-k8s-integration-raw-*
-          WORKFLOW: "AWS / Community K8S tests"
-          PREFIX_ARTIFACT: k8s-community-integration-test
 
       - name: Create Parity Coverage Docs
         working-directory: docs


### PR DESCRIPTION
## Motivation

Fixes [DOC-373](https://linear.app/localstack/issue/DOC-373/fix-broken-update-parity-docs-pipeline).

The [Update Parity Docs](https://github.com/localstack/localstack-docs/actions/workflows/docs-parity-updates.yml) pipeline has been failing since mid-June (e.g. [this run](https://github.com/localstack/localstack-docs/actions/runs/29720689091/job/88282957668)), so the implementation/parity coverage on service pages stopped updating.

Root cause is the CI restructure in localstack-pro (PR #7263, merged June 2, 2026):

1. **Parity metrics are now only produced by nightly runs.** `AWS / Build, Test, Push` runs the full integration suite (which uploads the `parity-metric-pro-raw-amd64-*` / `parity-metric-raw-amd64-*` artifacts) only on `schedule` events — push-triggered runs only execute acceptance tests. The fetch script (`get_latest_github_metrics.sh` from `localstack/meta`) scans only the **last 20 successful runs** of the workflow, and with ~12 push runs/day that window no longer reaches any nightly run. The pipeline kept working until mid-June only while pre-restructure runs remained inside the 20-run window.
2. **The `AWS / Community K8S tests` workflow was deleted** from localstack-pro in the same restructure, so the `parity-metric-community-k8s-integration-raw-*` artifacts can never be found again.

## Changes

- Set `LIMIT: 200` (env already supported by the fetch script) on the two parity-metric download steps so the artifact search window reaches the latest successful nightly run (currently at index ~26 of the successful-run window; 200 gives ~3 weeks of margin). The success-only filter is deliberately kept: failed nightlies upload **incomplete** parity artifacts (e.g. missing matrix groups), which would silently understate coverage.
- Removed the download step for the Free Plan K8s pipeline (`AWS / Community K8S tests`), since the upstream workflow no longer exists. `create_data_coverage.py` picks up test sources by CSV filename prefix, so the absence of these files is harmless.

The other steps need no changes: `capture-notimplemented*` artifacts are still uploaded on every main-branch run, and `AWS / Pro K8S tests` runs nightly with regular successes.

## Testing

Ran `get_latest_github_metrics.sh` locally with `LIMIT=200` for both previously-failing steps — both located the latest successful nightly run (Aug 5) and downloaded all 8 test-group CSVs each, producing the expected `pro-integration-test-*` / `community-integration-test-*` files in `target/metrics-raw`.

After merging, the fix can be verified by manually dispatching the [Update Parity Docs](https://github.com/localstack/localstack-docs/actions/workflows/docs-parity-updates.yml) workflow.