### PR TITLE
DOC-405: Drop Amazon Linux 2 AMI from EC2 Docker VMM docs

### DIFF
--- a/src/content/docs/aws/services/ec2.mdx
+++ b/src/content/docs/aws/services/ec2.mdx
@@ -251,10 +251,19 @@ The above example will make LocalStack treat the `ubuntu:focal` Docker image as 
 At startup, LocalStack downloads the following AMIs that can be used to launch Dockerized instances.
 - Ubuntu 22.04: `ami-df5de72bdb3b`
 - Amazon Linux 2023: `ami-024f768332f0`
-- Amazon Linux 2: `ami-07b643b5e45e`
 
 :::note
 The auto download of Docker images for default AMIs can be disabled using the `EC2_DOWNLOAD_DEFAULT_IMAGES=0` configuration variable.
+:::
+
+:::note
+Amazon Linux 2 reached its [AWS end-of-life](https://aws.amazon.com/amazon-linux-2/faqs/) on June 30, 2026, so LocalStack no longer pre-loads the `Amazon Linux 2` AMI (`ami-07b643b5e45e`) by default.
+You can still use it by manually registering it as a Docker-backed AMI:
+
+```bash
+docker pull amazonlinux:2
+docker tag amazonlinux:2 localstack-ec2/amazonlinux-2-ami:ami-07b643b5e45e
+```
 :::
 
 All LocalStack-managed Docker AMIs bear the resource tag `ec2_vm_manager:docker`.


### PR DESCRIPTION
## Summary
- Amazon Linux 2 reached its [AWS end-of-life](https://aws.amazon.com/amazon-linux-2/faqs/) on June 30, 2026, and localstack/localstack-pro#8250 removed it from the set of AMIs LocalStack downloads by default for the EC2 Docker VM manager.
- Removes the `Amazon Linux 2` entry from the default AMI list in `ec2.mdx` and adds a note explaining that it's no longer pre-loaded, with the `docker pull`/`docker tag` steps to manually register it if still needed.
- Ubuntu 22.04 and Amazon Linux 2023 remain pre-loaded and unchanged; other unrelated "Amazon Linux 2" mentions in the repo (CodeBuild, EKS, Lambda runtimes) refer to different AMI families and were left untouched.

## Audit Trail
- **Sources accessed:** https://aws.amazon.com/amazon-linux-2/faqs/ (AL2 EOL date); engineering PR https://github.com/localstack/localstack-pro/pull/8250 (file diff confirms `AMAZONLINUX_2_AMI`/`AMAZONLINUX_2_DOCKER_IMAGE` removed from `DEFAULT_IMAGES` in `vmmanager/docker.py`, plus the Dockerfile and CI matrix/test updates).
- **Coverage files parsed:** N/A — this is a Docker VMM configuration doc, not a service API coverage doc.
- **Confidence & gaps:** High confidence; verified against the actual code diff rather than just the PR description. No conflicting AWS/LocalStack behavior found.

## Test plan
- [x] `npm run build` — link/frontmatter validation passed, no broken links.
- [x] Confirmed AL2 removal against the `localstack-pro#8250` file diff (`docker.py`, Dockerfile removal, CI matrix, tests).

Closes DOC-405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)