### PR TITLE
docs: add Sealos deployment option

### DIFF
--- a/src/content/docs/aws/customization/kubernetes/index.md
+++ b/src/content/docs/aws/customization/kubernetes/index.md
@@ -43,6 +43,10 @@ The table below compares these methods.
 | **Helm chart** | · Simplifies deployment using templates and `values.yaml`<br> · Supports versioning, upgrades, and rollbacks<br> · Supports LocalStack for AWS under all Licences | · Customization is limited to chart values and overrides |
 | **DIY (YAML manifests)** | · Full control over Kubernetes configuration and resources | · Time-consuming to set up and maintain<br> · Manual updates and lifecycle management |
 
+If you already run Kubernetes on Sealos, you can also use the one-click deployment template to provision LocalStack with HTTPS and the Kubernetes-native executor:
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/localstack)
+
 ## Limitations
 | Service | Supported | Explanation |
 | ------- | --------- | ----------- |


### PR DESCRIPTION
## Summary

This PR adds a Sealos deployment option to the LocalStack Kubernetes overview page.

It adds:
- a Deploy on Sealos button in `src/content/docs/aws/customization/kubernetes/index.md`
- a short note that Sealos-managed Kubernetes can provision LocalStack with HTTPS and the Kubernetes-native executor

## Why

This gives LocalStack users another Kubernetes deployment path without changing the documented operator, Helm, or manifest options.

## Validation

- Sealos template: https://sealos.io/products/app-store/localstack
- Template repo: https://github.com/labring-actions/templates
- Validation record: PR #737, validated on 2026-08-10
- Persistence covered: yes
- Required env vars documented: yes

## Maintenance

I can help maintain the Sealos deployment path and follow up if the template or docs need updates.
Prepared with AI assistance and reviewed end to end.