### PR TITLE
docs (hotfix): Add License Assignment Docs for Entra

### DIFF
--- a/src/content/docs/aws/customization/advanced/usage-tracking.md
+++ b/src/content/docs/aws/customization/advanced/usage-tracking.md
@@ -22,7 +22,7 @@ Collecting basic anonymized usage of AWS services helps us better direct enginee
 The current usage event collection on the client side includes:
 
 - A randomly generated ID pertaining to the session
-- The Auth Token or legacy API key (if any)
+- The Auth Token
 - A randomly generated machine ID is kept throughout the session but deleted once the LocalStack cache directory is removed
 - The operating system (mostly Linux since LocalStack typically runs in our Debian container)
 - The LocalStack version being used

--- a/src/content/docs/aws/getting-started/faq.mdx
+++ b/src/content/docs/aws/getting-started/faq.mdx
@@ -398,7 +398,7 @@ localstack auth show-token
 
 Then check:
 
-- The variable name is exactly `LOCALSTACK_AUTH_TOKEN` (legacy `LOCALSTACK_API_KEY` is deprecated and removed).
+- The variable name is exactly `LOCALSTACK_AUTH_TOKEN`.
 - The token includes the `ls-…` prefix.
 - There is no trailing whitespace or quote character.
 - The token has not been committed to source control — if it has, regenerate it immediately at [app.localstack.cloud/workspace/auth-tokens](https://app.localstack.cloud/workspace/auth-tokens).

--- a/src/content/docs/aws/organizations-admin/managing-users-licenses.md
+++ b/src/content/docs/aws/organizations-admin/managing-users-licenses.md
@@ -1,6 +1,6 @@
 ---
 title: Users and Licenses
-description: Invite new members and manage a member's license and legacy API key.
+description: Invite new members and manage a member's license
 template: doc
 sidebar:
     order: 4
@@ -9,7 +9,7 @@ tags: ["Base"]
 
 ## Introduction
 
-The **Users & Licenses** page in the LocalStack Web Application allows workspace administrators to manage workspace memberships, assign licenses, and transition members from legacy API keys to the new license system.
+The **Users & Licenses** page in the LocalStack Web Application allows workspace administrators to manage workspace memberships and assign licenses.
 
 To access this page:
 1. Click your name or organization's name in the top-left corner of the dashboard.
@@ -85,29 +85,3 @@ Licenses are part of subscription plans and are shown in the **License** column 
 - A license can be reassigned at any time.
 
 Changes apply immediately and don’t require user action.
-
-## Migrating from Legacy API Keys
-
-Previously, access was granted via personal developer API keys.
-
-### Why move to Auth Tokens?
-
-- Auth Tokens are more secure and rotate-friendly.
-- Admins can manage licenses without the member needing to change configurations.
-- Members authenticate once with the token; the license is linked automatically.
-
-### Migration Process
-
-1. Go to the **Workspace Members** list.
-2. Assign a license to a member.
-3. Ask the member to switch their config to use an **Auth Token** (available in the **Auth Tokens** page).
-4. Remove the legacy API key once the Auth Token is in use.
-
-:::note
-If a member has both a legacy API key and a license, it only counts as **one** active license
-:::
-
-### Deprecation Notice
-
-Legacy API keys are still supported for now, but will be phased out over the coming months.
-We recommend migrating to licenses and Auth Tokens as soon as possible.

--- a/src/content/docs/aws/organizations-admin/sso/index.md
+++ b/src/content/docs/aws/organizations-admin/sso/index.md
@@ -321,7 +321,7 @@ For each new member that joins your org, you can specify user roles and permissi
 - **Default User Role**:  The Role that should be assigned to users of your organization signing up via SSO.
   In most cases, this should be a Member.
 - **Default User Permissions**: Use this to define which permissions should be assigned to users of your organization signing up via SSO.
-  - Tip: In order to enable self-serve licences (i.e., allowing your users to allocate themselves their own license), make sure to select the **Allow member to issue a license for themselves (or a legacy API key)** permission.
+  - Tip: In order to enable self-serve licences (i.e., allowing your users to allocate themselves their own license), make sure to select the **Allow member to issue a license for themselves** permission.
 
 
 ![User Roles and Permissions](/images/aws/roles-permissions.png)

--- a/src/content/docs/aws/organizations-admin/sso/scim/entra.md
+++ b/src/content/docs/aws/organizations-admin/sso/scim/entra.md
@@ -150,7 +150,3 @@ The `409` is transient - Entra retries the failed operation on the next cycle, a
 #### Last-Admin Protection
 
 LocalStack will reject any SCIM request that would leave the workspace without an admin. If you attempt to remove the only admin from the admin role group, the request fails with `409 Cannot remove the last workspace admin`. Assign another admin in LocalStack first, then retry the removal.
-
-:::note
-License assignment via SCIM is not supported with Microsoft Entra ID. To assign licenses through SCIM, use [Okta](/aws/organizations-admin/sso/scim/okta/#license-management). Otherwise, manage license assignments directly in the LocalStack web app.
-:::

--- a/src/content/docs/aws/organizations-admin/sso/scim/entra.md
+++ b/src/content/docs/aws/organizations-admin/sso/scim/entra.md
@@ -1,13 +1,13 @@
 ---
 title: SCIM with Entra ID
-description: Configuring Microsoft Entra ID as the SCIM client for LocalStack user provisioning.
+description: Configuring Microsoft Entra ID as the SCIM client for LocalStack user and license provisioning.
 template: doc
 tags: ['Enterprise']
 sidebar:
   order: 3
 ---
 
-This page covers configuring **Microsoft Entra ID** as your SCIM client to provision users and groups into LocalStack. Before starting, make sure you've completed the steps in the [SCIM overview](/aws/organizations-admin/sso/scim/) to enable SCIM and obtain the **SCIM Base Connector URL** and **Bearer Auth Token** from the LocalStack web app.
+This page covers configuring **Microsoft Entra ID** as your SCIM client to provision users, groups, and licenses into LocalStack. Before starting, make sure you've completed the steps in the [SCIM overview](/aws/organizations-admin/sso/scim/) to enable SCIM and obtain the **SCIM Base Connector URL** and **Bearer Auth Token** from the LocalStack web app.
 
 ## Configuring SCIM with Microsoft Entra ID
 
@@ -150,3 +150,56 @@ The `409` is transient - Entra retries the failed operation on the next cycle, a
 #### Last-Admin Protection
 
 LocalStack will reject any SCIM request that would leave the workspace without an admin. If you attempt to remove the only admin from the admin role group, the request fails with `409 Cannot remove the last workspace admin`. Assign another admin in LocalStack first, then retry the removal.
+
+### License Management
+
+Licenses are assigned to users by syncing specifically named SCIM groups that correspond to your LocalStack subscriptions.
+
+:::caution
+Each user can only be a member of one license group (subscription) per organization. Assigning a user to multiple license groups will result in an error and provisioning will fail for that user.
+:::
+
+#### Group Name Format
+
+License group names follow this format:
+
+```text
+{PLAN}-{EMULATOR}-{SUBSCRIPTION_ID}
+```
+
+For example: `Enterprise Plan-AWS-sub_1RqpMYGCs0LNOzY9UszOGJkL`
+
+The exact group name for each subscription is displayed in the SCIM configuration panel in the LocalStack web app. Use the subscription dropdown to select the plan you want to manage, and the correct group name will be shown for you to copy.
+
+:::tip
+Legacy users can be added to a license assignment group in Entra, provided their email address matches their LocalStack registration email, they have been assigned to the LocalStack Enterprise Application, and the group name matches the correct subscription.
+:::
+
+#### Creating a License Group in Microsoft Entra ID
+
+1. In **Microsoft Entra ID → Groups → All groups**, click **+ New group**. Create a **Security** group with **Membership type: Assigned** named exactly as shown in the LocalStack SCIM configuration panel.
+2. Add users to the group (users must already be assigned to the LocalStack Enterprise Application).
+3. Assign the group to the LocalStack Enterprise Application via **Manage → Users and groups**.
+4. Confirm that **Provision Microsoft Entra ID Groups** is enabled under **Provisioning → Mappings**.
+5. On the next provisioning cycle (or via **Provision on Demand**), Entra will sync the group to LocalStack and assign the corresponding license to all members.
+
+:::danger[License revocation risk]
+
+The Entra group's membership is the source of truth for license assignments on this subscription. Any change to this group in Entra (adding users, removing users, or syncing it) will reconcile the subscription's licenses to match the group exactly. Users who are licensed on this subscription but not in the Entra group will have their licenses revoked, regardless of how the license was originally assigned (manually or via SCIM).
+
+This means:
+
+- If you sync an **empty group**, every license on this subscription will be revoked.
+- If you sync a **partial group** (for example, 2 users in Entra but 5 currently licensed), the 3 users not in the group will lose their licenses.
+
+If you are enabling SCIM on a subscription that already has licensed users, follow the [Migrating Users with Existing Licenses](#migrating-users-with-existing-licenses) steps below **before** any sync occurs. Once SCIM is enabled, manage license assignments exclusively through Entra.
+
+:::
+
+#### Migrating Users with Existing Licenses
+
+If your organization already has users with assigned licenses and you want to manage them through SCIM:
+
+1. Create a license group in Entra with the correct name.
+2. Assign it to the LocalStack Enterprise Application via **Manage → Users and groups**.
+3. Add the existing licensed users to that group. Once synced - either on the next provisioning cycle, or immediately via **Provision on Demand** - they will be managed through SCIM going forward.

--- a/src/content/docs/aws/organizations-admin/sso/scim/entra.md
+++ b/src/content/docs/aws/organizations-admin/sso/scim/entra.md
@@ -183,19 +183,6 @@ Legacy users can be added to a license assignment group in Entra, provided their
 4. Confirm that **Provision Microsoft Entra ID Groups** is enabled under **Provisioning → Mappings**.
 5. On the next provisioning cycle (or via **Provision on Demand**), Entra will sync the group to LocalStack and assign the corresponding license to all members.
 
-:::danger[License revocation risk]
-
-The Entra group's membership is the source of truth for license assignments on this subscription. Any change to this group in Entra (adding users, removing users, or syncing it) will reconcile the subscription's licenses to match the group exactly. Users who are licensed on this subscription but not in the Entra group will have their licenses revoked, regardless of how the license was originally assigned (manually or via SCIM).
-
-This means:
-
-- If you sync an **empty group**, every license on this subscription will be revoked.
-- If you sync a **partial group** (for example, 2 users in Entra but 5 currently licensed), the 3 users not in the group will lose their licenses.
-
-If you are enabling SCIM on a subscription that already has licensed users, follow the [Migrating Users with Existing Licenses](#migrating-users-with-existing-licenses) steps below **before** any sync occurs. Once SCIM is enabled, manage license assignments exclusively through Entra.
-
-:::
-
 #### Migrating Users with Existing Licenses
 
 If your organization already has users with assigned licenses and you want to manage them through SCIM:

--- a/src/content/docs/aws/organizations-admin/sso/scim/index.md
+++ b/src/content/docs/aws/organizations-admin/sso/scim/index.md
@@ -18,10 +18,6 @@ For IdP-specific setup instructions, see:
 - [SCIM with Okta](/aws/organizations-admin/sso/scim/okta/)
 - [SCIM with Microsoft Entra ID](/aws/organizations-admin/sso/scim/entra/)
 
-:::note
-License assignment via SCIM is currently supported with **Okta** only. Microsoft Entra ID supports user provisioning, deprovisioning, and role management, but not license assignment.
-:::
-
 ## Prerequisites
 
 - An active Enterprise subscription with the SCIM feature enabled

--- a/src/content/docs/aws/organizations-admin/sso/scim/index.md
+++ b/src/content/docs/aws/organizations-admin/sso/scim/index.md
@@ -59,6 +59,8 @@ There are two ways roles and permissions are applied to SCIM-provisioned users:
 
 - **Role assignment via SCIM role groups** - workspace roles (**admin** / **member**) can be assigned and changed directly from your IdP by syncing role groups. See **Role Management** for [Okta](/aws/organizations-admin/sso/scim/okta/#role-management) or [Microsoft Entra ID](/aws/organizations-admin/sso/scim/entra/#role-management).
 
+- **License assignment via SCIM license groups** - licenses for a subscription can be assigned and revoked directly from your IdP by syncing license groups. See **License Management** for [Okta](/aws/organizations-admin/sso/scim/okta/#license-management) or [Microsoft Entra ID](/aws/organizations-admin/sso/scim/entra/#license-management).
+
 Granular permissions beyond the workspace role (e.g. specific CI credential grants) are not individually assignable via SCIM - they are controlled by the provisioning-time presets above or managed directly in the LocalStack web app.
 
 ## Limitations

--- a/src/content/docs/aws/organizations-admin/workspaces.md
+++ b/src/content/docs/aws/organizations-admin/workspaces.md
@@ -37,7 +37,6 @@ Here, administrators can configure and manage:
 - User and license management
 - Authentication tokens
 - Subscriptions and billing
-- Legacy CI/API keys (if applicable)
 
 These options are available under the **Administration** section.
 

--- a/src/content/docs/aws/tutorials/ephemeral-application-previews.mdx
+++ b/src/content/docs/aws/tutorials/ephemeral-application-previews.mdx
@@ -118,7 +118,7 @@ jobs:
 To deploy the application preview, you can utilize the `LocalStack/setup-localstack/ephemeral/startup` action, which requires the following parameters:
 
 - `github-token`: Automatically configured on the GitHub Action runner.
-- `localstack-api-key`: Configuration of a LocalStack [CI key](https://app.localstack.cloud/workspace/ci-keys) (`LOCALSTACK_API_KEY`) to activate licensed features in LocalStack (Note: You may need administrator permission to access creating new CI keys or legacy API keys).
+- `localstack-api-key`: Configuration of a LocalStack [CI key](https://app.localstack.cloud/workspace/ci-keys) (`LOCALSTACK_API_KEY`) to activate licensed features in LocalStack (Note: You may need administrator permission to access creating new CI keys).
 - `preview-cmd`: The set of commands necessary to deploy the application, including its infrastructure, on LocalStack.
 
 The following step sets up the dependencies and deploys the application preview on an ephemeral LocalStack instance:


### PR DESCRIPTION
As highly requested, we've tested License Assign via SCIM with Entra (We already have this functionality with Okta) and we're happy to make this publicly known via these documentation updates

## Changes:

- Removed any references to License assignment via Entra **NOT** supported
- Update Entra documentation to include steps on how to assign license via Entra (Pretty much an exact copy of Okta docs) @kostas-localstack Added to the review for technical overview
-  Removed any references to Legacy API Key. Confirmed with @Pive01 and we've completely removed this from LocalStack. Small cleanup job

My first docs PR at LocalStack so any feedback is much appreciated 

Closes: DOC-411