### PR TITLE
DOC-407 update Ubuntu image

### DIFF
--- a/src/content/docs/aws/services/ec2.mdx
+++ b/src/content/docs/aws/services/ec2.mdx
@@ -248,7 +248,7 @@ docker tag ubuntu:focal localstack-ec2/ubuntu-focal-ami:ami-000001
 The above example will make LocalStack treat the `ubuntu:focal` Docker image as an AMI with name `ubuntu-focal-ami` and ID `ami-000001`.
 
 At startup, LocalStack downloads the following AMIs that can be used to launch Dockerized instances.
-- Ubuntu 22.04: `ami-df5de72bdb3b`
+- Ubuntu 26.04: `ami-61ad6e59d7b0`
 - Amazon Linux 2023: `ami-024f768332f0`
 - Amazon Linux 2: `ami-07b643b5e45e`
 


### PR DESCRIPTION
This updates the base AMI that is used for EC2.

[Fixes DOC-407](https://linear.app/localstack/issue/DOC-407/doc-ec2-add-ubuntu-2604-ami)